### PR TITLE
fixed bug  issue #20 - when saving to local storage -> double cliking on word does not play media when coming back

### DIFF
--- a/docs/notes/2018-10-02-drafjs-2-entity-range.md
+++ b/docs/notes/2018-10-02-drafjs-2-entity-range.md
@@ -66,9 +66,6 @@ and entityMap would map key `0` to
 > so I can compare original text with actual text and know that it was changed also for subtitalizer I had to move some data out of draft.js content state as I wanted the changes on that not to get on the undo stack (users can undo text changes but not paragraph timecode changes on ctrl-z)
 
 
-<<<<<<< HEAD
-see [`examples/subtitalizer-entities-range-example.js`](./examples/subtitalizer-entities-range-example.js) for full example code.
-=======
 see [`examples/subtitalizer-entities-range-example.js`](./examples/subtitalizer-entities-range-example.js) for full example code.
 
 
@@ -188,4 +185,3 @@ Draftjs keeps them up to date.
     }
   },
 ```
->>>>>>> recover-entities

--- a/src/lib/TranscriptEditor/TimedTextEditor/index.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/index.js
@@ -95,7 +95,7 @@ class TimedTextEditor extends React.Component {
     const mediaUrl = this.props.mediaUrl;
     console.log('localSave', mediaUrl)
     const data = convertToRaw(this.state.editorState.getCurrentContent());
-    // console.log(data)
+    console.log('localSave: ',JSON.stringify(data, null,2))
     localStorage.setItem(`draftJs-${ mediaUrl }`, JSON.stringify(data));
     const newLastLocalSavedDate = new Date().toString();
     localStorage.setItem(`timestamp-${ mediaUrl }`, newLastLocalSavedDate);
@@ -116,10 +116,19 @@ class TimedTextEditor extends React.Component {
     const data = JSON.parse(localStorage.getItem(`draftJs-${ mediaUrl }`));
     if (data !== null) {
       const lastLocalSavedDate = localStorage.getItem(`timestamp-${ mediaUrl }`);
-      this.setEditorContentState(data.blocks)
+      console.log('loadLocalSavedData: ',JSON.stringify(data, null,2))
+      this.setEditorContentStateFromLocalStorage(data)
       return lastLocalSavedDate;
     }
     return ''
+  }
+
+  setEditorContentStateFromLocalStorage = (data) => {
+    // needs blocks and entityMap to use `convertFromRaw`
+    const contentState = convertFromRaw( data );
+     // eslint-disable-next-line no-use-before-define
+     const editorState = EditorState.createWithContent(contentState, decorator);
+     this.setState({ editorState });
   }
 
   // set DraftJS Editor content state from blocks

--- a/src/lib/TranscriptEditor/TimedTextEditor/index.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/index.js
@@ -93,9 +93,7 @@ class TimedTextEditor extends React.Component {
 
   localSave = () => {
     const mediaUrl = this.props.mediaUrl;
-    console.log('localSave', mediaUrl)
     const data = convertToRaw(this.state.editorState.getCurrentContent());
-    console.log('localSave: ',JSON.stringify(data, null,2))
     localStorage.setItem(`draftJs-${ mediaUrl }`, JSON.stringify(data));
     const newLastLocalSavedDate = new Date().toString();
     localStorage.setItem(`timestamp-${ mediaUrl }`, newLastLocalSavedDate);
@@ -112,11 +110,9 @@ class TimedTextEditor extends React.Component {
   }
 
   loadLocalSavedData(mediaUrl) {
-    console.log('loadLocalSavedData', mediaUrl);
     const data = JSON.parse(localStorage.getItem(`draftJs-${ mediaUrl }`));
     if (data !== null) {
       const lastLocalSavedDate = localStorage.getItem(`timestamp-${ mediaUrl }`);
-      console.log('loadLocalSavedData: ',JSON.stringify(data, null,2))
       this.setEditorContentStateFromLocalStorage(data)
       return lastLocalSavedDate;
     }


### PR DESCRIPTION
Fixed bug from https://github.com/bbc/react-transcript-editor/issues/20

`when saving to local storage -> double cliking on word does not play media when coming back`