### PR TITLE
Scroll sync

### DIFF
--- a/src/lib/TranscriptEditor/MediaPlayer/ScrollIntoView.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/ScrollIntoView.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './VolumeControl.module.css';
+class ScrollIntoView extends React.Component {
+
+    render() {
+        return (
+          <div>
+            <p className={ styles.helpText }>ScrollIntoView</p>
+            <label className={ styles.switch }>
+              <input type="checkbox"
+                defaultChecked={ this.props.isScrollIntoViewOn }
+                onChange={ this.props.handleToggle }
+                />
+              <span className={ styles.slider }></span>
+            </label>
+          </div>
+        );
+    }
+}
+
+ScrollIntoView.propTypes = {
+  handleToggle: PropTypes.func
+};
+
+export default ScrollIntoView;

--- a/src/lib/TranscriptEditor/MediaPlayer/index.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/index.js
@@ -9,6 +9,7 @@ import ProgressBar from './ProgressBar.js';
 import PlayerControls from './PlayerControls.js';
 import VolumeControl from './VolumeControl.js';
 import PauseWhileTyping from './PauseWhileTyping.js';
+import ScrollIntoView from './ScrollIntoView.js';
 
 import styles from './index.module.css';
 
@@ -33,7 +34,7 @@ class MediaPlayer extends React.Component {
   componentDidMount() {
     this.props.hookSeek(this.setCurrentTime);
     this.props.hookPlayMedia(this.playMedia);
-    this.props.hookIsPlaying(this.isPlaying)
+    this.props.hookIsPlaying(this.isPlaying);
   }
 
   setCurrentTime = (newCurrentTime) => {
@@ -147,6 +148,10 @@ class MediaPlayer extends React.Component {
       console.log(prevState.isPausedWhileTyping)
       return { isPausedWhileTyping:  !prevState.isPausedWhileTyping }
     })
+  }
+
+  handleToggleScrollIntoView = (e) => {
+    this.props.handleIsScrollIntoViewChange(e.target.checked);     
   }
 
   isPlaying=() => {
@@ -292,6 +297,11 @@ class MediaPlayer extends React.Component {
           isPausedWhileTyping={ this.props.isPausedWhileTyping }
           handleToggle={ this.handleTogglePauseWhileTyping.bind(this) }
         />
+
+        <ScrollIntoView 
+          isScrollIntoViewOn={ this.props.isScrollIntoViewOn }
+          handleToggle={ this.handleToggleScrollIntoView.bind(this) }
+        />
    
         <PlaybackRate
           playBackRate={ this.state.playBackRate }
@@ -345,7 +355,8 @@ MediaPlayer.propTypes = {
   hookSeek: PropTypes.func,
   hookPlayMedia: PropTypes.func,
   mediaUrl: PropTypes.string,
-  hookOnTimeUpdate: PropTypes.func
+  hookOnTimeUpdate: PropTypes.func,
+  hookIsScrollSyncToggle: PropTypes.func
 };
 
 export default hotkeys(MediaPlayer);

--- a/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
@@ -29,7 +29,6 @@ class WrapperBlock extends React.Component {
 
   handleOnClickEdit = (e) => {
     const newSpeakerName = prompt('New Speaker Name?');
-    console.log('newSpeakerName',newSpeakerName)
     if (newSpeakerName !== '' && newSpeakerName !== null) {
       this.setState({ speaker: newSpeakerName });
 

--- a/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
@@ -29,8 +29,8 @@ class WrapperBlock extends React.Component {
 
   handleOnClickEdit = (e) => {
     const newSpeakerName = prompt('New Speaker Name?');
-
-    if (newSpeakerName !== '') {
+    console.log('newSpeakerName',newSpeakerName)
+    if (newSpeakerName !== '' && newSpeakerName !== null) {
       this.setState({ speaker: newSpeakerName });
 
       // From docs: https://draftjs.org/docs/api-reference-selection-state#keys-and-offsets

--- a/src/lib/TranscriptEditor/TimedTextEditor/index.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/index.js
@@ -194,6 +194,10 @@ class TimedTextEditor extends React.Component {
           }
         }
     }
+    if(currentWord.start !== 'NA'){
+      const currentWordElement = document.querySelector(`span.Word[data-start="${ currentWord.start }"]`);
+      currentWordElement.scrollIntoView({ block: 'center', inline: 'center' })
+    }
     return currentWord;
   }
 

--- a/src/lib/TranscriptEditor/TimedTextEditor/index.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/index.js
@@ -195,8 +195,11 @@ class TimedTextEditor extends React.Component {
         }
     }
     if(currentWord.start !== 'NA'){
-      const currentWordElement = document.querySelector(`span.Word[data-start="${ currentWord.start }"]`);
-      currentWordElement.scrollIntoView({ block: 'center', inline: 'center' })
+      console.log('TimedTextEditor: ',this.props.isScrollIntoViewOn);
+      if(this.props.isScrollIntoViewOn){
+        const currentWordElement = document.querySelector(`span.Word[data-start="${ currentWord.start }"]`);
+        currentWordElement.scrollIntoView({ block: 'center', inline: 'center' })
+      }
     }
     return currentWord;
   }
@@ -267,7 +270,8 @@ TimedTextEditor.propTypes = {
   sttJsonType: PropTypes.string,
   isPlaying: PropTypes.func,
   playMedia: PropTypes.func,
-  currentTime: PropTypes.number
+  currentTime: PropTypes.number,
+  isScrollSyncToggle: PropTypes.func
 };
 
 export default TimedTextEditor;

--- a/src/lib/TranscriptEditor/index.js
+++ b/src/lib/TranscriptEditor/index.js
@@ -5,6 +5,7 @@ import TimedTextEditor from './TimedTextEditor';
 import MediaPlayer from './MediaPlayer';
 
 import styles from './index.module.css';
+import { throws } from 'assert';
 
 class TranscriptEditor extends React.Component {
   constructor(props) {
@@ -14,6 +15,7 @@ class TranscriptEditor extends React.Component {
       currentTime: 0,
       lastLocalSavedTime: '',
       transcriptData: null,
+      isScrollIntoViewOn: false
     }
   }
 
@@ -57,6 +59,17 @@ class TranscriptEditor extends React.Component {
   handleIsPlaying = () => {
     return this.isPlaying()
   }
+
+  // handleIsScrollSyncToggle = () => {
+  //   console.log('this.handleToggleScrollIntoView() ');
+  //   this.setState({ isScrollIntoViewOn: true })
+  //   // return this.isScrollIntoViewHandler();
+  // }
+
+  handleIsScrollIntoViewChange = (isChecked) => {
+    this.setState({ isScrollIntoViewOn: isChecked })
+  }
+
   getEditorContent = sttType => this.refs.timedTextEditor.getEditorContent(sttType)
 
   render() {
@@ -71,7 +84,9 @@ class TranscriptEditor extends React.Component {
               hookIsPlaying={ foo => this.isPlaying = foo }
               hookOnTimeUpdate={ this.handleTimeUpdate }
               mediaUrl={ this.props.mediaUrl }
-              />
+              isScrollIntoViewOn={ this.state.isScrollIntoViewOn }
+              handleIsScrollIntoViewChange={ this.handleIsScrollIntoViewChange }
+             />
           </aside>
           <main className={ styles.main }>
             <TimedTextEditor
@@ -79,6 +94,8 @@ class TranscriptEditor extends React.Component {
               onWordClick={ this.handleWordClick }
               playMedia={ this.handlePlayMedia }
               isPlaying={ this.handleIsPlaying }
+              // handleIsScrollSyncToggle={ this.handleIsScrollSyncToggle }
+              isScrollIntoViewOn={ this.state.isScrollIntoViewOn }
               currentTime={ this.state.currentTime }
               isEditable={ this.props.isEditable }
               sttJsonType={ this.props.sttJsonType }

--- a/src/lib/TranscriptEditor/index.js
+++ b/src/lib/TranscriptEditor/index.js
@@ -60,12 +60,6 @@ class TranscriptEditor extends React.Component {
     return this.isPlaying()
   }
 
-  // handleIsScrollSyncToggle = () => {
-  //   console.log('this.handleToggleScrollIntoView() ');
-  //   this.setState({ isScrollIntoViewOn: true })
-  //   // return this.isScrollIntoViewHandler();
-  // }
-
   handleIsScrollIntoViewChange = (isChecked) => {
     this.setState({ isScrollIntoViewOn: isChecked })
   }

--- a/src/lib/TranscriptEditor/index.js
+++ b/src/lib/TranscriptEditor/index.js
@@ -88,7 +88,6 @@ class TranscriptEditor extends React.Component {
               onWordClick={ this.handleWordClick }
               playMedia={ this.handlePlayMedia }
               isPlaying={ this.handleIsPlaying }
-              // handleIsScrollSyncToggle={ this.handleIsScrollSyncToggle }
               isScrollIntoViewOn={ this.state.isScrollIntoViewOn }
               currentTime={ this.state.currentTime }
               isEditable={ this.props.isEditable }


### PR DESCRIPTION
Added scroll sync https://github.com/bbc/react-transcript-editor/issues/34 - [notes](https://github.com/bbc/react-transcript-editor/blob/master/docs/notes/2018-11-29-scroll-sync.md)

- [x] Added scroll sync functionality 
- [x] added on and off toggle  
- [ ] the controllers for the toggle are in the `MediaPlayer` to keep them with the other player controls/settings but the functionalities are in the `TimedTextEditor`. so hard to pass the info through the parent component `TranscriptEditor` - not sure if this get convoluted. There might be a better cleaner way for a later refactor.

![scroll-sync](https://user-images.githubusercontent.com/4661975/49291683-10975580-f4a3-11e8-9cd3-4b4e20f99f7a.gif)

Ready for review - clean up before merge 