### PR TITLE
Render timecodes spike

### DIFF
--- a/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { EditorBlock } from 'draft-js';
+import { EditorBlock, Modifier, convertToRaw, EditorState } from 'draft-js';
 
 import SpeakerLabel from './SpeakerLabel';
 
@@ -15,10 +15,14 @@ class WrapperBlock extends React.Component {
   }
 
   componentDidMount() {
-    const { block } = this.props;
+    const { block, contentState, editorState } = this.props;
+    // console.log(this.props.blockProps)
     const speaker = block.getData().get('speaker');
     const start = block.getData().get('start');
-
+    // const blockKey = block.getKey();
+    // const entity = contentState.getEntity(blockKey);
+  
+  //   console.log('contentState',blockKey);
     this.setState({
       speaker: speaker,
       start: start
@@ -29,6 +33,22 @@ class WrapperBlock extends React.Component {
     const newSpeakerName = prompt('New Speaker Name?')
 
     this.setState({ speaker: newSpeakerName });
+
+    const selectionState = this.props.blockProps.editorState.getSelection();
+    //   // https://draftjs.org/docs/api-reference-modifier#mergeblockdata
+    const newBlockData = { speaker: newSpeakerName };
+    // https://stackoverflow.com/questions/47604432/how-to-insert-upload-image-update-entity-and-blocks-in-draft-js
+    const newContentState = Modifier.mergeBlockData(
+      this.props.contentState,
+      selectionState,
+      newBlockData//blockData
+    )
+    // TODO: new newContentState
+    const tmpRaw = convertToRaw(newContentState);
+    console.log(JSON.stringify(tmpRaw,null,2)); 
+    const newEditorState = EditorState.push(this.props.blockProps.editorState, newContentState);
+    // TODO: this last step of saving the stage needs to happen in TimedTextEditor
+    // this.setState({ editorState: newEditorState });
   }
 
   render() {

--- a/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { EditorBlock, Modifier, convertToRaw, EditorState } from 'draft-js';
+import { EditorBlock, Modifier, convertToRaw, EditorState, Editor } from 'draft-js';
 
 import SpeakerLabel from './SpeakerLabel';
 
@@ -47,6 +47,11 @@ class WrapperBlock extends React.Component {
     const tmpRaw = convertToRaw(newContentState);
     console.log(JSON.stringify(tmpRaw,null,2)); 
     const newEditorState = EditorState.push(this.props.blockProps.editorState, newContentState);
+    // https://draftjs.org/docs/api-reference-editor-state
+    // TODO: This below doesn't work?
+    EditorState.set(newEditorState, { allowUndo: false });
+    // Editor.forceUpdate();
+    
     // TODO: this last step of saving the stage needs to happen in TimedTextEditor
     // this.setState({ editorState: newEditorState });
   }

--- a/src/lib/TranscriptEditor/TimedTextEditor/index.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/index.js
@@ -169,7 +169,8 @@ class TimedTextEditor extends React.Component {
       component: WrapperBlock,
       editable: true,
       props: {
-        foo: 'bar'
+        foo: 'bar',
+        editorState: this.state.editorState
       }
     };
   }

--- a/src/lib/TranscriptEditor/TimedTextEditor/index.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/index.js
@@ -37,6 +37,7 @@ class TimedTextEditor extends React.Component {
   static getDerivedStateFromProps(nextProps, prevState) {
     if (nextProps.transcriptData !== null) {
       return {
+        editorState: prevState.editorState,
         transcriptData: nextProps.transcriptData,
         isEditable: nextProps.isEditable,
       }
@@ -155,6 +156,14 @@ class TimedTextEditor extends React.Component {
     this.setState({ editorState });
   }
 
+ /**
+  * Update Editor content state 
+  */ 
+  setEditorNewContentState = (newContentState) => {
+    const newEditorState = EditorState.push(this.state.editorState, newContentState);
+    this.setState({ editorState: newEditorState });
+  }
+
   getEditorContent = (sttType) => {
     // sttType used in conjunction with adapter/convert
     const type = sttType === null ? 'draftjs' : sttType;
@@ -170,7 +179,9 @@ class TimedTextEditor extends React.Component {
       editable: true,
       props: {
         foo: 'bar',
-        editorState: this.state.editorState
+        editorState: this.state.editorState,
+        // passing in callback function to be able to set state in parent component
+        setEditorNewContentState: this.setEditorNewContentState
       }
     };
   }


### PR DESCRIPTION
- [x] When editing a speaker now it saves the changes in the `TimedTextEditor` `editorState`


Still to do
- [ ] when breaking a paragraph block, eg adding a new line. it should add previous paragraph's speaker and first word of split paragraph timecode to data attribute.