### PR TITLE
Refactor play media spike

### DIFF
--- a/src/lib/TranscriptEditor/MediaPlayer/PlayerControls.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/PlayerControls.js
@@ -44,7 +44,7 @@ class PlayerControls extends React.Component {
 
         <button
           className={ style.playerButton }
-          onClick={ (e) => { this.props.playMedia(e); } }>
+          onClick={ () => { this.props.playMedia(); } }>
           {this.props.isPlaying() ? '❚❚' : '▶'}
         </button>
 

--- a/src/lib/TranscriptEditor/MediaPlayer/VideoPlayer.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/VideoPlayer.js
@@ -11,7 +11,7 @@ class VideoPlayer extends React.Component {
         onTimeUpdate={ this.props.onTimeUpdate }
         type="video/mp4"
         data-testid="media-player-id"
-        onClick={ this.props.onClick }
+        onClick={ () => { this.props.onClick(); } }
         ref={ this.props.videoRef }
       />
     );

--- a/src/lib/TranscriptEditor/MediaPlayer/index.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/index.js
@@ -141,13 +141,15 @@ class MediaPlayer extends React.Component {
   }
 
   /**
-   * @param {bool}  playPauseBool - is optional boolean - false -> pause | true -> play
-   * for integration with TimedTextEditor pause while typing
-   * If bool is not provided then if paused --> play | if playing --> pause
-   * Eg when triggered from play/pause btn
+   * @param {bool | undefined}  playPauseBool - optional boolean
+   * false -> pause 
+   * true -> play
+   * If bool is not provided (undefined) then 
+   * if paused --> play | if playing --> pause
+   * This is for use cases when triggered from play/pause btn
+   * and for integration with TimedTextEditor pause while typing functionality
    */
   playMedia = (playPauseBool) => {
-    console.log('playPauseBool',playPauseBool);
     // checks that there is a video player element initialized
     if (this.videoRef.current !== null) {
       // if playMedia is being triggered by PlayerControl or Video element

--- a/src/lib/TranscriptEditor/MediaPlayer/index.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/index.js
@@ -147,11 +147,12 @@ class MediaPlayer extends React.Component {
    * Eg when triggered from play/pause btn
    */
   playMedia = (playPauseBool) => {
+    console.log('playPauseBool',playPauseBool);
     // checks that there is a video player element initialized
     if (this.videoRef.current !== null) {
       // if playMedia is being triggered by PlayerControl or Video element
       // then it will have a target attribute
-      if (playPauseBool.target !== undefined) {
+      if (playPauseBool === undefined) {
         // checks on whether to use default fallback if no param is provided
         if (this.videoRef.current.paused) {
           this.videoRef.current.play();
@@ -168,6 +169,7 @@ class MediaPlayer extends React.Component {
             this.videoRef.current.pause();
           }
         }
+
       }
 
     }
@@ -216,7 +218,7 @@ class MediaPlayer extends React.Component {
     const player = <VideoPlayer
       mediaUrl={ this.props.mediaUrl }
       onTimeUpdate= { this.handleTimeUpdate }
-      onClick= { this.playMedia.bind(this) }
+      onClick={ this.playMedia.bind(this) }
       videoRef={ this.videoRef }
     />;
 


### PR DESCRIPTION
Suggested refactor `playMedia` function to discuss a possible simpler implantation, where the function only takes one **optional** boolean argument.

Tested and it works on 
- [x] click on video preview
- [x] clicking on play/pause button
- [x] used react tool to test `isPausedWhileTyping` - true/false for `TimedTextEditor`
- [x] `esc` keyboard shortcut