### PR TITLE
Add IBM Watson STT Json import support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ A React component to make transcribing audio and video easier and faster.
 
 [![install size](https://packagephobia.now.sh/badge?p=@bbc/react-transcript-editor)](https://packagephobia.now.sh/result?p=@bbc/react-transcript-editor)
 
-The project uses [this github project board to organise and the co-ordinate development](https://github.com/bbc/react-transcript-editor/projects/1).
-
 _--> Work in progress <--_ 
 
 <!-- _Screenshot of UI - optional_ -->
@@ -30,7 +28,10 @@ Node version is set in node version manager [`.nvmrc`](https://github.com/creati
 <!-- _stack - optional_ -->
 <!-- _How to build and run the code/app_ -->
 
-Fork this repository + git clone + cd into folder 
+* Fork this repository
+* ```git clone```
+* cd into folder
+* ```npm install```
 
 ## Usage - development
 
@@ -73,9 +74,11 @@ import { TranscriptEditor } from '@bbc/react-transcript-editor';
 
 <!-- _High level overview of system architecture_ -->
 
-Uses [`create-component-lib`](https://www.npmjs.com/package/create-component-lib) as explaied in this [blog post](https://hackernoon.com/creating-a-library-of-react-components-using-create-react-app-without-ejecting-d182df690c6b) to setup the environment to develop this React component.
+uses [`create-component-lib`](https://www.npmjs.com/package/create-component-lib) as explaied in this [blog post](https://hackernoon.com/creating-a-library-of-react-components-using-create-react-app-without-ejecting-d182df690c6b) to setup the environment to develop this React.
 
 This uses [Create React App 2.0](https://reactjs.org/blog/2018/10/01/create-react-app-v2.html) so we are using [CSS Modules](https://github.com/css-modules/css-modules) to contain the scope of the css for this component.
+<!-- 
+Uses CSS grid-layout https://medium.com/samsung-internet-dev/common-responsive-layouts-with-css-grid-and-some-without-245a862f48df -->
 
 > Place everything you want to publish to npm inside `src/lib`. 
 
@@ -112,7 +115,7 @@ Demo can be viewed at [https://bbc.github.io/react-transcript-editor](https://bb
 -->
 
 
-## Build - demo 
+## build - demo 
 
 This github repository uses [github pages](https://pages.github.com/) to host a demo of the component, in [docs/demo](./docs/demo)
 
@@ -157,14 +160,13 @@ This runs `npm run build:component` and `npm publish --access public` under the 
 
 ## Contributing 
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) guidelines and [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) guidelines.
-
+<!-- Contributing guidance, and link to contributing code of conduct -->
 
 ## Licence
 
-See [LICENCE.md](./LICENCE.md)
+<!-- mention MIT Licence -->
 
 
-## Legal Disclaimer
+<!-- ## Legal Disclaimer
 
-Despite using React and DraftJs, the BBC is not promoting any Facebook products or other commercial interest.
+Despite using React and Draftjs, the BBC is not promoting any FB product or other commercial interest. -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1233,11 +1233,6 @@
       "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
       "dev": true
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -1303,6 +1298,7 @@
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
       "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1328,11 +1324,6 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
     "ansi-colors": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.1.tgz",
@@ -1354,7 +1345,8 @@
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1387,16 +1379,8 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -1446,11 +1430,6 @@
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-flatten": {
       "version": "2.1.1",
@@ -1527,6 +1506,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -1571,7 +1551,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -1606,11 +1587,6 @@
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
-    "async-foreach": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
-    },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
@@ -1620,7 +1596,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -1664,12 +1641,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "axobject-query": {
       "version": "2.0.2",
@@ -2217,7 +2196,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -2290,6 +2270,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -2317,14 +2298,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
-    },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "requires": {
-        "inherits": "~2.0.0"
-      }
     },
     "bluebird": {
       "version": "3.5.3",
@@ -2391,6 +2364,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2577,7 +2551,8 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
@@ -2692,22 +2667,6 @@
       "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
       "dev": true
     },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-        }
-      }
-    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -2744,7 +2703,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.1",
@@ -2949,7 +2909,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -3006,6 +2967,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -3061,7 +3023,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -3095,11 +3058,6 @@
       "requires": {
         "date-now": "^0.1.4"
       }
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -3174,7 +3132,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.0.7",
@@ -3597,14 +3556,6 @@
         "cssom": "0.3.x"
       }
     },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "requires": {
-        "array-find-index": "^1.0.1"
-      }
-    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -3621,6 +3572,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3654,7 +3606,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -3802,12 +3755,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -4077,6 +4026,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -4207,6 +4157,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -4244,7 +4195,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.11.0",
@@ -4758,7 +4710,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -4860,12 +4813,14 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-glob": {
       "version": "2.2.4",
@@ -4884,7 +4839,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5094,6 +5050,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
       "requires": {
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
@@ -5165,7 +5122,8 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "fork-ts-checker-webpack-plugin-alt": {
       "version": "0.4.14",
@@ -5187,6 +5145,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -5256,7 +5215,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.4",
@@ -5299,12 +5259,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5319,17 +5281,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5446,7 +5411,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5458,6 +5424,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5472,6 +5439,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5479,12 +5447,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5503,6 +5473,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5583,7 +5554,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5595,6 +5567,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5716,6 +5689,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5787,17 +5761,6 @@
         }
       }
     },
-    "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -5821,66 +5784,11 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
-    },
-    "gaze": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-      "requires": {
-        "globule": "^1.0.0"
-      }
-    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
@@ -5913,6 +5821,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -5937,6 +5846,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6052,20 +5962,11 @@
         "pinkie-promise": "^2.0.0"
       }
     },
-    "globule": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
-      "requires": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.10",
-        "minimatch": "~3.0.2"
-      }
-    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -6174,12 +6075,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -6204,6 +6107,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -6211,7 +6115,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         }
       }
     },
@@ -6226,11 +6131,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -6341,7 +6241,8 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -6510,6 +6411,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -6787,19 +6689,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "in-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "requires": {
-        "repeating": "^2.0.0"
-      }
-    },
     "indexes-of": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -6816,6 +6705,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6824,7 +6714,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -6875,7 +6766,8 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -6924,7 +6816,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -6951,6 +6844,7 @@
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "^1.0.0"
       }
@@ -7066,6 +6960,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -7073,7 +6968,8 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-generator-fn": {
       "version": "1.0.0",
@@ -7244,12 +7140,14 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -7266,7 +7164,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isemail": {
       "version": "3.2.0",
@@ -7280,7 +7179,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -7300,7 +7200,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-api": {
       "version": "1.3.7",
@@ -8454,11 +8355,6 @@
         "topo": "2.x.x"
       }
     },
-    "js-base64": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.9.tgz",
-      "integrity": "sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ=="
-    },
     "js-levenshtein": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.4.tgz",
@@ -8483,7 +8379,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsdom": {
       "version": "13.0.0",
@@ -8542,12 +8439,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -8567,7 +8466,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -8611,6 +8511,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -8665,6 +8566,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -8772,7 +8674,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -8780,21 +8683,11 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -8825,11 +8718,6 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
-    },
-    "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -8882,15 +8770,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
-      }
-    },
     "lower-case": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
@@ -8901,6 +8780,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.4.tgz",
       "integrity": "sha512-EPstzZ23znHUVLKj+lcXO1KvZkrlw+ZirdwvOmnAnA/1PB4ggyXJ77LRkCqkff+ShQ+cqoxCxLQOh4cKITO5iA==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^3.0.2"
@@ -8952,11 +8832,6 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
-    },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -9013,79 +8888,6 @@
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      }
-    },
-    "meow": {
-      "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
-      },
-      "dependencies": {
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        }
       }
     },
     "merge": {
@@ -9183,12 +8985,14 @@
     "mime-db": {
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.21",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
       "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "dev": true,
       "requires": {
         "mime-db": "~1.37.0"
       }
@@ -9226,6 +9030,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -9233,7 +9038,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mississippi": {
       "version": "3.0.0",
@@ -9296,6 +9102,7 @@
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -9356,7 +9163,9 @@
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -9438,32 +9247,6 @@
       "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
       "dev": true
     },
-    "node-gyp": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-      "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-        }
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9530,83 +9313,6 @@
         "semver": "^5.3.0"
       }
     },
-    "node-sass": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.10.0.tgz",
-      "integrity": "sha512-fDQJfXszw6vek63Fe/ldkYXmRYK/QS6NbvM3i5oEo9ntPDy4XX7BcKZyTKv+/kSSxRtXXc7l+MSwEmYc0CSy6Q==",
-      "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
-        "node-gyp": "^3.8.0",
-        "npmlog": "^4.0.0",
-        "request": "^2.88.0",
-        "sass-graph": "^2.2.4",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
     "nomnom": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
@@ -9617,18 +9323,11 @@
         "underscore": "~1.4.4"
       }
     },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "requires": {
-        "abbrev": "1"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -9672,17 +9371,6 @@
         "path-key": "^2.0.0"
       }
     },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -9701,7 +9389,8 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nwsapi": {
       "version": "2.0.9",
@@ -9712,7 +9401,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -9873,6 +9563,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -9954,14 +9645,9 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-<<<<<<< HEAD
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-=======
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
->>>>>>> master
     },
     "os-locale": {
       "version": "2.1.0",
@@ -10010,23 +9696,9 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-<<<<<<< HEAD
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
-      }
-=======
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
->>>>>>> master
     },
     "output-file-sync": {
       "version": "2.0.1",
@@ -10159,6 +9831,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -10206,20 +9879,16 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
       "requires": {
         "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
       "version": "1.0.1",
-<<<<<<< HEAD
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-=======
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
->>>>>>> master
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -10270,22 +9939,26 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
       "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -12327,7 +12000,8 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.1",
@@ -12387,12 +12061,14 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -12444,7 +12120,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -12455,7 +12132,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "query-string": {
       "version": "4.3.4",
@@ -12930,6 +12608,7 @@
       "version": "2.3.6",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -12967,15 +12646,6 @@
       "dev": true,
       "requires": {
         "minimatch": "3.0.4"
-      }
-    },
-    "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
       }
     },
     "regenerate": {
@@ -13182,6 +12852,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -13190,6 +12861,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -13236,7 +12908,8 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -13247,7 +12920,8 @@
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -13345,6 +13019,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -13411,7 +13086,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -13449,155 +13125,6 @@
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
-        }
-      }
-    },
-    "sass-graph": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-      "requires": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "camelcase": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "requires": {
-            "lcid": "^1.0.0"
-          }
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "which-module": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-        },
-        "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-          "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-          "requires": {
-            "camelcase": "^3.0.0"
-          }
         }
       }
     },
@@ -13698,25 +13225,6 @@
         "ajv-keywords": "^3.1.0"
       }
     },
-    "scss-tokenizer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-      "requires": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -13735,7 +13243,8 @@
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -13808,7 +13317,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.0",
@@ -13919,7 +13429,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -14154,6 +13665,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
       "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -14162,12 +13674,14 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -14176,7 +13690,8 @@
     "spdx-license-ids": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg=="
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+      "dev": true
     },
     "spdy": {
       "version": "3.4.7",
@@ -14226,6 +13741,7 @@
       "version": "1.15.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
       "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -14285,14 +13801,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
-    },
-    "stdout-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
-      "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
-      "requires": {
-        "readable-stream": "^2.0.1"
-      }
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -14359,6 +13867,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -14379,6 +13888,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -14398,6 +13908,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
       }
@@ -14423,21 +13934,6 @@
       "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "requires": {
-        "get-stdin": "^4.0.1"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-        }
-      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -14609,16 +14105,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
       "integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==",
       "dev": true
-    },
-    "tar": {
-      "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-      "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
-      }
     },
     "terser": {
       "version": "3.10.12",
@@ -15037,6 +14523,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -15045,7 +14532,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -15057,11 +14545,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "trim-repeated": {
       "version": "1.0.0",
@@ -15077,14 +14560,6 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
-    },
-    "true-case-path": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
-      "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
-      "requires": {
-        "glob": "^7.1.2"
-      }
     },
     "tryer": {
       "version": "1.0.1",
@@ -15108,6 +14583,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -15115,7 +14591,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -15458,6 +14935,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -15525,7 +15003,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -15552,12 +15031,14 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -15579,6 +15060,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -16063,6 +15545,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -16072,14 +15555,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -16268,6 +15743,7 @@
       "version": "2.1.0",
       "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -16276,12 +15752,14 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -16290,6 +15768,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -16300,6 +15779,7 @@
           "version": "3.0.1",
           "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -16309,7 +15789,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "0.2.1",
@@ -16367,12 +15848,14 @@
     "y18n": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
     },
     "yallist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+      "dev": true
     },
     "yargs": {
       "version": "11.1.0",

--- a/src/lib/TranscriptEditor/MediaPlayer/index.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/index.js
@@ -241,7 +241,7 @@ class MediaPlayer extends React.Component {
 MediaPlayer.propTypes = {
   hookSeek: PropTypes.func,
   hookPlayMedia: PropTypes.func,
-  hookIsPlaying: PropTypes. func,
+  hookIsPlaying: PropTypes.func,
   mediaUrl: PropTypes.string,
   hookOnTimeUpdate: PropTypes.func,
 };

--- a/src/lib/Util/adapters/ibm/example-usage.js
+++ b/src/lib/Util/adapters/ibm/example-usage.js
@@ -1,0 +1,7 @@
+const ibmToDraft = require('./index');
+// using require, because of testing outside of React app
+const ibmTedTalkTranscript = require('./sample/ibmTedTalkTranscript.sample.json');
+
+const result = ibmToDraft(ibmTedTalkTranscript);
+
+console.log(result);

--- a/src/lib/Util/adapters/ibm/index.js
+++ b/src/lib/Util/adapters/ibm/index.js
@@ -1,0 +1,266 @@
+/**
+ * Convert IBM json
+ ```
+ {
+   "created": "2018-12-18T22:40:38.903Z",
+   "id": "f14cbe1e-0315-11e9-b590-a3e1e3acdd73",
+   "updated": "2018-12-18T22:47:30.392Z",
+   "results": [{
+      "result_index": 0,
+      "speaker_labels": [
+         {
+            "speaker": 1,
+            "confidence": 0.36,
+            "final": false,
+            "from": 13.04,
+            "to": 13.23
+         }, ...]
+      "results": [
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "there is a day about ten years ago when I asked a friend to hold a baby dinosaur robot upside down ",
+               "timestamps": [
+                  [
+                     "there",
+                     13.04,
+                     13.23
+                  ],
+                  [
+                     "is",
+                     13.23,
+                     13.36
+                  ] ...
+
+               "confidence": 0.938,
+               "word_confidence": [
+                  [
+                     "there",
+                     0.902
+                  ],
+                  [
+                     "is",
+                     0.52
+                  ],
+                  [
+                     "a",
+                     0.819
+                  ] ...
+        ...
+```
+ *
+ * into
+ *
+ ```
+ const blocks = [
+  {
+    "text": "There is a day.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 0",
+      "words": [
+        {
+          "start": 13.02,
+          "confidence": 0.68,
+          "end": 13.17,
+          "word": "there",
+          "punct": "There",
+          "index": 0
+        },
+        {
+          "start": 13.17,
+          "confidence": 0.61,
+          "end": 13.38,
+          "word": "is",
+          "punct": "is",
+          "index": 1
+        },
+        {
+          "start": 13.38,
+          "confidence": 0.99,
+          "end": 13.44,
+          "word": "a",
+          "punct": "a",
+          "index": 2
+        },
+        {
+          "start": 13.44,
+          "confidence": 1,
+          "end": 13.86,
+          "word": "day",
+          "punct": "day.",
+          "index": 3
+        }
+      ],
+      "start": 13.02
+    },
+    "entityRanges": [
+      {
+        "start": 13.02,
+        "end": 13.17,
+        "confidence": 0.68,
+        "text": "There",
+        "offset": 0,
+        "length": 5,
+        "key": "li6c6ld"
+      },
+      {
+        "start": 13.17,
+        "end": 13.38,
+        "confidence": 0.61,
+        "text": "is",
+        "offset": 6,
+        "length": 2,
+        "key": "pcgzkp6"
+      },
+      {
+        "start": 13.38,
+        "end": 13.44,
+        "confidence": 0.99,
+        "text": "a",
+        "offset": 9,
+        "length": 1,
+        "key": "ngomd9"
+      },
+      {
+        "start": 13.44,
+        "end": 13.86,
+        "confidence": 1,
+        "text": "day.",
+        "offset": 11,
+        "length": 4,
+        "key": "sgmfl4f"
+      }
+    ]
+  },
+  ...
+```
+ *
+ */
+
+const ibmToDraft = (ibmJson) => {
+
+  let x, y, z, topLvlResult, result;
+
+  const addPunctuation = true;
+  let newSentence = true;
+  let firstWordOfSentence = null;
+  let punctuatedWord = null;
+
+  // Watson doesn't include punctuation at this time (Dec-2018).
+  // Instead, manually capitalize first word after a "final" transcript block.
+  function capitalizeFirstLetter(string) {
+    if (!addPunctuation) {
+      return string;
+    } else {
+      return string.charAt(0).toUpperCase() + string.slice(1);
+    }
+  }
+
+  // Watson doesn't include punctuation at this time (Dec-2018).
+  // Instead, manually add punctuation on last word of "final" transcript blocks.
+  function punctuateEndOfSentence(firstWord, lastWord) {
+    if (!addPunctuation) {
+      return lastWord;
+
+    } else {
+
+      const interrogatives = [ 'when', 'where', 'why', 'how', 'does', "doesn't" ];
+
+      if (interrogatives.includes(firstWord)) {
+
+        return lastWord + '?';
+
+      } else {
+
+        return lastWord + '.';
+
+      }
+    }
+  }
+
+  const results = [];
+  for (x = 0; x < ibmJson.results.length; x++) { // result top level
+
+    topLvlResult = ibmJson.results[x];
+
+    for (y = 0; y < topLvlResult.results.length; y++) { // sentence level
+
+      const block = {};
+      const data = {};
+      const words = [];
+      const entityRanges = [];
+      const sentenceArray = [];
+      let offset = 0;
+
+      result = topLvlResult.results[y];
+
+      for (z = 0; z < result.alternatives[0].timestamps.length; z++) { // word level
+
+        const word = result.alternatives[0].timestamps[z][0];
+        const startTime = result.alternatives[0].timestamps[z][1];
+        const endTime = result.alternatives[0].timestamps[z][2];
+        const wordConfidence = result.alternatives[0].hasOwnProperty('word_confidence') ?
+          result.alternatives[0].word_confidence[z][1] : 100;
+
+        if (newSentence === true) {
+          punctuatedWord = capitalizeFirstLetter(word);
+          firstWordOfSentence = word;
+          newSentence = false;
+          data.speaker = 'TBC ' + topLvlResult.speaker_labels[z].speaker;
+          data.start = result.alternatives[0].timestamps[z][1];
+        } else {
+          punctuatedWord = word;
+        }
+
+        if ((z + 1) === (result.alternatives[0].timestamps.length) && result.final) { // end of block.
+          punctuatedWord = punctuateEndOfSentence(firstWordOfSentence, word);
+          newSentence = true;
+        }
+
+        const puncWordLength = punctuatedWord.length;
+
+        const aWord = {
+          start: startTime,
+          confidence: wordConfidence,
+          end: endTime,
+          word: word,
+          punct: punctuatedWord,
+          index: z
+        };
+
+        const anEntityRange = {
+          start: startTime,
+          end: endTime,
+          confidence: wordConfidence,
+          text: punctuatedWord,
+          offset: offset,
+          length: puncWordLength,
+          key: Math.random().toString(36).substring(6)
+        };
+
+        offset += puncWordLength + 1;
+
+        words.push(aWord);
+        entityRanges.push(anEntityRange);
+        sentenceArray.push(punctuatedWord);
+
+      }
+
+      data.words = words;
+
+      block['text'] = sentenceArray.join(' ');
+      block['type'] = 'paragraph';
+      block['data'] = data;
+      block['entityRanges'] = entityRanges;
+
+      results.push(block);
+
+    }
+
+  }
+
+  return results;
+};
+
+export default ibmToDraft;

--- a/src/lib/Util/adapters/ibm/index.js
+++ b/src/lib/Util/adapters/ibm/index.js
@@ -207,7 +207,7 @@ const ibmToDraft = (ibmJson) => {
           punctuatedWord = capitalizeFirstLetter(word);
           firstWordOfSentence = word;
           newSentence = false;
-          data.speaker = 'TBC ' + topLvlResult.speaker_labels[z].speaker;
+           data.speaker = 'Speaker ' + topLvlResult.speaker_labels[z].speaker;
           data.start = result.alternatives[0].timestamps[z][1];
         } else {
           punctuatedWord = word;

--- a/src/lib/Util/adapters/ibm/index.test.js
+++ b/src/lib/Util/adapters/ibm/index.test.js
@@ -1,0 +1,17 @@
+import bbcKaldiToDraft from './index';
+
+import draftTranscriptExample from './sample/bbcKaldiToDraft.sample.js';
+import kaldiTedTalkTranscript from './sample/kaldiTedTalkTranscript.sample.json';
+
+// TODO: figure out why the second of these two tests hang 
+// might need to review the draftJS data structure output
+describe('bbcKaldiToDraft', () => {
+  const result = bbcKaldiToDraft(kaldiTedTalkTranscript);
+  it('Should be defined', ( ) => {
+    expect(result).toBeDefined();
+  });
+
+  it('Should be equal to expected value', ( ) => {
+    expect(result).toEqual(draftTranscriptExample);
+  });
+});

--- a/src/lib/Util/adapters/ibm/index.test.js
+++ b/src/lib/Util/adapters/ibm/index.test.js
@@ -1,12 +1,12 @@
-import bbcKaldiToDraft from './index';
+import ibmToDraft from './index';
 
-import draftTranscriptExample from './sample/bbcKaldiToDraft.sample.js';
-import kaldiTedTalkTranscript from './sample/kaldiTedTalkTranscript.sample.json';
+import draftTranscriptExample from './sample/ibmToDraft.sample.js';
+import ibmTedTalkTranscript from './sample/ibmTedTalkTranscript.sample.json';
 
 // TODO: figure out why the second of these two tests hang 
 // might need to review the draftJS data structure output
 describe('bbcKaldiToDraft', () => {
-  const result = bbcKaldiToDraft(kaldiTedTalkTranscript);
+  const result = ibmToDraft(ibmTedTalkTranscript);
   it('Should be defined', ( ) => {
     expect(result).toBeDefined();
   });

--- a/src/lib/Util/adapters/ibm/sample/ibmTedTalkTranscript.sample.json
+++ b/src/lib/Util/adapters/ibm/sample/ibmTedTalkTranscript.sample.json
@@ -1,0 +1,29446 @@
+{
+   "created": "2018-12-18T22:40:38.903Z",
+   "id": "f14cbe1e-0315-11e9-b590-a3e1e3acdd73",
+   "updated": "2018-12-18T22:47:30.392Z",
+   "results": [{
+      "result_index": 0,
+      "speaker_labels": [
+         {
+            "speaker": 1,
+            "confidence": 0.36,
+            "final": false,
+            "from": 13.04,
+            "to": 13.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.36,
+            "final": false,
+            "from": 13.23,
+            "to": 13.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.36,
+            "final": false,
+            "from": 13.36,
+            "to": 13.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.36,
+            "final": false,
+            "from": 13.42,
+            "to": 13.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.36,
+            "final": false,
+            "from": 13.84,
+            "to": 14.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.36,
+            "final": false,
+            "from": 14.13,
+            "to": 14.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.36,
+            "final": false,
+            "from": 14.35,
+            "to": 14.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.36,
+            "final": false,
+            "from": 14.59,
+            "to": 15.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 15.46,
+            "to": 15.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 15.72,
+            "to": 15.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 15.78,
+            "to": 16.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 16.19,
+            "to": 16.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 16.27,
+            "to": 16.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 16.64,
+            "to": 16.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 16.72,
+            "to": 17.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.456,
+            "final": false,
+            "from": 17.23,
+            "to": 17.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.456,
+            "final": false,
+            "from": 17.31,
+            "to": 17.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.456,
+            "final": false,
+            "from": 17.62,
+            "to": 18.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.456,
+            "final": false,
+            "from": 18.12,
+            "to": 18.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.535,
+            "final": false,
+            "from": 18.72,
+            "to": 19.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.535,
+            "final": false,
+            "from": 19.16,
+            "to": 19.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.489,
+            "final": false,
+            "from": 21.86,
+            "to": 22.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.489,
+            "final": false,
+            "from": 22.07,
+            "to": 22.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.489,
+            "final": false,
+            "from": 22.22,
+            "to": 22.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.489,
+            "final": false,
+            "from": 22.68,
+            "to": 22.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.489,
+            "final": false,
+            "from": 22.86,
+            "to": 22.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.489,
+            "final": false,
+            "from": 22.94,
+            "to": 23.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.382,
+            "final": false,
+            "from": 24.2,
+            "to": 24.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 24.61,
+            "to": 24.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 24.71,
+            "to": 24.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 24.84,
+            "to": 25.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 25.32,
+            "to": 25.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 25.43,
+            "to": 25.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 25.48,
+            "to": 25.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 25.62,
+            "to": 25.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 25.86,
+            "to": 26.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 26.48,
+            "to": 26.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 26.82,
+            "to": 27.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.469,
+            "final": false,
+            "from": 27.03,
+            "to": 27.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.493,
+            "final": false,
+            "from": 28.42,
+            "to": 28.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.493,
+            "final": false,
+            "from": 28.57,
+            "to": 28.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.493,
+            "final": false,
+            "from": 28.76,
+            "to": 29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.493,
+            "final": false,
+            "from": 29,
+            "to": 29.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 29.75,
+            "to": 29.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 29.88,
+            "to": 30.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 30.02,
+            "to": 30.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 30.18,
+            "to": 30.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 30.42,
+            "to": 30.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 30.76,
+            "to": 30.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 30.92,
+            "to": 31.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 31.33,
+            "to": 31.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 31.79,
+            "to": 31.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 31.92,
+            "to": 32.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 32.1,
+            "to": 32.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 32.73,
+            "to": 32.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 32.89,
+            "to": 33.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 33.16,
+            "to": 33.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.438,
+            "final": false,
+            "from": 34.2,
+            "to": 34.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.438,
+            "final": false,
+            "from": 34.39,
+            "to": 34.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.438,
+            "final": false,
+            "from": 34.49,
+            "to": 34.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.438,
+            "final": false,
+            "from": 34.7,
+            "to": 34.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.438,
+            "final": false,
+            "from": 34.79,
+            "to": 35.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.438,
+            "final": false,
+            "from": 35.3,
+            "to": 35.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 36.49,
+            "to": 36.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 36.65,
+            "to": 36.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 36.78,
+            "to": 36.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 36.86,
+            "to": 36.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 36.96,
+            "to": 37.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 37.21,
+            "to": 37.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 37.32,
+            "to": 37.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 37.51,
+            "to": 37.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 37.67,
+            "to": 37.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.504,
+            "final": false,
+            "from": 37.95,
+            "to": 38.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.504,
+            "final": false,
+            "from": 38.37,
+            "to": 38.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.489,
+            "final": false,
+            "from": 39.25,
+            "to": 39.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.489,
+            "final": false,
+            "from": 39.46,
+            "to": 39.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 39.61,
+            "to": 39.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 39.81,
+            "to": 39.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 39.95,
+            "to": 40.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 40.53,
+            "to": 40.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 40.63,
+            "to": 40.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 40.99,
+            "to": 41.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 41.14,
+            "to": 41.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 42.01,
+            "to": 42.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 42.22,
+            "to": 42.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 42.32,
+            "to": 42.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 42.4,
+            "to": 42.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 42.61,
+            "to": 42.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 42.71,
+            "to": 43.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 43.04,
+            "to": 43.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.461,
+            "final": false,
+            "from": 44.24,
+            "to": 44.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.461,
+            "final": false,
+            "from": 44.43,
+            "to": 44.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.461,
+            "final": false,
+            "from": 44.66,
+            "to": 44.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.461,
+            "final": false,
+            "from": 44.74,
+            "to": 45.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.455,
+            "final": false,
+            "from": 46.52,
+            "to": 46.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.455,
+            "final": false,
+            "from": 46.62,
+            "to": 46.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.455,
+            "final": false,
+            "from": 46.67,
+            "to": 46.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.455,
+            "final": false,
+            "from": 46.88,
+            "to": 47.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 47.13,
+            "to": 47.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 47.26,
+            "to": 47.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 47.62,
+            "to": 47.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 47.98,
+            "to": 48.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 48.15,
+            "to": 48.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 48.25,
+            "to": 48.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 48.66,
+            "to": 48.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 48.81,
+            "to": 48.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 48.92,
+            "to": 49.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 49.02,
+            "to": 49.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 50.01,
+            "to": 50.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 50.15,
+            "to": 50.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 50.2,
+            "to": 50.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 50.38,
+            "to": 50.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 50.44,
+            "to": 50.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 50.81,
+            "to": 50.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 50.88,
+            "to": 50.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 50.96,
+            "to": 51.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 51.05,
+            "to": 51.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 51.22,
+            "to": 51.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 51.57,
+            "to": 51.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.384,
+            "final": false,
+            "from": 51.71,
+            "to": 52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 55.24,
+            "to": 55.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 55.37,
+            "to": 55.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 55.49,
+            "to": 55.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 55.91,
+            "to": 56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 56,
+            "to": 56.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 56.9,
+            "to": 57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 57,
+            "to": 57.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 57.2,
+            "to": 57.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.624,
+            "final": false,
+            "from": 58.87,
+            "to": 59.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 59.89,
+            "to": 60.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 60.11,
+            "to": 60.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 60.61,
+            "to": 61.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.486,
+            "final": false,
+            "from": 62.74,
+            "to": 63.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 63.24,
+            "to": 63.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 63.53,
+            "to": 63.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 63.56,
+            "to": 63.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 63.73,
+            "to": 64.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.621,
+            "final": false,
+            "from": 64.93,
+            "to": 65.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 65.48,
+            "to": 65.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 65.83,
+            "to": 65.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 65.97,
+            "to": 66.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 66.04,
+            "to": 66.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 67.71,
+            "to": 67.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 67.88,
+            "to": 67.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 67.95,
+            "to": 68.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 68.2,
+            "to": 68.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.432,
+            "final": false,
+            "from": 69.96,
+            "to": 70.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.432,
+            "final": false,
+            "from": 70.19,
+            "to": 70.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.432,
+            "final": false,
+            "from": 70.56,
+            "to": 71.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 71.92,
+            "to": 72.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 72.1,
+            "to": 72.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 72.22,
+            "to": 72.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 72.31,
+            "to": 72.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 72.55,
+            "to": 73.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 74.26,
+            "to": 74.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 74.42,
+            "to": 74.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 74.55,
+            "to": 74.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 74.61,
+            "to": 74.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 74.88,
+            "to": 74.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 74.98,
+            "to": 75.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 75.34,
+            "to": 75.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 75.43,
+            "to": 75.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 75.56,
+            "to": 75.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 75.65,
+            "to": 75.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.516,
+            "final": false,
+            "from": 75.91,
+            "to": 76.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 79.08,
+            "to": 79.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 79.13,
+            "to": 79.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 79.27,
+            "to": 79.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 79.43,
+            "to": 79.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 79.5,
+            "to": 79.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 79.6,
+            "to": 79.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 79.93,
+            "to": 80.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 80.58,
+            "to": 80.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 80.75,
+            "to": 81.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.55,
+            "final": false,
+            "from": 82.07,
+            "to": 82.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.55,
+            "final": false,
+            "from": 82.16,
+            "to": 82.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.55,
+            "final": false,
+            "from": 82.32,
+            "to": 82.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 82.96,
+            "to": 83.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 83.05,
+            "to": 83.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 83.3,
+            "to": 83.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 83.37,
+            "to": 83.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 83.77,
+            "to": 84.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 84.39,
+            "to": 84.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 84.9,
+            "to": 85.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 85.05,
+            "to": 85.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 85.14,
+            "to": 85.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 86.66,
+            "to": 86.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 86.9,
+            "to": 87.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 87.15,
+            "to": 87.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 87.28,
+            "to": 87.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 87.37,
+            "to": 87.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 87.59,
+            "to": 87.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 87.65,
+            "to": 87.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 87.96,
+            "to": 88.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 88.26,
+            "to": 88.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.577,
+            "final": false,
+            "from": 88.48,
+            "to": 88.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.379,
+            "final": false,
+            "from": 89.41,
+            "to": 89.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.379,
+            "final": false,
+            "from": 89.54,
+            "to": 89.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.379,
+            "final": false,
+            "from": 89.63,
+            "to": 89.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.379,
+            "final": false,
+            "from": 89.89,
+            "to": 90.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 90.18,
+            "to": 90.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 90.48,
+            "to": 90.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 90.71,
+            "to": 91.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 91.23,
+            "to": 91.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 91.43,
+            "to": 91.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 91.53,
+            "to": 91.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 91.73,
+            "to": 91.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 91.85,
+            "to": 92.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 95.01,
+            "to": 95.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 95.26,
+            "to": 95.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 95.43,
+            "to": 95.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 95.88,
+            "to": 96.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 96.09,
+            "to": 96.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 96.42,
+            "to": 96.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 96.56,
+            "to": 96.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 96.84,
+            "to": 97.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 97.25,
+            "to": 97.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.551,
+            "final": false,
+            "from": 97.9,
+            "to": 98.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.551,
+            "final": false,
+            "from": 98.01,
+            "to": 98.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.551,
+            "final": false,
+            "from": 98.15,
+            "to": 98.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.551,
+            "final": false,
+            "from": 98.88,
+            "to": 99.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.551,
+            "final": false,
+            "from": 99.14,
+            "to": 99.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.551,
+            "final": false,
+            "from": 99.38,
+            "to": 99.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.551,
+            "final": false,
+            "from": 99.92,
+            "to": 100.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.574,
+            "final": false,
+            "from": 101.5,
+            "to": 101.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.574,
+            "final": false,
+            "from": 101.67,
+            "to": 101.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.574,
+            "final": false,
+            "from": 101.85,
+            "to": 101.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.574,
+            "final": false,
+            "from": 101.93,
+            "to": 102.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.574,
+            "final": false,
+            "from": 102.35,
+            "to": 102.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.574,
+            "final": false,
+            "from": 102.64,
+            "to": 103.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.574,
+            "final": false,
+            "from": 103.37,
+            "to": 103.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.574,
+            "final": false,
+            "from": 103.5,
+            "to": 103.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.574,
+            "final": false,
+            "from": 103.65,
+            "to": 104.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.566,
+            "final": false,
+            "from": 104.43,
+            "to": 104.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.566,
+            "final": false,
+            "from": 104.57,
+            "to": 104.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.558,
+            "final": false,
+            "from": 106.4,
+            "to": 106.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.558,
+            "final": false,
+            "from": 106.62,
+            "to": 106.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 106.91,
+            "to": 107.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 107.68,
+            "to": 108.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 108.09,
+            "to": 108.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 108.18,
+            "to": 109.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 109.1,
+            "to": 109.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 109.31,
+            "to": 109.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 109.37,
+            "to": 109.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 109.72,
+            "to": 109.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 109.81,
+            "to": 110.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.208,
+            "final": false,
+            "from": 110.19,
+            "to": 110.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.208,
+            "final": false,
+            "from": 110.35,
+            "to": 110.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.533,
+            "final": false,
+            "from": 110.75,
+            "to": 111.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.533,
+            "final": false,
+            "from": 111.26,
+            "to": 111.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 112.91,
+            "to": 113.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 113.14,
+            "to": 113.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 113.37,
+            "to": 113.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 113.42,
+            "to": 113.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 113.71,
+            "to": 113.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 113.87,
+            "to": 114.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 114.11,
+            "to": 114.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.608,
+            "final": false,
+            "from": 116.21,
+            "to": 116.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.608,
+            "final": false,
+            "from": 116.35,
+            "to": 116.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.608,
+            "final": false,
+            "from": 116.46,
+            "to": 116.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.608,
+            "final": false,
+            "from": 116.55,
+            "to": 116.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.608,
+            "final": false,
+            "from": 116.63,
+            "to": 116.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.608,
+            "final": false,
+            "from": 116.86,
+            "to": 116.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.608,
+            "final": false,
+            "from": 116.91,
+            "to": 117.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.608,
+            "final": false,
+            "from": 117.56,
+            "to": 117.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.608,
+            "final": false,
+            "from": 117.74,
+            "to": 118.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 118.44,
+            "to": 118.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 118.6,
+            "to": 119.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 119.18,
+            "to": 119.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 119.26,
+            "to": 119.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 119.42,
+            "to": 119.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 119.77,
+            "to": 119.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 119.92,
+            "to": 120.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 120.21,
+            "to": 120.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 120.35,
+            "to": 120.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 121,
+            "to": 121.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 121.13,
+            "to": 121.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 121.6,
+            "to": 122.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 122.07,
+            "to": 122.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 122.15,
+            "to": 122.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 122.29,
+            "to": 122.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 122.58,
+            "to": 122.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 123.53,
+            "to": 123.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 123.72,
+            "to": 123.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 123.83,
+            "to": 123.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 123.92,
+            "to": 124.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 124.4,
+            "to": 124.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 124.54,
+            "to": 124.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 124.63,
+            "to": 125.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 125.45,
+            "to": 126.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 126.15,
+            "to": 126.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.547,
+            "final": false,
+            "from": 127.21,
+            "to": 127.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.547,
+            "final": false,
+            "from": 127.5,
+            "to": 127.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.547,
+            "final": false,
+            "from": 127.64,
+            "to": 128.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 128.97,
+            "to": 129.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 129.09,
+            "to": 129.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 129.56,
+            "to": 129.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 129.72,
+            "to": 130
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 130,
+            "to": 130.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.382,
+            "final": false,
+            "from": 130.38,
+            "to": 130.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.382,
+            "final": false,
+            "from": 130.74,
+            "to": 130.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.382,
+            "final": false,
+            "from": 130.87,
+            "to": 132.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.643,
+            "final": false,
+            "from": 133.44,
+            "to": 133.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.643,
+            "final": false,
+            "from": 133.66,
+            "to": 133.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.643,
+            "final": false,
+            "from": 133.75,
+            "to": 134.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.643,
+            "final": false,
+            "from": 134.01,
+            "to": 134.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.643,
+            "final": false,
+            "from": 134.12,
+            "to": 134.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.643,
+            "final": false,
+            "from": 134.25,
+            "to": 134.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.643,
+            "final": false,
+            "from": 134.31,
+            "to": 135.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.505,
+            "final": false,
+            "from": 135.16,
+            "to": 135.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.505,
+            "final": false,
+            "from": 135.34,
+            "to": 135.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.618,
+            "final": false,
+            "from": 135.55,
+            "to": 135.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.618,
+            "final": false,
+            "from": 135.76,
+            "to": 136.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.618,
+            "final": false,
+            "from": 136.05,
+            "to": 136.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.618,
+            "final": false,
+            "from": 136.38,
+            "to": 136.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 139.24,
+            "to": 139.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 139.39,
+            "to": 139.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 139.55,
+            "to": 139.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 139.9,
+            "to": 140.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 140.04,
+            "to": 140.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 140.73,
+            "to": 140.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 140.86,
+            "to": 141.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 141.37,
+            "to": 141.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 141.74,
+            "to": 142.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 142.25,
+            "to": 142.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 142.41,
+            "to": 142.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 142.5,
+            "to": 142.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 142.89,
+            "to": 143.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 143.19,
+            "to": 144.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.506,
+            "final": false,
+            "from": 144.07,
+            "to": 144.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.506,
+            "final": false,
+            "from": 144.24,
+            "to": 144.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.506,
+            "final": false,
+            "from": 144.79,
+            "to": 145.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.527,
+            "final": false,
+            "from": 145.29,
+            "to": 145.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.527,
+            "final": false,
+            "from": 145.86,
+            "to": 146
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.527,
+            "final": false,
+            "from": 146,
+            "to": 146.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.527,
+            "final": false,
+            "from": 146.55,
+            "to": 146.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.527,
+            "final": false,
+            "from": 146.93,
+            "to": 147.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.527,
+            "final": false,
+            "from": 147.28,
+            "to": 147.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.527,
+            "final": false,
+            "from": 147.51,
+            "to": 147.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.527,
+            "final": false,
+            "from": 147.64,
+            "to": 147.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.527,
+            "final": false,
+            "from": 147.89,
+            "to": 148.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 148.37,
+            "to": 148.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 148.46,
+            "to": 148.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 148.57,
+            "to": 148.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 148.95,
+            "to": 149.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 149.08,
+            "to": 149.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 149.15,
+            "to": 149.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 149.54,
+            "to": 150.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 150.43,
+            "to": 150.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 150.55,
+            "to": 150.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 150.68,
+            "to": 150.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 150.93,
+            "to": 151.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 151.13,
+            "to": 151.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 151.19,
+            "to": 151.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 151.48,
+            "to": 151.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 151.8,
+            "to": 151.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 151.89,
+            "to": 152.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 152.03,
+            "to": 152.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 152.89,
+            "to": 153.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 153.07,
+            "to": 153.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 153.29,
+            "to": 153.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 153.46,
+            "to": 153.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 153.51,
+            "to": 153.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 153.88,
+            "to": 153.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 153.97,
+            "to": 154.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 154.02,
+            "to": 154.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 154.43,
+            "to": 154.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 154.64,
+            "to": 154.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 154.71,
+            "to": 154.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 154.81,
+            "to": 155.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 155.08,
+            "to": 155.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 155.2,
+            "to": 155.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 155.43,
+            "to": 155.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 155.86,
+            "to": 156.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 156.02,
+            "to": 156.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 156.51,
+            "to": 156.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 156.62,
+            "to": 156.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 156.69,
+            "to": 156.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 156.89,
+            "to": 157.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 157.26,
+            "to": 157.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 157.38,
+            "to": 157.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 157.56,
+            "to": 157.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 157.71,
+            "to": 157.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.612,
+            "final": false,
+            "from": 157.81,
+            "to": 158.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 159.22,
+            "to": 159.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 159.52,
+            "to": 159.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 159.67,
+            "to": 160.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 160.12,
+            "to": 160.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 160.24,
+            "to": 160.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 160.34,
+            "to": 160.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 160.43,
+            "to": 160.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 160.93,
+            "to": 161.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 161.01,
+            "to": 161.17
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 161.17,
+            "to": 161.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.588,
+            "final": false,
+            "from": 161.67,
+            "to": 162.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.197,
+            "final": false,
+            "from": 163.04,
+            "to": 163.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.197,
+            "final": false,
+            "from": 163.2,
+            "to": 163.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.197,
+            "final": false,
+            "from": 163.31,
+            "to": 163.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.197,
+            "final": false,
+            "from": 163.79,
+            "to": 163.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.197,
+            "final": false,
+            "from": 163.88,
+            "to": 164.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 165.26,
+            "to": 165.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 165.56,
+            "to": 165.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 165.73,
+            "to": 166.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 166.19,
+            "to": 166.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 166.4,
+            "to": 166.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 166.75,
+            "to": 166.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 166.96,
+            "to": 167.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 167.6,
+            "to": 167.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 167.81,
+            "to": 168.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 168.3,
+            "to": 168.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 168.56,
+            "to": 169
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 169,
+            "to": 169.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 169.16,
+            "to": 169.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 169.61,
+            "to": 170.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 170.04,
+            "to": 170.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.435,
+            "final": false,
+            "from": 170.44,
+            "to": 170.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.407,
+            "final": false,
+            "from": 171.31,
+            "to": 171.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.407,
+            "final": false,
+            "from": 171.42,
+            "to": 171.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.407,
+            "final": false,
+            "from": 171.68,
+            "to": 172.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.414,
+            "final": false,
+            "from": 174.97,
+            "to": 175.17
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.414,
+            "final": false,
+            "from": 175.17,
+            "to": 175.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.414,
+            "final": false,
+            "from": 175.39,
+            "to": 175.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.414,
+            "final": false,
+            "from": 175.54,
+            "to": 176.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 176.24,
+            "to": 176.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 176.36,
+            "to": 176.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 176.94,
+            "to": 177.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 177.65,
+            "to": 178.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.564,
+            "final": false,
+            "from": 178.83,
+            "to": 179.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.564,
+            "final": false,
+            "from": 179.09,
+            "to": 179.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.564,
+            "final": false,
+            "from": 179.43,
+            "to": 179.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.564,
+            "final": false,
+            "from": 179.59,
+            "to": 180.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.412,
+            "final": false,
+            "from": 180.95,
+            "to": 181.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.412,
+            "final": false,
+            "from": 181.08,
+            "to": 181.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.412,
+            "final": false,
+            "from": 181.27,
+            "to": 181.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.412,
+            "final": false,
+            "from": 181.41,
+            "to": 181.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.412,
+            "final": false,
+            "from": 181.91,
+            "to": 182.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.412,
+            "final": false,
+            "from": 182.04,
+            "to": 182.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.4,
+            "final": false,
+            "from": 183.59,
+            "to": 183.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 184.07,
+            "to": 184.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 184.2,
+            "to": 184.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 184.47,
+            "to": 184.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 184.61,
+            "to": 185.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 185.16,
+            "to": 185.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 185.3,
+            "to": 185.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 185.74,
+            "to": 186.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 186.07,
+            "to": 186.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 186.42,
+            "to": 186.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 186.84,
+            "to": 186.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 186.95,
+            "to": 187.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 187.18,
+            "to": 187.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 187.32,
+            "to": 187.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 187.38,
+            "to": 188.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 188.03,
+            "to": 188.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.458,
+            "final": false,
+            "from": 188.29,
+            "to": 188.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.482,
+            "final": false,
+            "from": 189.47,
+            "to": 189.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 189.76,
+            "to": 189.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 189.87,
+            "to": 190.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 190.05,
+            "to": 190.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 190.12,
+            "to": 190.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 190.33,
+            "to": 190.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 190.48,
+            "to": 190.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 190.76,
+            "to": 190.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 190.92,
+            "to": 191.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 192.24,
+            "to": 192.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 192.37,
+            "to": 192.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 192.68,
+            "to": 192.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 192.8,
+            "to": 192.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 192.92,
+            "to": 193.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 193.06,
+            "to": 193.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 193.94,
+            "to": 194.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 194.47,
+            "to": 194.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 194.93,
+            "to": 195.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.326,
+            "final": false,
+            "from": 195.08,
+            "to": 195.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 196.1,
+            "to": 196.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.381,
+            "final": false,
+            "from": 196.88,
+            "to": 197.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.381,
+            "final": false,
+            "from": 197.19,
+            "to": 197.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.381,
+            "final": false,
+            "from": 197.59,
+            "to": 197.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.381,
+            "final": false,
+            "from": 197.79,
+            "to": 198.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 198.57,
+            "to": 198.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 198.78,
+            "to": 199.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 199.37,
+            "to": 199.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 199.46,
+            "to": 199.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 199.57,
+            "to": 200.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 200.11,
+            "to": 200.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 200.5,
+            "to": 200.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 200.65,
+            "to": 201.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 201.13,
+            "to": 201.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.617,
+            "final": false,
+            "from": 201.2,
+            "to": 201.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.493,
+            "final": false,
+            "from": 203.2,
+            "to": 203.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.493,
+            "final": false,
+            "from": 203.39,
+            "to": 203.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.493,
+            "final": false,
+            "from": 203.74,
+            "to": 203.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.273,
+            "final": false,
+            "from": 204.02,
+            "to": 204.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.273,
+            "final": false,
+            "from": 204.2,
+            "to": 204.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.273,
+            "final": false,
+            "from": 204.46,
+            "to": 204.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.273,
+            "final": false,
+            "from": 204.57,
+            "to": 204.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.273,
+            "final": false,
+            "from": 204.93,
+            "to": 205.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.273,
+            "final": false,
+            "from": 205.1,
+            "to": 205.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.273,
+            "final": false,
+            "from": 205.28,
+            "to": 205.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.533,
+            "final": false,
+            "from": 206.69,
+            "to": 206.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.533,
+            "final": false,
+            "from": 206.91,
+            "to": 207.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.533,
+            "final": false,
+            "from": 207.23,
+            "to": 208
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 208.03,
+            "to": 208.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 208.56,
+            "to": 208.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 208.76,
+            "to": 209.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 209.38,
+            "to": 209.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 209.53,
+            "to": 209.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 209.72,
+            "to": 210.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 210.15,
+            "to": 210.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 210.26,
+            "to": 210.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 211.09,
+            "to": 211.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 211.27,
+            "to": 211.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 211.4,
+            "to": 212.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 212.01,
+            "to": 212.17
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 212.17,
+            "to": 212.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 212.34,
+            "to": 212.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 212.53,
+            "to": 212.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.609,
+            "final": false,
+            "from": 212.77,
+            "to": 213.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.45,
+            "final": false,
+            "from": 214.35,
+            "to": 214.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 214.95,
+            "to": 215.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 215.37,
+            "to": 215.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 215.57,
+            "to": 215.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 215.66,
+            "to": 215.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 215.76,
+            "to": 215.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 215.86,
+            "to": 216.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 216.03,
+            "to": 216.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 216.31,
+            "to": 216.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 216.44,
+            "to": 216.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 216.78,
+            "to": 217.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 217.16,
+            "to": 217.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 217.75,
+            "to": 218.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 218.25,
+            "to": 218.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.555,
+            "final": false,
+            "from": 218.83,
+            "to": 218.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.555,
+            "final": false,
+            "from": 218.98,
+            "to": 219.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.555,
+            "final": false,
+            "from": 219.4,
+            "to": 219.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.555,
+            "final": false,
+            "from": 219.81,
+            "to": 220.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 221.68,
+            "to": 221.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 221.9,
+            "to": 221.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 221.99,
+            "to": 222.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 222.48,
+            "to": 222.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 222.68,
+            "to": 222.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 222.97,
+            "to": 223.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 223.24,
+            "to": 223.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 223.35,
+            "to": 223.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 223.77,
+            "to": 223.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 223.86,
+            "to": 224.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 224.23,
+            "to": 224.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 224.77,
+            "to": 224.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 224.9,
+            "to": 225
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 225,
+            "to": 225.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 225.1,
+            "to": 225.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 225.43,
+            "to": 225.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 225.56,
+            "to": 225.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 225.72,
+            "to": 226.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 226.22,
+            "to": 226.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 226.54,
+            "to": 226.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 226.66,
+            "to": 226.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 226.78,
+            "to": 227.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 227.09,
+            "to": 227.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 227.21,
+            "to": 227.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 227.53,
+            "to": 227.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 227.78,
+            "to": 227.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 227.96,
+            "to": 228.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 228.36,
+            "to": 228.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.59,
+            "final": false,
+            "from": 228.48,
+            "to": 228.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 229.31,
+            "to": 229.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 229.48,
+            "to": 229.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 229.7,
+            "to": 230.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 230.11,
+            "to": 230.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 230.27,
+            "to": 230.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 230.38,
+            "to": 230.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 230.59,
+            "to": 230.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 230.75,
+            "to": 230.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 230.87,
+            "to": 230.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 230.93,
+            "to": 231.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 231.09,
+            "to": 231.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 231.43,
+            "to": 231.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 231.6,
+            "to": 231.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.579,
+            "final": false,
+            "from": 231.72,
+            "to": 232.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 234.43,
+            "to": 234.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 234.59,
+            "to": 234.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 234.71,
+            "to": 234.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 234.85,
+            "to": 235.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 235.28,
+            "to": 235.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 235.65,
+            "to": 236.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 236.48,
+            "to": 236.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 236.63,
+            "to": 236.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 236.99,
+            "to": 237.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 237.18,
+            "to": 237.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.247,
+            "final": false,
+            "from": 237.74,
+            "to": 238.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 238.2,
+            "to": 238.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.568,
+            "final": false,
+            "from": 238.37,
+            "to": 238.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.532,
+            "final": false,
+            "from": 239.18,
+            "to": 239.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.532,
+            "final": false,
+            "from": 239.36,
+            "to": 240.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.344,
+            "final": false,
+            "from": 240.3,
+            "to": 240.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.344,
+            "final": false,
+            "from": 240.6,
+            "to": 241.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.344,
+            "final": false,
+            "from": 241.26,
+            "to": 241.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.344,
+            "final": false,
+            "from": 241.37,
+            "to": 241.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.344,
+            "final": false,
+            "from": 241.66,
+            "to": 242.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.344,
+            "final": false,
+            "from": 242.51,
+            "to": 243.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.344,
+            "final": false,
+            "from": 243.45,
+            "to": 244.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.37,
+            "final": false,
+            "from": 244.49,
+            "to": 244.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.37,
+            "final": false,
+            "from": 244.73,
+            "to": 245.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.37,
+            "final": false,
+            "from": 245.06,
+            "to": 245.17
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.37,
+            "final": false,
+            "from": 245.17,
+            "to": 245.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 246.57,
+            "to": 246.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 246.71,
+            "to": 246.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 246.85,
+            "to": 246.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 246.95,
+            "to": 247.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 247.34,
+            "to": 247.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 247.57,
+            "to": 247.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 247.68,
+            "to": 248.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 248.09,
+            "to": 248.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 248.32,
+            "to": 248.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 248.56,
+            "to": 248.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 248.85,
+            "to": 249.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.611,
+            "final": false,
+            "from": 249.34,
+            "to": 249.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 249.65,
+            "to": 249.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 249.9,
+            "to": 250.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 250.38,
+            "to": 250.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 250.51,
+            "to": 250.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 250.69,
+            "to": 250.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 250.87,
+            "to": 251.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 251.67,
+            "to": 251.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 251.85,
+            "to": 252.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 252.01,
+            "to": 252.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 252.54,
+            "to": 253.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.584,
+            "final": false,
+            "from": 253.11,
+            "to": 253.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 253.41,
+            "to": 253.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 253.96,
+            "to": 254.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 254.46,
+            "to": 254.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 254.74,
+            "to": 254.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 254.92,
+            "to": 255.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 255.03,
+            "to": 255.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 255.09,
+            "to": 255.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 255.3,
+            "to": 255.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 255.63,
+            "to": 255.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 255.9,
+            "to": 256.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 256.55,
+            "to": 256.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 256.67,
+            "to": 256.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 256.75,
+            "to": 257.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 257.04,
+            "to": 257.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 257.15,
+            "to": 257.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 257.26,
+            "to": 257.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 257.52,
+            "to": 257.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 257.59,
+            "to": 257.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 257.98,
+            "to": 258.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 258.36,
+            "to": 258.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 261.63,
+            "to": 261.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 261.73,
+            "to": 261.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 261.92,
+            "to": 262.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 262.08,
+            "to": 262.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 262.26,
+            "to": 262.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 262.45,
+            "to": 262.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 262.79,
+            "to": 262.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 262.96,
+            "to": 263.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 263.36,
+            "to": 263.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 263.55,
+            "to": 264.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 264.39,
+            "to": 264.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 264.65,
+            "to": 265.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 265.03,
+            "to": 265.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 265.22,
+            "to": 265.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 265.77,
+            "to": 266.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 266.41,
+            "to": 266.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 266.51,
+            "to": 266.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 266.63,
+            "to": 267.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.402,
+            "final": false,
+            "from": 267.27,
+            "to": 267.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.402,
+            "final": false,
+            "from": 267.55,
+            "to": 267.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.402,
+            "final": false,
+            "from": 267.66,
+            "to": 267.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.402,
+            "final": false,
+            "from": 267.84,
+            "to": 267.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.402,
+            "final": false,
+            "from": 267.98,
+            "to": 268.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.402,
+            "final": false,
+            "from": 268.2,
+            "to": 268.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.402,
+            "final": false,
+            "from": 268.5,
+            "to": 268.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.402,
+            "final": false,
+            "from": 268.68,
+            "to": 269.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 269.88,
+            "to": 270.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 270.19,
+            "to": 270.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 270.29,
+            "to": 270.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 270.4,
+            "to": 270.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 270.64,
+            "to": 270.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 270.82,
+            "to": 271
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 271,
+            "to": 271.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.593,
+            "final": false,
+            "from": 271.24,
+            "to": 271.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.291,
+            "final": false,
+            "from": 273.6,
+            "to": 274.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 274.49,
+            "to": 274.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 274.66,
+            "to": 274.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 274.95,
+            "to": 275.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 275.2,
+            "to": 275.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 275.26,
+            "to": 275.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 275.69,
+            "to": 275.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 275.85,
+            "to": 276.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 276.32,
+            "to": 276.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.459,
+            "final": false,
+            "from": 276.55,
+            "to": 277.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 277.66,
+            "to": 278.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 278.03,
+            "to": 278.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 278.57,
+            "to": 278.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 278.82,
+            "to": 279.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 279.21,
+            "to": 279.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 279.4,
+            "to": 279.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 279.55,
+            "to": 279.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 279.82,
+            "to": 280.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 280.24,
+            "to": 280.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 280.76,
+            "to": 280.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 280.95,
+            "to": 281.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.432,
+            "final": false,
+            "from": 281.41,
+            "to": 282.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.432,
+            "final": false,
+            "from": 282.31,
+            "to": 283.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.123,
+            "final": false,
+            "from": 283.82,
+            "to": 284.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.576,
+            "final": false,
+            "from": 284.13,
+            "to": 284.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.576,
+            "final": false,
+            "from": 284.33,
+            "to": 284.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.576,
+            "final": false,
+            "from": 284.53,
+            "to": 285.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.576,
+            "final": false,
+            "from": 285.21,
+            "to": 285.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.576,
+            "final": false,
+            "from": 285.36,
+            "to": 285.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.255,
+            "final": false,
+            "from": 285.89,
+            "to": 286.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.255,
+            "final": false,
+            "from": 286.57,
+            "to": 286.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 287.21,
+            "to": 287.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 287.43,
+            "to": 288.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 288.01,
+            "to": 288.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 288.67,
+            "to": 288.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.587,
+            "final": false,
+            "from": 288.91,
+            "to": 289.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.473,
+            "final": false,
+            "from": 290.05,
+            "to": 290.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.473,
+            "final": false,
+            "from": 290.37,
+            "to": 290.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.473,
+            "final": false,
+            "from": 290.57,
+            "to": 290.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.473,
+            "final": false,
+            "from": 290.7,
+            "to": 291.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.473,
+            "final": false,
+            "from": 291.07,
+            "to": 292.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 292.64,
+            "to": 292.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 292.76,
+            "to": 292.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 292.99,
+            "to": 293.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 293.18,
+            "to": 293.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 293.41,
+            "to": 293.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 293.51,
+            "to": 293.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 293.75,
+            "to": 294.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 294.31,
+            "to": 294.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 294.42,
+            "to": 294.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 294.7,
+            "to": 294.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 294.83,
+            "to": 295.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 295.06,
+            "to": 295.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 295.18,
+            "to": 295.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 295.31,
+            "to": 296.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 296.02,
+            "to": 296.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.145,
+            "final": false,
+            "from": 296.23,
+            "to": 296.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 297.48,
+            "to": 297.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 297.97,
+            "to": 298.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 298.06,
+            "to": 298.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 298.3,
+            "to": 298.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.335,
+            "final": false,
+            "from": 299.11,
+            "to": 299.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.335,
+            "final": false,
+            "from": 299.44,
+            "to": 299.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.335,
+            "final": false,
+            "from": 299.76,
+            "to": 299.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.335,
+            "final": false,
+            "from": 299.85,
+            "to": 300.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.335,
+            "final": false,
+            "from": 300.47,
+            "to": 301.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.52,
+            "final": false,
+            "from": 301.41,
+            "to": 301.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.52,
+            "final": false,
+            "from": 301.54,
+            "to": 301.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.52,
+            "final": false,
+            "from": 301.64,
+            "to": 301.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.52,
+            "final": false,
+            "from": 301.96,
+            "to": 302.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.52,
+            "final": false,
+            "from": 302.12,
+            "to": 302.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.52,
+            "final": false,
+            "from": 302.3,
+            "to": 302.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.313,
+            "final": false,
+            "from": 302.91,
+            "to": 303.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.313,
+            "final": false,
+            "from": 303.14,
+            "to": 303.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.558,
+            "final": false,
+            "from": 303.86,
+            "to": 303.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.558,
+            "final": false,
+            "from": 303.97,
+            "to": 304.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 305.51,
+            "to": 305.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 305.66,
+            "to": 305.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 305.9,
+            "to": 306.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 306.42,
+            "to": 306.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 306.57,
+            "to": 306.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 306.92,
+            "to": 307.17
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 307.17,
+            "to": 307.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 307.74,
+            "to": 307.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 307.93,
+            "to": 308.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.386,
+            "final": false,
+            "from": 308.88,
+            "to": 309.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.386,
+            "final": false,
+            "from": 309.04,
+            "to": 309.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.386,
+            "final": false,
+            "from": 309.23,
+            "to": 310.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.163,
+            "final": false,
+            "from": 310.47,
+            "to": 310.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 310.76,
+            "to": 310.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 310.96,
+            "to": 311.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 311.31,
+            "to": 311.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 311.44,
+            "to": 311.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 311.71,
+            "to": 311.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.499,
+            "final": false,
+            "from": 311.86,
+            "to": 312.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.57,
+            "final": false,
+            "from": 312.59,
+            "to": 312.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.57,
+            "final": false,
+            "from": 312.85,
+            "to": 313.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.57,
+            "final": false,
+            "from": 313.08,
+            "to": 313.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.57,
+            "final": false,
+            "from": 313.14,
+            "to": 313.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.57,
+            "final": false,
+            "from": 313.53,
+            "to": 313.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.57,
+            "final": false,
+            "from": 313.62,
+            "to": 314.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.57,
+            "final": false,
+            "from": 314.11,
+            "to": 314.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.57,
+            "final": false,
+            "from": 314.21,
+            "to": 314.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.57,
+            "final": false,
+            "from": 314.31,
+            "to": 315.17
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 315.8,
+            "to": 315.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 315.92,
+            "to": 316.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 316.09,
+            "to": 316.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 316.2,
+            "to": 316.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 316.68,
+            "to": 316.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 316.81,
+            "to": 317.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 317.01,
+            "to": 317.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 317.25,
+            "to": 317.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 317.34,
+            "to": 317.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 317.78,
+            "to": 318.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 318.36,
+            "to": 318.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 318.49,
+            "to": 318.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 318.91,
+            "to": 319.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.351,
+            "final": false,
+            "from": 321.45,
+            "to": 322.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.295,
+            "final": false,
+            "from": 323.02,
+            "to": 323.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.295,
+            "final": false,
+            "from": 323.5,
+            "to": 323.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.295,
+            "final": false,
+            "from": 323.71,
+            "to": 324.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.426,
+            "final": false,
+            "from": 324.6,
+            "to": 325.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.426,
+            "final": false,
+            "from": 325.01,
+            "to": 325.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.426,
+            "final": false,
+            "from": 325.11,
+            "to": 325.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 327.62,
+            "to": 327.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 327.81,
+            "to": 327.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 327.87,
+            "to": 328.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 328.02,
+            "to": 328.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 328.24,
+            "to": 328.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 328.33,
+            "to": 328.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 328.57,
+            "to": 328.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 328.92,
+            "to": 329.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 329.04,
+            "to": 329.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 329.68,
+            "to": 329.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 329.8,
+            "to": 330.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 330.23,
+            "to": 330.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 330.5,
+            "to": 330.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 330.72,
+            "to": 330.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 330.99,
+            "to": 331.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 331.22,
+            "to": 331.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 331.69,
+            "to": 332.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 332.08,
+            "to": 332.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 332.12,
+            "to": 332.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 332.27,
+            "to": 332.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.635,
+            "final": false,
+            "from": 332.66,
+            "to": 333.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 335.03,
+            "to": 335.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 335.24,
+            "to": 335.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 335.49,
+            "to": 335.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 335.76,
+            "to": 335.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.56,
+            "final": false,
+            "from": 335.95,
+            "to": 336.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.284,
+            "final": false,
+            "from": 337.79,
+            "to": 338.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.284,
+            "final": false,
+            "from": 338.01,
+            "to": 338.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.284,
+            "final": false,
+            "from": 338.2,
+            "to": 338.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.581,
+            "final": false,
+            "from": 339.01,
+            "to": 339.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.637,
+            "final": false,
+            "from": 339.56,
+            "to": 339.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.637,
+            "final": false,
+            "from": 339.76,
+            "to": 339.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.637,
+            "final": false,
+            "from": 339.86,
+            "to": 340.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.637,
+            "final": false,
+            "from": 340.16,
+            "to": 340.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 340.29,
+            "to": 340.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 340.94,
+            "to": 341.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 341.4,
+            "to": 341.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 341.56,
+            "to": 341.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 341.67,
+            "to": 342.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 342.03,
+            "to": 342.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 342.68,
+            "to": 342.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 342.79,
+            "to": 342.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 342.96,
+            "to": 343.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 343.05,
+            "to": 343.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 343.8,
+            "to": 343.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 343.93,
+            "to": 344.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 344.24,
+            "to": 344.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 344.37,
+            "to": 344.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 344.61,
+            "to": 344.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 344.76,
+            "to": 345.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 345.36,
+            "to": 345.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 345.51,
+            "to": 345.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.648,
+            "final": false,
+            "from": 345.73,
+            "to": 346.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 347.33,
+            "to": 347.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 347.51,
+            "to": 347.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 347.64,
+            "to": 347.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 347.75,
+            "to": 348.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 348.04,
+            "to": 348.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 349.2,
+            "to": 349.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 349.35,
+            "to": 349.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 349.97,
+            "to": 350.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 350.09,
+            "to": 350.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 350.37,
+            "to": 350.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 350.45,
+            "to": 350.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 350.52,
+            "to": 350.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 350.98,
+            "to": 351.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 351.08,
+            "to": 351.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 351.41,
+            "to": 351.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 351.98,
+            "to": 352.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 352.51,
+            "to": 352.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 352.6,
+            "to": 352.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 352.73,
+            "to": 353.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 353.1,
+            "to": 353.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 353.21,
+            "to": 353.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 353.31,
+            "to": 353.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.622,
+            "final": false,
+            "from": 353.59,
+            "to": 354.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 354.49,
+            "to": 354.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 354.66,
+            "to": 354.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 354.79,
+            "to": 354.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 354.89,
+            "to": 355.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 355.28,
+            "to": 355.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 355.46,
+            "to": 355.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 355.61,
+            "to": 356.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 356.03,
+            "to": 356.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.614,
+            "final": false,
+            "from": 356.14,
+            "to": 356.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 358.51,
+            "to": 358.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 358.68,
+            "to": 358.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 358.78,
+            "to": 359
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 359,
+            "to": 359.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 359.41,
+            "to": 359.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 359.48,
+            "to": 359.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 359.61,
+            "to": 359.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 359.93,
+            "to": 360.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 360.09,
+            "to": 360.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 360.67,
+            "to": 360.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 360.75,
+            "to": 361.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 361.33,
+            "to": 361.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 361.49,
+            "to": 361.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 361.92,
+            "to": 362.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 362.43,
+            "to": 362.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.642,
+            "final": false,
+            "from": 362.56,
+            "to": 363.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 364.15,
+            "to": 364.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 364.33,
+            "to": 364.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 364.61,
+            "to": 364.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 364.93,
+            "to": 365.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 365.13,
+            "to": 365.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 365.46,
+            "to": 365.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 365.72,
+            "to": 366.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 366.23,
+            "to": 366.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 366.37,
+            "to": 366.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 366.84,
+            "to": 367.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 367.27,
+            "to": 367.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 367.57,
+            "to": 367.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 367.78,
+            "to": 368.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 368.4,
+            "to": 368.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 368.92,
+            "to": 369.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 369.11,
+            "to": 369.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 369.62,
+            "to": 369.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 369.91,
+            "to": 370.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 370.02,
+            "to": 370.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 370.37,
+            "to": 370.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 370.47,
+            "to": 370.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 370.56,
+            "to": 370.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 370.95,
+            "to": 371.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.658,
+            "final": false,
+            "from": 371.16,
+            "to": 372.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 372.49,
+            "to": 372.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 372.78,
+            "to": 373.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 373.14,
+            "to": 373.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 373.49,
+            "to": 373.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 373.64,
+            "to": 374.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 374.2,
+            "to": 374.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 374.34,
+            "to": 374.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 374.73,
+            "to": 375
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 375,
+            "to": 375.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 375.12,
+            "to": 375.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 375.56,
+            "to": 375.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 375.76,
+            "to": 375.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.638,
+            "final": false,
+            "from": 375.87,
+            "to": 376.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.5,
+            "final": false,
+            "from": 377.41,
+            "to": 377.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.5,
+            "final": false,
+            "from": 377.55,
+            "to": 377.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.5,
+            "final": false,
+            "from": 377.68,
+            "to": 377.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.5,
+            "final": false,
+            "from": 377.88,
+            "to": 378.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.5,
+            "final": false,
+            "from": 378.05,
+            "to": 378.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.5,
+            "final": false,
+            "from": 378.16,
+            "to": 378.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 379.72,
+            "to": 380.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 380.03,
+            "to": 380.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 380.4,
+            "to": 380.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 380.7,
+            "to": 381.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 381.06,
+            "to": 381.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 381.39,
+            "to": 381.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 381.54,
+            "to": 381.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 381.75,
+            "to": 382.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 382.25,
+            "to": 382.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 382.38,
+            "to": 382.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 382.98,
+            "to": 383.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 383.08,
+            "to": 383.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 383.42,
+            "to": 383.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.528,
+            "final": false,
+            "from": 383.65,
+            "to": 384.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.61,
+            "final": false,
+            "from": 385.53,
+            "to": 385.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.61,
+            "final": false,
+            "from": 385.72,
+            "to": 385.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.61,
+            "final": false,
+            "from": 385.89,
+            "to": 385.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.61,
+            "final": false,
+            "from": 385.98,
+            "to": 386.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.61,
+            "final": false,
+            "from": 386.41,
+            "to": 386.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.61,
+            "final": false,
+            "from": 386.64,
+            "to": 386.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.61,
+            "final": false,
+            "from": 386.91,
+            "to": 387.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.626,
+            "final": false,
+            "from": 387.35,
+            "to": 387.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.626,
+            "final": false,
+            "from": 387.52,
+            "to": 387.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.636,
+            "final": false,
+            "from": 387.89,
+            "to": 388.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.636,
+            "final": false,
+            "from": 388.05,
+            "to": 388.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.636,
+            "final": false,
+            "from": 388.45,
+            "to": 388.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.636,
+            "final": false,
+            "from": 388.91,
+            "to": 389
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.636,
+            "final": false,
+            "from": 389,
+            "to": 389.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.636,
+            "final": false,
+            "from": 389.15,
+            "to": 389.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.636,
+            "final": false,
+            "from": 389.61,
+            "to": 390.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.334,
+            "final": false,
+            "from": 390.66,
+            "to": 390.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.334,
+            "final": false,
+            "from": 390.77,
+            "to": 391.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.334,
+            "final": false,
+            "from": 391.07,
+            "to": 391.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.334,
+            "final": false,
+            "from": 391.23,
+            "to": 391.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.267,
+            "final": false,
+            "from": 392.21,
+            "to": 392.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.267,
+            "final": false,
+            "from": 392.38,
+            "to": 392.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.267,
+            "final": false,
+            "from": 392.43,
+            "to": 393.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.591,
+            "final": false,
+            "from": 393.34,
+            "to": 393.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.591,
+            "final": false,
+            "from": 393.79,
+            "to": 394.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.591,
+            "final": false,
+            "from": 394.03,
+            "to": 394.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.591,
+            "final": false,
+            "from": 394.22,
+            "to": 394.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.591,
+            "final": false,
+            "from": 394.31,
+            "to": 394.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.591,
+            "final": false,
+            "from": 394.37,
+            "to": 395.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 395.6,
+            "to": 395.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 395.76,
+            "to": 396.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 396.16,
+            "to": 396.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 396.44,
+            "to": 396.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 396.68,
+            "to": 396.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.487,
+            "final": false,
+            "from": 396.84,
+            "to": 397.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 398.26,
+            "to": 398.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 398.36,
+            "to": 398.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 398.52,
+            "to": 399.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 399.04,
+            "to": 399.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 400.33,
+            "to": 400.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 400.44,
+            "to": 400.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 400.61,
+            "to": 401.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.086,
+            "final": false,
+            "from": 402.49,
+            "to": 402.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.086,
+            "final": false,
+            "from": 402.75,
+            "to": 403.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 405.01,
+            "to": 405.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 405.13,
+            "to": 405.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 405.44,
+            "to": 405.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 405.76,
+            "to": 405.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 405.86,
+            "to": 406.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 406.14,
+            "to": 406.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 406.47,
+            "to": 407.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 407.08,
+            "to": 407.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 407.44,
+            "to": 407.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 407.52,
+            "to": 407.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 407.86,
+            "to": 408.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.383,
+            "final": false,
+            "from": 410.53,
+            "to": 410.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.383,
+            "final": false,
+            "from": 410.68,
+            "to": 410.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.383,
+            "final": false,
+            "from": 410.81,
+            "to": 410.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.383,
+            "final": false,
+            "from": 410.92,
+            "to": 411
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.383,
+            "final": false,
+            "from": 411,
+            "to": 411.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.383,
+            "final": false,
+            "from": 411.35,
+            "to": 411.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.383,
+            "final": false,
+            "from": 411.66,
+            "to": 412.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.378,
+            "final": false,
+            "from": 412.39,
+            "to": 412.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.578,
+            "final": false,
+            "from": 412.7,
+            "to": 412.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.578,
+            "final": false,
+            "from": 412.79,
+            "to": 413
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.578,
+            "final": false,
+            "from": 413,
+            "to": 413.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.077,
+            "final": false,
+            "from": 413.24,
+            "to": 414.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.077,
+            "final": false,
+            "from": 414.02,
+            "to": 414.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.299,
+            "final": false,
+            "from": 414.92,
+            "to": 415.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.299,
+            "final": false,
+            "from": 415.28,
+            "to": 415.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.299,
+            "final": false,
+            "from": 415.55,
+            "to": 415.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.299,
+            "final": false,
+            "from": 415.85,
+            "to": 416.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.299,
+            "final": false,
+            "from": 416.11,
+            "to": 416.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 417.81,
+            "to": 417.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 417.93,
+            "to": 418.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 418.04,
+            "to": 418.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 418.22,
+            "to": 418.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 418.44,
+            "to": 418.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 418.58,
+            "to": 418.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 418.81,
+            "to": 418.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 418.9,
+            "to": 419.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 419.04,
+            "to": 419.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 419.4,
+            "to": 420.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.502,
+            "final": false,
+            "from": 420.74,
+            "to": 420.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.502,
+            "final": false,
+            "from": 420.98,
+            "to": 421.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.502,
+            "final": false,
+            "from": 421.13,
+            "to": 421.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.502,
+            "final": false,
+            "from": 421.54,
+            "to": 422.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.597,
+            "final": false,
+            "from": 422.23,
+            "to": 422.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.329,
+            "final": false,
+            "from": 422.5,
+            "to": 422.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.329,
+            "final": false,
+            "from": 422.9,
+            "to": 423.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 424.07,
+            "to": 424.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 424.13,
+            "to": 424.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 424.74,
+            "to": 424.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 424.88,
+            "to": 425
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 425,
+            "to": 425.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 425.47,
+            "to": 425.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 425.79,
+            "to": 426.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 426.03,
+            "to": 426.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 427.14,
+            "to": 427.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 427.3,
+            "to": 427.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 427.42,
+            "to": 427.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 427.75,
+            "to": 427.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 427.93,
+            "to": 428.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 428.35,
+            "to": 428.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 428.63,
+            "to": 428.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 428.91,
+            "to": 429.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 429.02,
+            "to": 429.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 429.93,
+            "to": 430.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 430.3,
+            "to": 430.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.132,
+            "final": false,
+            "from": 430.64,
+            "to": 430.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.132,
+            "final": false,
+            "from": 430.85,
+            "to": 431.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 431.68,
+            "to": 431.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 431.82,
+            "to": 432.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 432.05,
+            "to": 432.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.47,
+            "final": false,
+            "from": 432.2,
+            "to": 432.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.552,
+            "final": false,
+            "from": 432.31,
+            "to": 432.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.437,
+            "final": false,
+            "from": 432.91,
+            "to": 433.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.437,
+            "final": false,
+            "from": 433.02,
+            "to": 433.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.437,
+            "final": false,
+            "from": 433.09,
+            "to": 433.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 435.5,
+            "to": 436.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 436.11,
+            "to": 436.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 436.18,
+            "to": 436.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 436.34,
+            "to": 436.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 436.74,
+            "to": 437.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 437.18,
+            "to": 437.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 437.26,
+            "to": 437.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 437.56,
+            "to": 437.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 437.72,
+            "to": 438
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 438,
+            "to": 438.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 438.24,
+            "to": 438.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 438.36,
+            "to": 438.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.639,
+            "final": false,
+            "from": 438.91,
+            "to": 439.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 439.86,
+            "to": 440.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 440.12,
+            "to": 440.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 440.27,
+            "to": 440.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 440.84,
+            "to": 441.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 441.2,
+            "to": 441.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 441.42,
+            "to": 441.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 441.56,
+            "to": 441.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 441.98,
+            "to": 442.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 442.32,
+            "to": 442.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 442.42,
+            "to": 442.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.645,
+            "final": false,
+            "from": 442.77,
+            "to": 443.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.628,
+            "final": false,
+            "from": 444.08,
+            "to": 444.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.628,
+            "final": false,
+            "from": 444.23,
+            "to": 444.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.628,
+            "final": false,
+            "from": 444.75,
+            "to": 444.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.628,
+            "final": false,
+            "from": 444.96,
+            "to": 445.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.628,
+            "final": false,
+            "from": 445.06,
+            "to": 445.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.628,
+            "final": false,
+            "from": 445.47,
+            "to": 445.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.628,
+            "final": false,
+            "from": 445.61,
+            "to": 445.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.628,
+            "final": false,
+            "from": 445.71,
+            "to": 446.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 446.68,
+            "to": 446.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 446.98,
+            "to": 447.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 447.19,
+            "to": 447.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 447.53,
+            "to": 447.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 447.85,
+            "to": 448.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 448.18,
+            "to": 449.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.534,
+            "final": false,
+            "from": 449.76,
+            "to": 449.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.534,
+            "final": false,
+            "from": 449.87,
+            "to": 449.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.534,
+            "final": false,
+            "from": 449.97,
+            "to": 450.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.534,
+            "final": false,
+            "from": 450.28,
+            "to": 450.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.534,
+            "final": false,
+            "from": 450.4,
+            "to": 450.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.534,
+            "final": false,
+            "from": 450.53,
+            "to": 451.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.534,
+            "final": false,
+            "from": 451.01,
+            "to": 451.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.525,
+            "final": false,
+            "from": 451.42,
+            "to": 451.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.525,
+            "final": false,
+            "from": 451.63,
+            "to": 452.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.367,
+            "final": false,
+            "from": 452.33,
+            "to": 452.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.367,
+            "final": false,
+            "from": 452.51,
+            "to": 452.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.367,
+            "final": false,
+            "from": 452.8,
+            "to": 453.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.615,
+            "final": false,
+            "from": 455.28,
+            "to": 455.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.615,
+            "final": false,
+            "from": 455.63,
+            "to": 455.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.615,
+            "final": false,
+            "from": 455.74,
+            "to": 456.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.423,
+            "final": false,
+            "from": 456.32,
+            "to": 456.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.423,
+            "final": false,
+            "from": 456.62,
+            "to": 457.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.595,
+            "final": false,
+            "from": 457.8,
+            "to": 458.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.595,
+            "final": false,
+            "from": 458.16,
+            "to": 458.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.417,
+            "final": false,
+            "from": 458.92,
+            "to": 459.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 459.72,
+            "to": 460.17
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 460.17,
+            "to": 460.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 460.77,
+            "to": 460.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 460.9,
+            "to": 461.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 462.55,
+            "to": 462.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 462.7,
+            "to": 462.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 462.86,
+            "to": 463.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 463.11,
+            "to": 463.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 463.25,
+            "to": 463.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 463.51,
+            "to": 463.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 463.93,
+            "to": 464.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 464.06,
+            "to": 464.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 464.15,
+            "to": 464.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 464.78,
+            "to": 465.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 465.03,
+            "to": 465.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 465.19,
+            "to": 465.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 465.62,
+            "to": 465.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 465.82,
+            "to": 466.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.545,
+            "final": false,
+            "from": 468.73,
+            "to": 468.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.545,
+            "final": false,
+            "from": 468.82,
+            "to": 469.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.545,
+            "final": false,
+            "from": 469.05,
+            "to": 469.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.545,
+            "final": false,
+            "from": 469.31,
+            "to": 470.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 470.13,
+            "to": 470.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 470.34,
+            "to": 470.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 470.7,
+            "to": 471.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 471.07,
+            "to": 471.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 471.69,
+            "to": 471.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 471.77,
+            "to": 472.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 472.06,
+            "to": 472.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 472.19,
+            "to": 472.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 472.37,
+            "to": 472.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 472.66,
+            "to": 473.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.507,
+            "final": false,
+            "from": 473.07,
+            "to": 473.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 474.43,
+            "to": 474.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 474.47,
+            "to": 474.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 474.64,
+            "to": 474.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 474.69,
+            "to": 475.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 475.14,
+            "to": 475.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 475.28,
+            "to": 475.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 475.37,
+            "to": 475.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 475.68,
+            "to": 476.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.541,
+            "final": false,
+            "from": 476.01,
+            "to": 476.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.409,
+            "final": false,
+            "from": 476.88,
+            "to": 477.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 477.54,
+            "to": 477.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 477.68,
+            "to": 477.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 477.86,
+            "to": 478.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 478.24,
+            "to": 478.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 478.35,
+            "to": 478.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 478.63,
+            "to": 478.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 478.89,
+            "to": 479.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 479.31,
+            "to": 479.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 479.75,
+            "to": 479.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 479.9,
+            "to": 479.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 479.99,
+            "to": 480.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 480.19,
+            "to": 480.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 480.31,
+            "to": 480.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 480.4,
+            "to": 480.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 480.74,
+            "to": 481.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 481.07,
+            "to": 481.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 481.16,
+            "to": 481.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.578,
+            "final": false,
+            "from": 482.28,
+            "to": 482.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.578,
+            "final": false,
+            "from": 482.39,
+            "to": 482.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.578,
+            "final": false,
+            "from": 482.47,
+            "to": 482.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.578,
+            "final": false,
+            "from": 482.68,
+            "to": 482.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.578,
+            "final": false,
+            "from": 482.81,
+            "to": 483.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.578,
+            "final": false,
+            "from": 483.18,
+            "to": 483.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.416,
+            "final": false,
+            "from": 483.98,
+            "to": 484.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.416,
+            "final": false,
+            "from": 484.15,
+            "to": 484.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.416,
+            "final": false,
+            "from": 484.42,
+            "to": 484.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.416,
+            "final": false,
+            "from": 484.59,
+            "to": 485.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.518,
+            "final": false,
+            "from": 485.13,
+            "to": 485.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.518,
+            "final": false,
+            "from": 485.27,
+            "to": 485.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.518,
+            "final": false,
+            "from": 485.78,
+            "to": 485.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.518,
+            "final": false,
+            "from": 485.91,
+            "to": 486.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.518,
+            "final": false,
+            "from": 486.26,
+            "to": 486.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.393,
+            "final": false,
+            "from": 486.82,
+            "to": 487.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.393,
+            "final": false,
+            "from": 487.15,
+            "to": 487.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.393,
+            "final": false,
+            "from": 487.26,
+            "to": 487.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.449,
+            "final": false,
+            "from": 488.69,
+            "to": 488.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.449,
+            "final": false,
+            "from": 488.89,
+            "to": 489.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.449,
+            "final": false,
+            "from": 489.05,
+            "to": 489.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.449,
+            "final": false,
+            "from": 489.16,
+            "to": 489.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.409,
+            "final": false,
+            "from": 489.72,
+            "to": 489.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.409,
+            "final": false,
+            "from": 489.81,
+            "to": 490.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.409,
+            "final": false,
+            "from": 490.19,
+            "to": 490.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.409,
+            "final": false,
+            "from": 490.32,
+            "to": 490.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 490.93,
+            "to": 491.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 491.04,
+            "to": 491.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 491.14,
+            "to": 491.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 491.38,
+            "to": 491.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 491.49,
+            "to": 491.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 491.59,
+            "to": 492.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 492.01,
+            "to": 492.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 492.12,
+            "to": 492.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 492.41,
+            "to": 492.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.53,
+            "final": false,
+            "from": 492.51,
+            "to": 493.17
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.057,
+            "final": false,
+            "from": 496.84,
+            "to": 497.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 497.17,
+            "to": 497.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 497.4,
+            "to": 497.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 497.64,
+            "to": 497.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 497.78,
+            "to": 497.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 497.91,
+            "to": 498.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 498.02,
+            "to": 498.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 498.09,
+            "to": 498.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 498.28,
+            "to": 498.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 498.44,
+            "to": 498.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 498.97,
+            "to": 499.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 499.12,
+            "to": 499.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 499.22,
+            "to": 499.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 499.9,
+            "to": 500
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 500,
+            "to": 500.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 500.11,
+            "to": 500.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 500.29,
+            "to": 500.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 500.57,
+            "to": 500.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 500.89,
+            "to": 501
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 501,
+            "to": 501.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 501.09,
+            "to": 501.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 501.84,
+            "to": 502.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 502.44,
+            "to": 502.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 502.7,
+            "to": 502.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 502.83,
+            "to": 502.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 502.99,
+            "to": 503.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 503.07,
+            "to": 503.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 503.54,
+            "to": 503.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 503.76,
+            "to": 503.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 503.96,
+            "to": 504.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 504.33,
+            "to": 504.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.616,
+            "final": false,
+            "from": 504.76,
+            "to": 505.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.294,
+            "final": false,
+            "from": 505.36,
+            "to": 505.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.294,
+            "final": false,
+            "from": 505.54,
+            "to": 505.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.294,
+            "final": false,
+            "from": 505.64,
+            "to": 505.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.294,
+            "final": false,
+            "from": 505.72,
+            "to": 506.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.294,
+            "final": false,
+            "from": 506.2,
+            "to": 506.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.294,
+            "final": false,
+            "from": 506.26,
+            "to": 506.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.425,
+            "final": false,
+            "from": 507.35,
+            "to": 507.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.443,
+            "final": false,
+            "from": 507.79,
+            "to": 507.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.443,
+            "final": false,
+            "from": 507.98,
+            "to": 508.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.443,
+            "final": false,
+            "from": 508.13,
+            "to": 508.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.443,
+            "final": false,
+            "from": 508.32,
+            "to": 508.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.443,
+            "final": false,
+            "from": 508.4,
+            "to": 508.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.443,
+            "final": false,
+            "from": 508.71,
+            "to": 509.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 510.06,
+            "to": 510.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 510.33,
+            "to": 510.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 510.49,
+            "to": 510.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 510.8,
+            "to": 511.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 511.13,
+            "to": 511.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.583,
+            "final": false,
+            "from": 511.59,
+            "to": 512.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.592,
+            "final": false,
+            "from": 512.11,
+            "to": 512.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.592,
+            "final": false,
+            "from": 512.3,
+            "to": 512.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.592,
+            "final": false,
+            "from": 512.44,
+            "to": 513.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 513.04,
+            "to": 513.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 513.6,
+            "to": 514.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 514.01,
+            "to": 514.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.172,
+            "final": false,
+            "from": 516.82,
+            "to": 516.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.172,
+            "final": false,
+            "from": 516.99,
+            "to": 517.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.172,
+            "final": false,
+            "from": 517.18,
+            "to": 517.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.172,
+            "final": false,
+            "from": 517.33,
+            "to": 517.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.172,
+            "final": false,
+            "from": 517.58,
+            "to": 517.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.172,
+            "final": false,
+            "from": 517.82,
+            "to": 517.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.172,
+            "final": false,
+            "from": 517.93,
+            "to": 518.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.172,
+            "final": false,
+            "from": 518.22,
+            "to": 518.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.172,
+            "final": false,
+            "from": 518.33,
+            "to": 518.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.401,
+            "final": false,
+            "from": 518.64,
+            "to": 518.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.401,
+            "final": false,
+            "from": 518.82,
+            "to": 519.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.401,
+            "final": false,
+            "from": 519.24,
+            "to": 519.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.401,
+            "final": false,
+            "from": 519.33,
+            "to": 519.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 519.99,
+            "to": 520.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 520.22,
+            "to": 520.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 520.34,
+            "to": 520.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.408,
+            "final": false,
+            "from": 520.4,
+            "to": 520.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 520.91,
+            "to": 521.17
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 521.17,
+            "to": 521.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 521.27,
+            "to": 521.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.421,
+            "final": false,
+            "from": 521.37,
+            "to": 521.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.44,
+            "final": false,
+            "from": 521.94,
+            "to": 522.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.44,
+            "final": false,
+            "from": 522.22,
+            "to": 522.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.44,
+            "final": false,
+            "from": 522.49,
+            "to": 522.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.44,
+            "final": false,
+            "from": 522.69,
+            "to": 522.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.44,
+            "final": false,
+            "from": 522.76,
+            "to": 523.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.44,
+            "final": false,
+            "from": 523.23,
+            "to": 523.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.44,
+            "final": false,
+            "from": 523.35,
+            "to": 523.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.44,
+            "final": false,
+            "from": 523.55,
+            "to": 523.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.44,
+            "final": false,
+            "from": 523.68,
+            "to": 524.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.561,
+            "final": false,
+            "from": 525.56,
+            "to": 525.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.561,
+            "final": false,
+            "from": 525.78,
+            "to": 525.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.561,
+            "final": false,
+            "from": 525.96,
+            "to": 526.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.561,
+            "final": false,
+            "from": 526.2,
+            "to": 526.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.561,
+            "final": false,
+            "from": 526.48,
+            "to": 526.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.486,
+            "final": false,
+            "from": 526.78,
+            "to": 527.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.486,
+            "final": false,
+            "from": 527.06,
+            "to": 527.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.486,
+            "final": false,
+            "from": 527.28,
+            "to": 527.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.486,
+            "final": false,
+            "from": 527.61,
+            "to": 527.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.486,
+            "final": false,
+            "from": 527.71,
+            "to": 528.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 529.18,
+            "to": 529.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 529.37,
+            "to": 529.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 529.44,
+            "to": 529.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 529.7,
+            "to": 530.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 530.06,
+            "to": 530.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 530.56,
+            "to": 530.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 530.66,
+            "to": 530.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 530.76,
+            "to": 531
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 531,
+            "to": 531.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 531.08,
+            "to": 531.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 531.47,
+            "to": 531.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 531.73,
+            "to": 531.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 531.82,
+            "to": 531.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 531.93,
+            "to": 532.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.524,
+            "final": false,
+            "from": 532.4,
+            "to": 533.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 533.68,
+            "to": 534.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.582,
+            "final": false,
+            "from": 534.09,
+            "to": 534.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.582,
+            "final": false,
+            "from": 534.33,
+            "to": 534.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.582,
+            "final": false,
+            "from": 534.5,
+            "to": 534.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.582,
+            "final": false,
+            "from": 534.65,
+            "to": 535.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.582,
+            "final": false,
+            "from": 535.11,
+            "to": 535.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.314,
+            "final": false,
+            "from": 536,
+            "to": 536.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 536.68,
+            "to": 537.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 537.4,
+            "to": 537.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 537.8,
+            "to": 537.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 537.87,
+            "to": 538.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 538.54,
+            "to": 538.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 538.79,
+            "to": 538.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 538.89,
+            "to": 539.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.439,
+            "final": false,
+            "from": 540.02,
+            "to": 540.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.439,
+            "final": false,
+            "from": 540.26,
+            "to": 540.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.439,
+            "final": false,
+            "from": 540.45,
+            "to": 540.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.439,
+            "final": false,
+            "from": 540.96,
+            "to": 541.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 543.2,
+            "to": 543.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.515,
+            "final": false,
+            "from": 543.63,
+            "to": 543.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.515,
+            "final": false,
+            "from": 543.83,
+            "to": 544.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.515,
+            "final": false,
+            "from": 544.03,
+            "to": 544.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.515,
+            "final": false,
+            "from": 544.12,
+            "to": 544.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 544.55,
+            "to": 545.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 545.36,
+            "to": 546.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 546.9,
+            "to": 547.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 547.08,
+            "to": 547.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 547.25,
+            "to": 547.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 547.53,
+            "to": 547.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 547.58,
+            "to": 548.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 548.25,
+            "to": 548.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 548.7,
+            "to": 549.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 549.33,
+            "to": 549.56
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 549.56,
+            "to": 549.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 549.7,
+            "to": 549.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 549.92,
+            "to": 550.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 550.13,
+            "to": 550.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 550.21,
+            "to": 550.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 550.41,
+            "to": 550.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 550.7,
+            "to": 551.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 551.16,
+            "to": 551.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 551.33,
+            "to": 551.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 551.4,
+            "to": 551.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 551.68,
+            "to": 551.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 551.78,
+            "to": 551.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 551.88,
+            "to": 551.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 551.98,
+            "to": 552.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 552.25,
+            "to": 552.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 552.42,
+            "to": 552.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 552.82,
+            "to": 553.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 553.06,
+            "to": 553.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 553.25,
+            "to": 553.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.629,
+            "final": false,
+            "from": 553.62,
+            "to": 554.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.463,
+            "final": false,
+            "from": 554.41,
+            "to": 554.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.463,
+            "final": false,
+            "from": 554.82,
+            "to": 554.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.463,
+            "final": false,
+            "from": 554.95,
+            "to": 555.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.463,
+            "final": false,
+            "from": 555.1,
+            "to": 555.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.463,
+            "final": false,
+            "from": 555.32,
+            "to": 555.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.463,
+            "final": false,
+            "from": 555.5,
+            "to": 555.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.463,
+            "final": false,
+            "from": 555.7,
+            "to": 555.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.463,
+            "final": false,
+            "from": 555.8,
+            "to": 556.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 556.64,
+            "to": 556.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 556.88,
+            "to": 557.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 557.21,
+            "to": 557.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 557.42,
+            "to": 557.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 557.83,
+            "to": 558.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 558.19,
+            "to": 558.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 558.31,
+            "to": 558.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 558.61,
+            "to": 559.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 559.1,
+            "to": 559.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 559.21,
+            "to": 559.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 559.27,
+            "to": 559.49
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 559.49,
+            "to": 559.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 559.74,
+            "to": 559.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 559.91,
+            "to": 560.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 560.08,
+            "to": 560.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.573,
+            "final": false,
+            "from": 560.29,
+            "to": 561.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 561.31,
+            "to": 561.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 561.47,
+            "to": 561.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 561.7,
+            "to": 561.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 561.79,
+            "to": 562.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 562.08,
+            "to": 562.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 562.34,
+            "to": 562.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 562.74,
+            "to": 562.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.644,
+            "final": false,
+            "from": 562.83,
+            "to": 563.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 563.72,
+            "to": 563.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 563.85,
+            "to": 564.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 564.22,
+            "to": 564.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 564.44,
+            "to": 564.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 564.64,
+            "to": 564.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 564.77,
+            "to": 565.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 565.04,
+            "to": 565.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.501,
+            "final": false,
+            "from": 565.23,
+            "to": 566.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.194,
+            "final": false,
+            "from": 566.57,
+            "to": 566.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.3,
+            "final": false,
+            "from": 567.21,
+            "to": 567.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.3,
+            "final": false,
+            "from": 567.4,
+            "to": 567.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.3,
+            "final": false,
+            "from": 567.52,
+            "to": 568.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.328,
+            "final": false,
+            "from": 568.15,
+            "to": 568.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.328,
+            "final": false,
+            "from": 568.53,
+            "to": 568.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 568.8,
+            "to": 569.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 569.15,
+            "to": 569.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 569.65,
+            "to": 570.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 570.08,
+            "to": 570.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 570.25,
+            "to": 570.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 570.78,
+            "to": 570.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 570.99,
+            "to": 571.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 571.07,
+            "to": 571.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 571.26,
+            "to": 571.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 571.35,
+            "to": 571.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.599,
+            "final": false,
+            "from": 571.68,
+            "to": 572.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 573.58,
+            "to": 573.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 573.66,
+            "to": 573.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 573.92,
+            "to": 574.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 574.1,
+            "to": 574.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 574.16,
+            "to": 574.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 574.39,
+            "to": 574.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.649,
+            "final": false,
+            "from": 574.89,
+            "to": 575.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 575.51,
+            "to": 575.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 575.71,
+            "to": 575.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 575.97,
+            "to": 576.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 576.04,
+            "to": 576.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 576.13,
+            "to": 576.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 576.48,
+            "to": 576.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 576.75,
+            "to": 576.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 576.86,
+            "to": 577.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 577.48,
+            "to": 577.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 577.99,
+            "to": 578.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 578.21,
+            "to": 578.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 578.58,
+            "to": 578.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 578.73,
+            "to": 579.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 579.19,
+            "to": 579.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 579.3,
+            "to": 579.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 579.4,
+            "to": 579.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 579.6,
+            "to": 579.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 579.82,
+            "to": 579.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 579.93,
+            "to": 580.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 580.52,
+            "to": 580.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 580.85,
+            "to": 581.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 581.27,
+            "to": 581.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 581.78,
+            "to": 581.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.65,
+            "final": false,
+            "from": 581.9,
+            "to": 582.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.42,
+            "final": false,
+            "from": 582.89,
+            "to": 583.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.42,
+            "final": false,
+            "from": 583.04,
+            "to": 583.15
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.42,
+            "final": false,
+            "from": 583.15,
+            "to": 583.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.42,
+            "final": false,
+            "from": 583.83,
+            "to": 584.18
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.42,
+            "final": false,
+            "from": 584.18,
+            "to": 584.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.284,
+            "final": false,
+            "from": 585.7,
+            "to": 585.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.284,
+            "final": false,
+            "from": 585.84,
+            "to": 586.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.284,
+            "final": false,
+            "from": 586.08,
+            "to": 586.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 586.86,
+            "to": 587
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 587,
+            "to": 587.09
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 587.09,
+            "to": 587.5
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 587.5,
+            "to": 587.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 587.95,
+            "to": 588.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 588.07,
+            "to": 588.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 588.37,
+            "to": 588.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 588.68,
+            "to": 589.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 589.36,
+            "to": 589.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.606,
+            "final": false,
+            "from": 589.53,
+            "to": 589.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 590.45,
+            "to": 590.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 590.57,
+            "to": 590.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 590.73,
+            "to": 591.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 591.4,
+            "to": 591.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.514,
+            "final": false,
+            "from": 591.58,
+            "to": 592.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 593.19,
+            "to": 593.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 593.4,
+            "to": 593.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.575,
+            "final": false,
+            "from": 593.77,
+            "to": 594.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.561,
+            "final": false,
+            "from": 594.35,
+            "to": 594.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.561,
+            "final": false,
+            "from": 594.98,
+            "to": 595.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.561,
+            "final": false,
+            "from": 595.37,
+            "to": 595.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 597.46,
+            "to": 597.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 597.67,
+            "to": 597.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 597.85,
+            "to": 598.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 598.25,
+            "to": 598.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 598.46,
+            "to": 598.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.619,
+            "final": false,
+            "from": 598.65,
+            "to": 599.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.28,
+            "final": false,
+            "from": 599.77,
+            "to": 600.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.28,
+            "final": false,
+            "from": 600.12,
+            "to": 600.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.28,
+            "final": false,
+            "from": 600.23,
+            "to": 600.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.28,
+            "final": false,
+            "from": 600.69,
+            "to": 600.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.28,
+            "final": false,
+            "from": 600.83,
+            "to": 601.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.28,
+            "final": false,
+            "from": 601.22,
+            "to": 601.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.28,
+            "final": false,
+            "from": 601.29,
+            "to": 601.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.28,
+            "final": false,
+            "from": 601.69,
+            "to": 602.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.132,
+            "final": false,
+            "from": 603.19,
+            "to": 603.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.256,
+            "final": false,
+            "from": 603.54,
+            "to": 603.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.256,
+            "final": false,
+            "from": 603.96,
+            "to": 604.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.256,
+            "final": false,
+            "from": 604.05,
+            "to": 604.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.256,
+            "final": false,
+            "from": 604.14,
+            "to": 604.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.256,
+            "final": false,
+            "from": 604.64,
+            "to": 604.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.256,
+            "final": false,
+            "from": 604.77,
+            "to": 605.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 606.13,
+            "to": 606.28
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 606.28,
+            "to": 606.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 606.8,
+            "to": 606.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 606.92,
+            "to": 607.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 607.24,
+            "to": 607.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 607.36,
+            "to": 607.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 607.45,
+            "to": 607.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 607.63,
+            "to": 607.96
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 607.96,
+            "to": 608.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 608.06,
+            "to": 608.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 608.25,
+            "to": 608.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 608.33,
+            "to": 608.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.488,
+            "final": false,
+            "from": 608.54,
+            "to": 609
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 610.48,
+            "to": 610.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 610.65,
+            "to": 610.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 610.95,
+            "to": 611.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 611.14,
+            "to": 611.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 611.47,
+            "to": 611.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.543,
+            "final": false,
+            "from": 611.72,
+            "to": 612.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 613.53,
+            "to": 613.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 613.74,
+            "to": 613.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.631,
+            "final": false,
+            "from": 613.93,
+            "to": 614.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.049,
+            "final": false,
+            "from": 614.4,
+            "to": 615.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 615.05,
+            "to": 615.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 615.38,
+            "to": 615.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 615.67,
+            "to": 616.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 616.12,
+            "to": 616.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 616.27,
+            "to": 616.37
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 616.37,
+            "to": 616.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 616.47,
+            "to": 616.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 616.52,
+            "to": 617.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 617.13,
+            "to": 617.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 617.26,
+            "to": 617.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 617.6,
+            "to": 617.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 617.82,
+            "to": 617.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 617.93,
+            "to": 618.1
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 618.1,
+            "to": 618.81
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 618.81,
+            "to": 619.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 619.73,
+            "to": 619.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 619.9,
+            "to": 620.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 620.04,
+            "to": 620.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 620.7,
+            "to": 621.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 621.05,
+            "to": 621.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 621.72,
+            "to": 622.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.641,
+            "final": false,
+            "from": 622.44,
+            "to": 622.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.641,
+            "final": false,
+            "from": 622.67,
+            "to": 623.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.641,
+            "final": false,
+            "from": 623.12,
+            "to": 623.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.641,
+            "final": false,
+            "from": 623.22,
+            "to": 623.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.641,
+            "final": false,
+            "from": 623.29,
+            "to": 623.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.646,
+            "final": false,
+            "from": 625.62,
+            "to": 625.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.646,
+            "final": false,
+            "from": 625.84,
+            "to": 625.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.646,
+            "final": false,
+            "from": 625.95,
+            "to": 626.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.646,
+            "final": false,
+            "from": 626.27,
+            "to": 626.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.646,
+            "final": false,
+            "from": 626.88,
+            "to": 627.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.646,
+            "final": false,
+            "from": 627.4,
+            "to": 628.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.651,
+            "final": false,
+            "from": 628.1,
+            "to": 628.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.651,
+            "final": false,
+            "from": 628.82,
+            "to": 629.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.651,
+            "final": false,
+            "from": 629.2,
+            "to": 629.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.651,
+            "final": false,
+            "from": 629.35,
+            "to": 629.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.651,
+            "final": false,
+            "from": 629.43,
+            "to": 629.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.651,
+            "final": false,
+            "from": 629.94,
+            "to": 630.07
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.651,
+            "final": false,
+            "from": 630.07,
+            "to": 630.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.651,
+            "final": false,
+            "from": 630.39,
+            "to": 630.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.063,
+            "final": false,
+            "from": 631.37,
+            "to": 631.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.063,
+            "final": false,
+            "from": 631.55,
+            "to": 631.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.325,
+            "final": false,
+            "from": 632.54,
+            "to": 633
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.325,
+            "final": false,
+            "from": 633,
+            "to": 633.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.325,
+            "final": false,
+            "from": 633.48,
+            "to": 633.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.325,
+            "final": false,
+            "from": 633.62,
+            "to": 633.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.325,
+            "final": false,
+            "from": 633.95,
+            "to": 634.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.455,
+            "final": false,
+            "from": 635.37,
+            "to": 635.46
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.455,
+            "final": false,
+            "from": 635.46,
+            "to": 635.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.455,
+            "final": false,
+            "from": 635.59,
+            "to": 635.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.621,
+            "final": false,
+            "from": 635.92,
+            "to": 636.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.621,
+            "final": false,
+            "from": 636.38,
+            "to": 636.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.621,
+            "final": false,
+            "from": 636.51,
+            "to": 637
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.621,
+            "final": false,
+            "from": 637,
+            "to": 637.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.249,
+            "final": false,
+            "from": 639.48,
+            "to": 639.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.249,
+            "final": false,
+            "from": 639.64,
+            "to": 639.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.249,
+            "final": false,
+            "from": 639.84,
+            "to": 640.14
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 642.59,
+            "to": 642.73
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 642.73,
+            "to": 642.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 642.86,
+            "to": 643.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 643.26,
+            "to": 643.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 643.47,
+            "to": 644.08
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 644.08,
+            "to": 644.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 644.32,
+            "to": 644.41
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 644.41,
+            "to": 644.89
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 644.89,
+            "to": 644.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 644.99,
+            "to": 645.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 645.44,
+            "to": 645.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.652,
+            "final": false,
+            "from": 645.71,
+            "to": 646.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 646.56,
+            "to": 646.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 646.88,
+            "to": 646.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 646.98,
+            "to": 647.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 647.42,
+            "to": 647.52
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 647.52,
+            "to": 647.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 647.92,
+            "to": 648.3
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.557,
+            "final": false,
+            "from": 648.3,
+            "to": 648.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 649.34,
+            "to": 649.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 649.48,
+            "to": 649.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 649.66,
+            "to": 649.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 649.76,
+            "to": 650.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 650.22,
+            "to": 650.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 650.35,
+            "to": 650.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 650.83,
+            "to": 651.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 651.4,
+            "to": 651.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 651.78,
+            "to": 651.92
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.64,
+            "final": false,
+            "from": 651.92,
+            "to": 652.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 652.3,
+            "to": 652.63
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 652.63,
+            "to": 652.74
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 652.74,
+            "to": 653.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 653.03,
+            "to": 653.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 653.19,
+            "to": 653.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 653.34,
+            "to": 653.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.352,
+            "final": false,
+            "from": 653.59,
+            "to": 654.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.443,
+            "final": false,
+            "from": 654.24,
+            "to": 654.67
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.443,
+            "final": false,
+            "from": 654.67,
+            "to": 654.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.443,
+            "final": false,
+            "from": 654.77,
+            "to": 654.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.35,
+            "final": false,
+            "from": 654.97,
+            "to": 655.31
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.35,
+            "final": false,
+            "from": 655.31,
+            "to": 655.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.35,
+            "final": false,
+            "from": 655.71,
+            "to": 656.25
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 657.2,
+            "to": 657.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 657.51,
+            "to": 657.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 657.86,
+            "to": 657.99
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 657.99,
+            "to": 658.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 658.4,
+            "to": 658.71
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.602,
+            "final": false,
+            "from": 658.71,
+            "to": 659.38
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.425,
+            "final": false,
+            "from": 660.1,
+            "to": 660.27
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.425,
+            "final": false,
+            "from": 660.27,
+            "to": 660.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.425,
+            "final": false,
+            "from": 660.85,
+            "to": 661.19
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.425,
+            "final": false,
+            "from": 661.19,
+            "to": 661.35
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.425,
+            "final": false,
+            "from": 661.35,
+            "to": 661.64
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.425,
+            "final": false,
+            "from": 661.64,
+            "to": 662.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.152,
+            "final": false,
+            "from": 662.38,
+            "to": 662.6
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.152,
+            "final": false,
+            "from": 662.6,
+            "to": 663.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 664.89,
+            "to": 665.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 665.06,
+            "to": 665.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 665.57,
+            "to": 665.68
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 665.68,
+            "to": 665.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 665.91,
+            "to": 666.04
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 666.04,
+            "to": 666.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 666.2,
+            "to": 666.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 666.29,
+            "to": 666.84
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 666.84,
+            "to": 666.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.661,
+            "final": false,
+            "from": 666.97,
+            "to": 667.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 668.88,
+            "to": 669.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 669.32,
+            "to": 669.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 669.57,
+            "to": 669.7
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 669.7,
+            "to": 669.93
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 669.93,
+            "to": 670.03
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 670.03,
+            "to": 670.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 670.24,
+            "to": 670.36
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 670.36,
+            "to": 670.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 670.57,
+            "to": 670.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 670.72,
+            "to": 670.79
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 670.79,
+            "to": 670.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 670.98,
+            "to": 671.57
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 671.57,
+            "to": 671.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.634,
+            "final": false,
+            "from": 671.66,
+            "to": 672.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 674.22,
+            "to": 674.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 674.48,
+            "to": 674.54
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 674.54,
+            "to": 674.66
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 674.66,
+            "to": 674.76
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 674.76,
+            "to": 675.05
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 675.05,
+            "to": 675.16
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 675.16,
+            "to": 675.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 675.23,
+            "to": 675.53
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 675.53,
+            "to": 675.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 675.69,
+            "to": 676.29
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.186,
+            "final": false,
+            "from": 676.44,
+            "to": 676.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.186,
+            "final": false,
+            "from": 676.62,
+            "to": 676.86
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.186,
+            "final": false,
+            "from": 676.86,
+            "to": 676.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.186,
+            "final": false,
+            "from": 676.97,
+            "to": 677.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.186,
+            "final": false,
+            "from": 677.2,
+            "to": 677.72
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.186,
+            "final": false,
+            "from": 677.72,
+            "to": 677.8
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.186,
+            "final": false,
+            "from": 677.8,
+            "to": 678.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 678.96,
+            "to": 679.06
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 679.06,
+            "to": 679.2
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 679.2,
+            "to": 679.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 679.45,
+            "to": 679.75
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.627,
+            "final": false,
+            "from": 679.75,
+            "to": 680.69
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 681.38,
+            "to": 681.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.539,
+            "final": false,
+            "from": 681.58,
+            "to": 682.26
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.632,
+            "final": false,
+            "from": 682.29,
+            "to": 682.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.632,
+            "final": false,
+            "from": 682.44,
+            "to": 682.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.632,
+            "final": false,
+            "from": 682.65,
+            "to": 682.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.632,
+            "final": false,
+            "from": 682.78,
+            "to": 683.12
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.632,
+            "final": false,
+            "from": 683.12,
+            "to": 683.23
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.632,
+            "final": false,
+            "from": 683.23,
+            "to": 683.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 685.48,
+            "to": 685.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 685.82,
+            "to": 685.97
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 685.97,
+            "to": 686.02
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 686.02,
+            "to": 686.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 686.47,
+            "to": 686.59
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 686.59,
+            "to": 686.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 686.98,
+            "to": 687.11
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 687.11,
+            "to": 687.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 687.21,
+            "to": 687.47
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 687.47,
+            "to": 687.58
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.623,
+            "final": false,
+            "from": 687.58,
+            "to": 687.78
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 689.23,
+            "to": 689.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 689.4,
+            "to": 689.48
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 689.48,
+            "to": 689.95
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 689.95,
+            "to": 690.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 690.33,
+            "to": 690.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 690.44,
+            "to": 690.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 690.77,
+            "to": 690.85
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 690.85,
+            "to": 691.21
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 691.21,
+            "to": 691.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 691.34,
+            "to": 691.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.521,
+            "final": false,
+            "from": 691.43,
+            "to": 692.22
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 693.26,
+            "to": 693.42
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 693.42,
+            "to": 693.55
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 693.55,
+            "to": 693.61
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 693.61,
+            "to": 693.82
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 693.82,
+            "to": 693.94
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 693.94,
+            "to": 694.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 694.32,
+            "to": 694.87
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 694.87,
+            "to": 694.98
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 694.98,
+            "to": 695.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 695.43,
+            "to": 695.51
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 695.51,
+            "to": 695.9
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 695.9,
+            "to": 696.13
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.553,
+            "final": false,
+            "from": 696.13,
+            "to": 696.88
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.562,
+            "final": false,
+            "from": 698.21,
+            "to": 698.43
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.562,
+            "final": false,
+            "from": 698.43,
+            "to": 698.83
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.562,
+            "final": false,
+            "from": 698.83,
+            "to": 699.4
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 699.44,
+            "to": 699.91
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 699.91,
+            "to": 700.01
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 700.01,
+            "to": 700.34
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 700.34,
+            "to": 700.45
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.601,
+            "final": false,
+            "from": 700.45,
+            "to": 701.39
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.563,
+            "final": false,
+            "from": 702.48,
+            "to": 702.65
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.563,
+            "final": false,
+            "from": 702.65,
+            "to": 703.24
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.563,
+            "final": false,
+            "from": 703.24,
+            "to": 703.33
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.563,
+            "final": false,
+            "from": 703.33,
+            "to": 703.44
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.563,
+            "final": false,
+            "from": 703.44,
+            "to": 703.62
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.563,
+            "final": false,
+            "from": 703.62,
+            "to": 704.32
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.461,
+            "final": false,
+            "from": 705.5,
+            "to": 705.77
+         },
+         {
+            "speaker": 1,
+            "confidence": 0.461,
+            "final": true,
+            "from": 705.77,
+            "to": 705.94
+         }
+      ],
+      "results": [
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "there is a day about ten years ago when I asked a friend to hold a baby dinosaur robot upside down ",
+               "timestamps": [
+                  [
+                     "there",
+                     13.04,
+                     13.23
+                  ],
+                  [
+                     "is",
+                     13.23,
+                     13.36
+                  ],
+                  [
+                     "a",
+                     13.36,
+                     13.42
+                  ],
+                  [
+                     "day",
+                     13.42,
+                     13.84
+                  ],
+                  [
+                     "about",
+                     13.84,
+                     14.13
+                  ],
+                  [
+                     "ten",
+                     14.13,
+                     14.35
+                  ],
+                  [
+                     "years",
+                     14.35,
+                     14.59
+                  ],
+                  [
+                     "ago",
+                     14.59,
+                     15.16
+                  ],
+                  [
+                     "when",
+                     15.46,
+                     15.72
+                  ],
+                  [
+                     "I",
+                     15.72,
+                     15.78
+                  ],
+                  [
+                     "asked",
+                     15.78,
+                     16.19
+                  ],
+                  [
+                     "a",
+                     16.19,
+                     16.27
+                  ],
+                  [
+                     "friend",
+                     16.27,
+                     16.64
+                  ],
+                  [
+                     "to",
+                     16.64,
+                     16.72
+                  ],
+                  [
+                     "hold",
+                     16.72,
+                     17.2
+                  ],
+                  [
+                     "a",
+                     17.23,
+                     17.31
+                  ],
+                  [
+                     "baby",
+                     17.31,
+                     17.62
+                  ],
+                  [
+                     "dinosaur",
+                     17.62,
+                     18.12
+                  ],
+                  [
+                     "robot",
+                     18.12,
+                     18.6
+                  ],
+                  [
+                     "upside",
+                     18.72,
+                     19.16
+                  ],
+                  [
+                     "down",
+                     19.16,
+                     19.52
+                  ]
+               ],
+               "confidence": 0.938,
+               "word_confidence": [
+                  [
+                     "there",
+                     0.902
+                  ],
+                  [
+                     "is",
+                     0.52
+                  ],
+                  [
+                     "a",
+                     0.819
+                  ],
+                  [
+                     "day",
+                     0.948
+                  ],
+                  [
+                     "about",
+                     0.976
+                  ],
+                  [
+                     "ten",
+                     1
+                  ],
+                  [
+                     "years",
+                     1
+                  ],
+                  [
+                     "ago",
+                     1
+                  ],
+                  [
+                     "when",
+                     1
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "asked",
+                     0.818
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "friend",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "hold",
+                     1
+                  ],
+                  [
+                     "a",
+                     0.643
+                  ],
+                  [
+                     "baby",
+                     1
+                  ],
+                  [
+                     "dinosaur",
+                     0.981
+                  ],
+                  [
+                     "robot",
+                     0.861
+                  ],
+                  [
+                     "upside",
+                     0.832
+                  ],
+                  [
+                     "down",
+                     0.992
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "use this toy call the pleroma that I had ordered and I was really excited about it because I've always loved robots and this one has really cool technical features it had motors and touch sensors and it had an infrared camera and one of the things that had with a tilt sensor so we knew what direction it was the thing and when you held it upside down would start to crack ",
+               "timestamps": [
+                  [
+                     "use",
+                     21.86,
+                     22.07
+                  ],
+                  [
+                     "this",
+                     22.07,
+                     22.22
+                  ],
+                  [
+                     "toy",
+                     22.22,
+                     22.68
+                  ],
+                  [
+                     "call",
+                     22.68,
+                     22.86
+                  ],
+                  [
+                     "the",
+                     22.86,
+                     22.94
+                  ],
+                  [
+                     "pleroma",
+                     22.94,
+                     23.77
+                  ],
+                  [
+                     "that",
+                     24.2,
+                     24.57
+                  ],
+                  [
+                     "I",
+                     24.61,
+                     24.71
+                  ],
+                  [
+                     "had",
+                     24.71,
+                     24.84
+                  ],
+                  [
+                     "ordered",
+                     24.84,
+                     25.32
+                  ],
+                  [
+                     "and",
+                     25.32,
+                     25.43
+                  ],
+                  [
+                     "I",
+                     25.43,
+                     25.48
+                  ],
+                  [
+                     "was",
+                     25.48,
+                     25.62
+                  ],
+                  [
+                     "really",
+                     25.62,
+                     25.86
+                  ],
+                  [
+                     "excited",
+                     25.86,
+                     26.48
+                  ],
+                  [
+                     "about",
+                     26.48,
+                     26.82
+                  ],
+                  [
+                     "it",
+                     26.82,
+                     27.03
+                  ],
+                  [
+                     "because",
+                     27.03,
+                     27.77
+                  ],
+                  [
+                     "I've",
+                     28.42,
+                     28.57
+                  ],
+                  [
+                     "always",
+                     28.57,
+                     28.76
+                  ],
+                  [
+                     "loved",
+                     28.76,
+                     29
+                  ],
+                  [
+                     "robots",
+                     29,
+                     29.55
+                  ],
+                  [
+                     "and",
+                     29.75,
+                     29.88
+                  ],
+                  [
+                     "this",
+                     29.88,
+                     30.02
+                  ],
+                  [
+                     "one",
+                     30.02,
+                     30.18
+                  ],
+                  [
+                     "has",
+                     30.18,
+                     30.42
+                  ],
+                  [
+                     "really",
+                     30.42,
+                     30.76
+                  ],
+                  [
+                     "cool",
+                     30.76,
+                     30.92
+                  ],
+                  [
+                     "technical",
+                     30.92,
+                     31.33
+                  ],
+                  [
+                     "features",
+                     31.33,
+                     31.79
+                  ],
+                  [
+                     "it",
+                     31.79,
+                     31.92
+                  ],
+                  [
+                     "had",
+                     31.92,
+                     32.1
+                  ],
+                  [
+                     "motors",
+                     32.1,
+                     32.73
+                  ],
+                  [
+                     "and",
+                     32.73,
+                     32.89
+                  ],
+                  [
+                     "touch",
+                     32.89,
+                     33.16
+                  ],
+                  [
+                     "sensors",
+                     33.16,
+                     33.87
+                  ],
+                  [
+                     "and",
+                     34.2,
+                     34.39
+                  ],
+                  [
+                     "it",
+                     34.39,
+                     34.49
+                  ],
+                  [
+                     "had",
+                     34.49,
+                     34.7
+                  ],
+                  [
+                     "an",
+                     34.7,
+                     34.79
+                  ],
+                  [
+                     "infrared",
+                     34.79,
+                     35.3
+                  ],
+                  [
+                     "camera",
+                     35.3,
+                     35.97
+                  ],
+                  [
+                     "and",
+                     36.49,
+                     36.65
+                  ],
+                  [
+                     "one",
+                     36.65,
+                     36.78
+                  ],
+                  [
+                     "of",
+                     36.78,
+                     36.86
+                  ],
+                  [
+                     "the",
+                     36.86,
+                     36.96
+                  ],
+                  [
+                     "things",
+                     36.96,
+                     37.21
+                  ],
+                  [
+                     "that",
+                     37.21,
+                     37.32
+                  ],
+                  [
+                     "had",
+                     37.32,
+                     37.51
+                  ],
+                  [
+                     "with",
+                     37.51,
+                     37.67
+                  ],
+                  [
+                     "a",
+                     37.67,
+                     37.78
+                  ],
+                  [
+                     "tilt",
+                     37.95,
+                     38.37
+                  ],
+                  [
+                     "sensor",
+                     38.37,
+                     38.98
+                  ],
+                  [
+                     "so",
+                     39.25,
+                     39.46
+                  ],
+                  [
+                     "we",
+                     39.46,
+                     39.58
+                  ],
+                  [
+                     "knew",
+                     39.61,
+                     39.81
+                  ],
+                  [
+                     "what",
+                     39.81,
+                     39.95
+                  ],
+                  [
+                     "direction",
+                     39.95,
+                     40.53
+                  ],
+                  [
+                     "it",
+                     40.53,
+                     40.63
+                  ],
+                  [
+                     "was",
+                     40.63,
+                     40.89
+                  ],
+                  [
+                     "the",
+                     40.99,
+                     41.14
+                  ],
+                  [
+                     "thing",
+                     41.14,
+                     41.54
+                  ],
+                  [
+                     "and",
+                     42.01,
+                     42.22
+                  ],
+                  [
+                     "when",
+                     42.22,
+                     42.32
+                  ],
+                  [
+                     "you",
+                     42.32,
+                     42.4
+                  ],
+                  [
+                     "held",
+                     42.4,
+                     42.61
+                  ],
+                  [
+                     "it",
+                     42.61,
+                     42.71
+                  ],
+                  [
+                     "upside",
+                     42.71,
+                     43.04
+                  ],
+                  [
+                     "down",
+                     43.04,
+                     43.6
+                  ],
+                  [
+                     "would",
+                     44.24,
+                     44.43
+                  ],
+                  [
+                     "start",
+                     44.43,
+                     44.66
+                  ],
+                  [
+                     "to",
+                     44.66,
+                     44.74
+                  ],
+                  [
+                     "crack",
+                     44.74,
+                     45.27
+                  ]
+               ],
+               "confidence": 0.841,
+               "word_confidence": [
+                  [
+                     "use",
+                     0.164
+                  ],
+                  [
+                     "this",
+                     0.929
+                  ],
+                  [
+                     "toy",
+                     0.945
+                  ],
+                  [
+                     "call",
+                     0.497
+                  ],
+                  [
+                     "the",
+                     0.836
+                  ],
+                  [
+                     "pleroma",
+                     0.172
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "I",
+                     0.867
+                  ],
+                  [
+                     "had",
+                     0.867
+                  ],
+                  [
+                     "ordered",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "was",
+                     1
+                  ],
+                  [
+                     "really",
+                     1
+                  ],
+                  [
+                     "excited",
+                     1
+                  ],
+                  [
+                     "about",
+                     1
+                  ],
+                  [
+                     "it",
+                     0.982
+                  ],
+                  [
+                     "because",
+                     0.997
+                  ],
+                  [
+                     "I've",
+                     0.941
+                  ],
+                  [
+                     "always",
+                     1
+                  ],
+                  [
+                     "loved",
+                     0.99
+                  ],
+                  [
+                     "robots",
+                     0.876
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "one",
+                     1
+                  ],
+                  [
+                     "has",
+                     0.988
+                  ],
+                  [
+                     "really",
+                     0.948
+                  ],
+                  [
+                     "cool",
+                     0.677
+                  ],
+                  [
+                     "technical",
+                     0.989
+                  ],
+                  [
+                     "features",
+                     0.79
+                  ],
+                  [
+                     "it",
+                     0.63
+                  ],
+                  [
+                     "had",
+                     0.905
+                  ],
+                  [
+                     "motors",
+                     0.931
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "touch",
+                     1
+                  ],
+                  [
+                     "sensors",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.84
+                  ],
+                  [
+                     "it",
+                     0.379
+                  ],
+                  [
+                     "had",
+                     0.919
+                  ],
+                  [
+                     "an",
+                     0.959
+                  ],
+                  [
+                     "infrared",
+                     0.748
+                  ],
+                  [
+                     "camera",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "one",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "things",
+                     1
+                  ],
+                  [
+                     "that",
+                     0.717
+                  ],
+                  [
+                     "had",
+                     0.837
+                  ],
+                  [
+                     "with",
+                     0.563
+                  ],
+                  [
+                     "a",
+                     0.298
+                  ],
+                  [
+                     "tilt",
+                     0.482
+                  ],
+                  [
+                     "sensor",
+                     0.978
+                  ],
+                  [
+                     "so",
+                     0.898
+                  ],
+                  [
+                     "we",
+                     0.226
+                  ],
+                  [
+                     "knew",
+                     0.815
+                  ],
+                  [
+                     "what",
+                     1
+                  ],
+                  [
+                     "direction",
+                     1
+                  ],
+                  [
+                     "it",
+                     0.974
+                  ],
+                  [
+                     "was",
+                     0.823
+                  ],
+                  [
+                     "the",
+                     0.346
+                  ],
+                  [
+                     "thing",
+                     0.767
+                  ],
+                  [
+                     "and",
+                     0.88
+                  ],
+                  [
+                     "when",
+                     0.973
+                  ],
+                  [
+                     "you",
+                     1
+                  ],
+                  [
+                     "held",
+                     0.503
+                  ],
+                  [
+                     "it",
+                     0.454
+                  ],
+                  [
+                     "upside",
+                     1
+                  ],
+                  [
+                     "down",
+                     0.991
+                  ],
+                  [
+                     "would",
+                     0.511
+                  ],
+                  [
+                     "start",
+                     0.989
+                  ],
+                  [
+                     "to",
+                     0.907
+                  ],
+                  [
+                     "crack",
+                     0.341
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and I thought this was super cool so I'm showing off to my friend and I said to hold it up by that helps you to ",
+               "timestamps": [
+                  [
+                     "and",
+                     46.52,
+                     46.62
+                  ],
+                  [
+                     "I",
+                     46.62,
+                     46.67
+                  ],
+                  [
+                     "thought",
+                     46.67,
+                     46.88
+                  ],
+                  [
+                     "this",
+                     46.88,
+                     47.1
+                  ],
+                  [
+                     "was",
+                     47.13,
+                     47.26
+                  ],
+                  [
+                     "super",
+                     47.26,
+                     47.62
+                  ],
+                  [
+                     "cool",
+                     47.62,
+                     47.98
+                  ],
+                  [
+                     "so",
+                     47.98,
+                     48.15
+                  ],
+                  [
+                     "I'm",
+                     48.15,
+                     48.25
+                  ],
+                  [
+                     "showing",
+                     48.25,
+                     48.66
+                  ],
+                  [
+                     "off",
+                     48.66,
+                     48.81
+                  ],
+                  [
+                     "to",
+                     48.81,
+                     48.92
+                  ],
+                  [
+                     "my",
+                     48.92,
+                     49.02
+                  ],
+                  [
+                     "friend",
+                     49.02,
+                     49.57
+                  ],
+                  [
+                     "and",
+                     50.01,
+                     50.15
+                  ],
+                  [
+                     "I",
+                     50.15,
+                     50.2
+                  ],
+                  [
+                     "said",
+                     50.2,
+                     50.38
+                  ],
+                  [
+                     "to",
+                     50.38,
+                     50.44
+                  ],
+                  [
+                     "hold",
+                     50.44,
+                     50.81
+                  ],
+                  [
+                     "it",
+                     50.81,
+                     50.88
+                  ],
+                  [
+                     "up",
+                     50.88,
+                     50.96
+                  ],
+                  [
+                     "by",
+                     50.96,
+                     51.05
+                  ],
+                  [
+                     "that",
+                     51.05,
+                     51.22
+                  ],
+                  [
+                     "helps",
+                     51.22,
+                     51.57
+                  ],
+                  [
+                     "you",
+                     51.57,
+                     51.71
+                  ],
+                  [
+                     "to",
+                     51.71,
+                     52
+                  ]
+               ],
+               "confidence": 0.622,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.616
+                  ],
+                  [
+                     "I",
+                     0.799
+                  ],
+                  [
+                     "thought",
+                     0.894
+                  ],
+                  [
+                     "this",
+                     0.244
+                  ],
+                  [
+                     "was",
+                     0.103
+                  ],
+                  [
+                     "super",
+                     0.943
+                  ],
+                  [
+                     "cool",
+                     0.869
+                  ],
+                  [
+                     "so",
+                     0.321
+                  ],
+                  [
+                     "I'm",
+                     0.116
+                  ],
+                  [
+                     "showing",
+                     0.885
+                  ],
+                  [
+                     "off",
+                     0.702
+                  ],
+                  [
+                     "to",
+                     0.56
+                  ],
+                  [
+                     "my",
+                     1
+                  ],
+                  [
+                     "friend",
+                     0.682
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "said",
+                     0.949
+                  ],
+                  [
+                     "to",
+                     0.195
+                  ],
+                  [
+                     "hold",
+                     0.63
+                  ],
+                  [
+                     "it",
+                     0.443
+                  ],
+                  [
+                     "up",
+                     0.451
+                  ],
+                  [
+                     "by",
+                     0.954
+                  ],
+                  [
+                     "that",
+                     0.375
+                  ],
+                  [
+                     "helps",
+                     0.282
+                  ],
+                  [
+                     "you",
+                     0.426
+                  ],
+                  [
+                     "to",
+                     0.188
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "so we're watching the theatrics of this robot ",
+               "timestamps": [
+                  [
+                     "so",
+                     55.24,
+                     55.37
+                  ],
+                  [
+                     "we're",
+                     55.37,
+                     55.49
+                  ],
+                  [
+                     "watching",
+                     55.49,
+                     55.91
+                  ],
+                  [
+                     "the",
+                     55.91,
+                     56
+                  ],
+                  [
+                     "theatrics",
+                     56,
+                     56.9
+                  ],
+                  [
+                     "of",
+                     56.9,
+                     57
+                  ],
+                  [
+                     "this",
+                     57,
+                     57.2
+                  ],
+                  [
+                     "robot",
+                     57.2,
+                     57.94
+                  ]
+               ],
+               "confidence": 0.946,
+               "word_confidence": [
+                  [
+                     "so",
+                     0.438
+                  ],
+                  [
+                     "we're",
+                     0.483
+                  ],
+                  [
+                     "watching",
+                     0.988
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "theatrics",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "robot",
+                     0.991
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "struggle and cry out ",
+               "timestamps": [
+                  [
+                     "struggle",
+                     58.87,
+                     59.83
+                  ],
+                  [
+                     "and",
+                     59.89,
+                     60.11
+                  ],
+                  [
+                     "cry",
+                     60.11,
+                     60.61
+                  ],
+                  [
+                     "out",
+                     60.61,
+                     61.09
+                  ]
+               ],
+               "confidence": 0.693,
+               "word_confidence": [
+                  [
+                     "struggle",
+                     0.592
+                  ],
+                  [
+                     "and",
+                     0.872
+                  ],
+                  [
+                     "cry",
+                     0.556
+                  ],
+                  [
+                     "out",
+                     0.954
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and after a few seconds first bother me a little ",
+               "timestamps": [
+                  [
+                     "and",
+                     62.74,
+                     63.01
+                  ],
+                  [
+                     "after",
+                     63.24,
+                     63.53
+                  ],
+                  [
+                     "a",
+                     63.53,
+                     63.56
+                  ],
+                  [
+                     "few",
+                     63.56,
+                     63.73
+                  ],
+                  [
+                     "seconds",
+                     63.73,
+                     64.46
+                  ],
+                  [
+                     "first",
+                     64.93,
+                     65.31
+                  ],
+                  [
+                     "bother",
+                     65.48,
+                     65.83
+                  ],
+                  [
+                     "me",
+                     65.83,
+                     65.97
+                  ],
+                  [
+                     "a",
+                     65.97,
+                     66.04
+                  ],
+                  [
+                     "little",
+                     66.04,
+                     66.43
+                  ]
+               ],
+               "confidence": 0.94,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.858
+                  ],
+                  [
+                     "after",
+                     1
+                  ],
+                  [
+                     "a",
+                     0.673
+                  ],
+                  [
+                     "few",
+                     1
+                  ],
+                  [
+                     "seconds",
+                     0.995
+                  ],
+                  [
+                     "first",
+                     0.853
+                  ],
+                  [
+                     "bother",
+                     0.86
+                  ],
+                  [
+                     "me",
+                     0.98
+                  ],
+                  [
+                     "a",
+                     0.896
+                  ],
+                  [
+                     "little",
+                     0.994
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and I said okay ",
+               "timestamps": [
+                  [
+                     "and",
+                     67.71,
+                     67.88
+                  ],
+                  [
+                     "I",
+                     67.88,
+                     67.95
+                  ],
+                  [
+                     "said",
+                     67.95,
+                     68.2
+                  ],
+                  [
+                     "okay",
+                     68.2,
+                     68.83
+                  ]
+               ],
+               "confidence": 0.976,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "said",
+                     1
+                  ],
+                  [
+                     "okay",
+                     0.957
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "that's enough now ",
+               "timestamps": [
+                  [
+                     "that's",
+                     69.96,
+                     70.19
+                  ],
+                  [
+                     "enough",
+                     70.19,
+                     70.56
+                  ],
+                  [
+                     "now",
+                     70.56,
+                     71.03
+                  ]
+               ],
+               "confidence": 0.903,
+               "word_confidence": [
+                  [
+                     "that's",
+                     0.854
+                  ],
+                  [
+                     "enough",
+                     0.988
+                  ],
+                  [
+                     "now",
+                     0.859
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "let's put him back down ",
+               "timestamps": [
+                  [
+                     "let's",
+                     71.92,
+                     72.1
+                  ],
+                  [
+                     "put",
+                     72.1,
+                     72.22
+                  ],
+                  [
+                     "him",
+                     72.22,
+                     72.31
+                  ],
+                  [
+                     "back",
+                     72.31,
+                     72.55
+                  ],
+                  [
+                     "down",
+                     72.55,
+                     73.08
+                  ]
+               ],
+               "confidence": 0.713,
+               "word_confidence": [
+                  [
+                     "let's",
+                     0.628
+                  ],
+                  [
+                     "put",
+                     0.682
+                  ],
+                  [
+                     "him",
+                     0.338
+                  ],
+                  [
+                     "back",
+                     0.921
+                  ],
+                  [
+                     "down",
+                     0.718
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and then I packed the robot to make it stop crying ",
+               "timestamps": [
+                  [
+                     "and",
+                     74.26,
+                     74.42
+                  ],
+                  [
+                     "then",
+                     74.42,
+                     74.55
+                  ],
+                  [
+                     "I",
+                     74.55,
+                     74.61
+                  ],
+                  [
+                     "packed",
+                     74.61,
+                     74.88
+                  ],
+                  [
+                     "the",
+                     74.88,
+                     74.98
+                  ],
+                  [
+                     "robot",
+                     74.98,
+                     75.34
+                  ],
+                  [
+                     "to",
+                     75.34,
+                     75.43
+                  ],
+                  [
+                     "make",
+                     75.43,
+                     75.56
+                  ],
+                  [
+                     "it",
+                     75.56,
+                     75.65
+                  ],
+                  [
+                     "stop",
+                     75.65,
+                     75.91
+                  ],
+                  [
+                     "crying",
+                     75.91,
+                     76.46
+                  ]
+               ],
+               "confidence": 0.746,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "then",
+                     1
+                  ],
+                  [
+                     "I",
+                     0.969
+                  ],
+                  [
+                     "packed",
+                     0.123
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "robot",
+                     0.351
+                  ],
+                  [
+                     "to",
+                     0.509
+                  ],
+                  [
+                     "make",
+                     1
+                  ],
+                  [
+                     "it",
+                     0.874
+                  ],
+                  [
+                     "stop",
+                     0.958
+                  ],
+                  [
+                     "crying",
+                     0.964
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "I was kind of a weird experience for me ",
+               "timestamps": [
+                  [
+                     "I",
+                     79.08,
+                     79.13
+                  ],
+                  [
+                     "was",
+                     79.13,
+                     79.27
+                  ],
+                  [
+                     "kind",
+                     79.27,
+                     79.43
+                  ],
+                  [
+                     "of",
+                     79.43,
+                     79.5
+                  ],
+                  [
+                     "a",
+                     79.5,
+                     79.6
+                  ],
+                  [
+                     "weird",
+                     79.6,
+                     79.93
+                  ],
+                  [
+                     "experience",
+                     79.93,
+                     80.58
+                  ],
+                  [
+                     "for",
+                     80.58,
+                     80.75
+                  ],
+                  [
+                     "me",
+                     80.75,
+                     81.15
+                  ]
+               ],
+               "confidence": 0.952,
+               "word_confidence": [
+                  [
+                     "I",
+                     0.22
+                  ],
+                  [
+                     "was",
+                     0.602
+                  ],
+                  [
+                     "kind",
+                     0.998
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "weird",
+                     1
+                  ],
+                  [
+                     "experience",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "me",
+                     0.992
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "for one thing I wasn't the most maternal person at the time ",
+               "timestamps": [
+                  [
+                     "for",
+                     82.07,
+                     82.16
+                  ],
+                  [
+                     "one",
+                     82.16,
+                     82.32
+                  ],
+                  [
+                     "thing",
+                     82.32,
+                     82.68
+                  ],
+                  [
+                     "I",
+                     82.96,
+                     83.05
+                  ],
+                  [
+                     "wasn't",
+                     83.05,
+                     83.3
+                  ],
+                  [
+                     "the",
+                     83.3,
+                     83.37
+                  ],
+                  [
+                     "most",
+                     83.37,
+                     83.68
+                  ],
+                  [
+                     "maternal",
+                     83.77,
+                     84.39
+                  ],
+                  [
+                     "person",
+                     84.39,
+                     84.9
+                  ],
+                  [
+                     "at",
+                     84.9,
+                     85.05
+                  ],
+                  [
+                     "the",
+                     85.05,
+                     85.14
+                  ],
+                  [
+                     "time",
+                     85.14,
+                     85.79
+                  ]
+               ],
+               "confidence": 0.941,
+               "word_confidence": [
+                  [
+                     "for",
+                     0.491
+                  ],
+                  [
+                     "one",
+                     0.991
+                  ],
+                  [
+                     "thing",
+                     0.999
+                  ],
+                  [
+                     "I",
+                     0.473
+                  ],
+                  [
+                     "wasn't",
+                     0.915
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "most",
+                     1
+                  ],
+                  [
+                     "maternal",
+                     1
+                  ],
+                  [
+                     "person",
+                     0.982
+                  ],
+                  [
+                     "at",
+                     0.614
+                  ],
+                  [
+                     "the",
+                     0.891
+                  ],
+                  [
+                     "time",
+                     0.992
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "although since then I've become a mother nine months ago and I've learned that babies also squirming hold them off and on ",
+               "timestamps": [
+                  [
+                     "although",
+                     86.66,
+                     86.9
+                  ],
+                  [
+                     "since",
+                     86.9,
+                     87.15
+                  ],
+                  [
+                     "then",
+                     87.15,
+                     87.28
+                  ],
+                  [
+                     "I've",
+                     87.28,
+                     87.37
+                  ],
+                  [
+                     "become",
+                     87.37,
+                     87.59
+                  ],
+                  [
+                     "a",
+                     87.59,
+                     87.65
+                  ],
+                  [
+                     "mother",
+                     87.65,
+                     87.96
+                  ],
+                  [
+                     "nine",
+                     87.96,
+                     88.26
+                  ],
+                  [
+                     "months",
+                     88.26,
+                     88.48
+                  ],
+                  [
+                     "ago",
+                     88.48,
+                     88.91
+                  ],
+                  [
+                     "and",
+                     89.41,
+                     89.54
+                  ],
+                  [
+                     "I've",
+                     89.54,
+                     89.63
+                  ],
+                  [
+                     "learned",
+                     89.63,
+                     89.89
+                  ],
+                  [
+                     "that",
+                     89.89,
+                     90.15
+                  ],
+                  [
+                     "babies",
+                     90.18,
+                     90.48
+                  ],
+                  [
+                     "also",
+                     90.48,
+                     90.71
+                  ],
+                  [
+                     "squirming",
+                     90.71,
+                     91.23
+                  ],
+                  [
+                     "hold",
+                     91.23,
+                     91.43
+                  ],
+                  [
+                     "them",
+                     91.43,
+                     91.53
+                  ],
+                  [
+                     "off",
+                     91.53,
+                     91.73
+                  ],
+                  [
+                     "and",
+                     91.73,
+                     91.85
+                  ],
+                  [
+                     "on",
+                     91.85,
+                     92.19
+                  ]
+               ],
+               "confidence": 0.743,
+               "word_confidence": [
+                  [
+                     "although",
+                     1
+                  ],
+                  [
+                     "since",
+                     0.953
+                  ],
+                  [
+                     "then",
+                     0.455
+                  ],
+                  [
+                     "I've",
+                     0.395
+                  ],
+                  [
+                     "become",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "mother",
+                     0.905
+                  ],
+                  [
+                     "nine",
+                     0.755
+                  ],
+                  [
+                     "months",
+                     1
+                  ],
+                  [
+                     "ago",
+                     0.998
+                  ],
+                  [
+                     "and",
+                     0.987
+                  ],
+                  [
+                     "I've",
+                     0.704
+                  ],
+                  [
+                     "learned",
+                     0.998
+                  ],
+                  [
+                     "that",
+                     0.905
+                  ],
+                  [
+                     "babies",
+                     0.77
+                  ],
+                  [
+                     "also",
+                     1
+                  ],
+                  [
+                     "squirming",
+                     0.23
+                  ],
+                  [
+                     "hold",
+                     0.606
+                  ],
+                  [
+                     "them",
+                     0.426
+                  ],
+                  [
+                     "off",
+                     0.393
+                  ],
+                  [
+                     "and",
+                     0.427
+                  ],
+                  [
+                     "on",
+                     0.433
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "but my response this robot was also interesting because I know exactly how this machine work ",
+               "timestamps": [
+                  [
+                     "but",
+                     95.01,
+                     95.26
+                  ],
+                  [
+                     "my",
+                     95.26,
+                     95.43
+                  ],
+                  [
+                     "response",
+                     95.43,
+                     95.88
+                  ],
+                  [
+                     "this",
+                     95.88,
+                     96.09
+                  ],
+                  [
+                     "robot",
+                     96.09,
+                     96.42
+                  ],
+                  [
+                     "was",
+                     96.42,
+                     96.56
+                  ],
+                  [
+                     "also",
+                     96.56,
+                     96.84
+                  ],
+                  [
+                     "interesting",
+                     96.84,
+                     97.25
+                  ],
+                  [
+                     "because",
+                     97.25,
+                     97.7
+                  ],
+                  [
+                     "I",
+                     97.9,
+                     98.01
+                  ],
+                  [
+                     "know",
+                     98.01,
+                     98.15
+                  ],
+                  [
+                     "exactly",
+                     98.15,
+                     98.88
+                  ],
+                  [
+                     "how",
+                     98.88,
+                     99.14
+                  ],
+                  [
+                     "this",
+                     99.14,
+                     99.38
+                  ],
+                  [
+                     "machine",
+                     99.38,
+                     99.92
+                  ],
+                  [
+                     "work",
+                     99.92,
+                     100.56
+                  ]
+               ],
+               "confidence": 0.948,
+               "word_confidence": [
+                  [
+                     "but",
+                     1
+                  ],
+                  [
+                     "my",
+                     1
+                  ],
+                  [
+                     "response",
+                     0.991
+                  ],
+                  [
+                     "this",
+                     0.962
+                  ],
+                  [
+                     "robot",
+                     0.819
+                  ],
+                  [
+                     "was",
+                     1
+                  ],
+                  [
+                     "also",
+                     1
+                  ],
+                  [
+                     "interesting",
+                     1
+                  ],
+                  [
+                     "because",
+                     1
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "know",
+                     0.298
+                  ],
+                  [
+                     "exactly",
+                     0.994
+                  ],
+                  [
+                     "how",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "machine",
+                     0.993
+                  ],
+                  [
+                     "work",
+                     0.843
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and yet I still felt compelled to be kind to it ",
+               "timestamps": [
+                  [
+                     "and",
+                     101.5,
+                     101.67
+                  ],
+                  [
+                     "yet",
+                     101.67,
+                     101.85
+                  ],
+                  [
+                     "I",
+                     101.85,
+                     101.93
+                  ],
+                  [
+                     "still",
+                     101.93,
+                     102.35
+                  ],
+                  [
+                     "felt",
+                     102.35,
+                     102.64
+                  ],
+                  [
+                     "compelled",
+                     102.64,
+                     103.37
+                  ],
+                  [
+                     "to",
+                     103.37,
+                     103.5
+                  ],
+                  [
+                     "be",
+                     103.5,
+                     103.65
+                  ],
+                  [
+                     "kind",
+                     103.65,
+                     104.38
+                  ],
+                  [
+                     "to",
+                     104.43,
+                     104.57
+                  ],
+                  [
+                     "it",
+                     104.57,
+                     104.79
+                  ]
+               ],
+               "confidence": 0.963,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "yet",
+                     0.933
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "still",
+                     1
+                  ],
+                  [
+                     "felt",
+                     0.765
+                  ],
+                  [
+                     "compelled",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "be",
+                     1
+                  ],
+                  [
+                     "kind",
+                     0.981
+                  ],
+                  [
+                     "to",
+                     0.838
+                  ],
+                  [
+                     "it",
+                     0.985
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and that observation sparked the curiosity that I spent the fact the past decade pursuing ",
+               "timestamps": [
+                  [
+                     "and",
+                     106.4,
+                     106.62
+                  ],
+                  [
+                     "that",
+                     106.62,
+                     106.86
+                  ],
+                  [
+                     "observation",
+                     106.91,
+                     107.68
+                  ],
+                  [
+                     "sparked",
+                     107.68,
+                     108.09
+                  ],
+                  [
+                     "the",
+                     108.09,
+                     108.18
+                  ],
+                  [
+                     "curiosity",
+                     108.18,
+                     109.1
+                  ],
+                  [
+                     "that",
+                     109.1,
+                     109.31
+                  ],
+                  [
+                     "I",
+                     109.31,
+                     109.37
+                  ],
+                  [
+                     "spent",
+                     109.37,
+                     109.72
+                  ],
+                  [
+                     "the",
+                     109.72,
+                     109.81
+                  ],
+                  [
+                     "fact",
+                     109.81,
+                     110.16
+                  ],
+                  [
+                     "the",
+                     110.19,
+                     110.35
+                  ],
+                  [
+                     "past",
+                     110.35,
+                     110.7
+                  ],
+                  [
+                     "decade",
+                     110.75,
+                     111.26
+                  ],
+                  [
+                     "pursuing",
+                     111.26,
+                     111.99
+                  ]
+               ],
+               "confidence": 0.771,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.879
+                  ],
+                  [
+                     "that",
+                     0.316
+                  ],
+                  [
+                     "observation",
+                     0.581
+                  ],
+                  [
+                     "sparked",
+                     0.537
+                  ],
+                  [
+                     "the",
+                     0.62
+                  ],
+                  [
+                     "curiosity",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "I",
+                     0.614
+                  ],
+                  [
+                     "spent",
+                     0.732
+                  ],
+                  [
+                     "the",
+                     0.905
+                  ],
+                  [
+                     "fact",
+                     0.277
+                  ],
+                  [
+                     "the",
+                     0.955
+                  ],
+                  [
+                     "past",
+                     0.984
+                  ],
+                  [
+                     "decade",
+                     0.803
+                  ],
+                  [
+                     "pursuing",
+                     0.974
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "why did I come for this robot ",
+               "timestamps": [
+                  [
+                     "why",
+                     112.91,
+                     113.14
+                  ],
+                  [
+                     "did",
+                     113.14,
+                     113.37
+                  ],
+                  [
+                     "I",
+                     113.37,
+                     113.42
+                  ],
+                  [
+                     "come",
+                     113.42,
+                     113.71
+                  ],
+                  [
+                     "for",
+                     113.71,
+                     113.87
+                  ],
+                  [
+                     "this",
+                     113.87,
+                     114.11
+                  ],
+                  [
+                     "robot",
+                     114.11,
+                     114.61
+                  ]
+               ],
+               "confidence": 0.607,
+               "word_confidence": [
+                  [
+                     "why",
+                     0.95
+                  ],
+                  [
+                     "did",
+                     0.643
+                  ],
+                  [
+                     "I",
+                     0.442
+                  ],
+                  [
+                     "come",
+                     0.381
+                  ],
+                  [
+                     "for",
+                     0.379
+                  ],
+                  [
+                     "this",
+                     0.882
+                  ],
+                  [
+                     "robot",
+                     0.521
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and one of the things I discovered was that my treatment of this machine was more than just an awkward moment in my living room that in a world where were increasingly integrating robots into our lives an instance like that might actually have consequences ",
+               "timestamps": [
+                  [
+                     "and",
+                     116.21,
+                     116.35
+                  ],
+                  [
+                     "one",
+                     116.35,
+                     116.46
+                  ],
+                  [
+                     "of",
+                     116.46,
+                     116.55
+                  ],
+                  [
+                     "the",
+                     116.55,
+                     116.63
+                  ],
+                  [
+                     "things",
+                     116.63,
+                     116.86
+                  ],
+                  [
+                     "I",
+                     116.86,
+                     116.91
+                  ],
+                  [
+                     "discovered",
+                     116.91,
+                     117.56
+                  ],
+                  [
+                     "was",
+                     117.56,
+                     117.74
+                  ],
+                  [
+                     "that",
+                     117.74,
+                     118.19
+                  ],
+                  [
+                     "my",
+                     118.44,
+                     118.6
+                  ],
+                  [
+                     "treatment",
+                     118.6,
+                     119.18
+                  ],
+                  [
+                     "of",
+                     119.18,
+                     119.26
+                  ],
+                  [
+                     "this",
+                     119.26,
+                     119.42
+                  ],
+                  [
+                     "machine",
+                     119.42,
+                     119.77
+                  ],
+                  [
+                     "was",
+                     119.77,
+                     119.92
+                  ],
+                  [
+                     "more",
+                     119.92,
+                     120.21
+                  ],
+                  [
+                     "than",
+                     120.21,
+                     120.35
+                  ],
+                  [
+                     "just",
+                     120.35,
+                     120.76
+                  ],
+                  [
+                     "an",
+                     121,
+                     121.13
+                  ],
+                  [
+                     "awkward",
+                     121.13,
+                     121.6
+                  ],
+                  [
+                     "moment",
+                     121.6,
+                     122.07
+                  ],
+                  [
+                     "in",
+                     122.07,
+                     122.15
+                  ],
+                  [
+                     "my",
+                     122.15,
+                     122.29
+                  ],
+                  [
+                     "living",
+                     122.29,
+                     122.58
+                  ],
+                  [
+                     "room",
+                     122.58,
+                     122.97
+                  ],
+                  [
+                     "that",
+                     123.53,
+                     123.72
+                  ],
+                  [
+                     "in",
+                     123.72,
+                     123.83
+                  ],
+                  [
+                     "a",
+                     123.83,
+                     123.92
+                  ],
+                  [
+                     "world",
+                     123.92,
+                     124.4
+                  ],
+                  [
+                     "where",
+                     124.4,
+                     124.54
+                  ],
+                  [
+                     "were",
+                     124.54,
+                     124.63
+                  ],
+                  [
+                     "increasingly",
+                     124.63,
+                     125.42
+                  ],
+                  [
+                     "integrating",
+                     125.45,
+                     126.15
+                  ],
+                  [
+                     "robots",
+                     126.15,
+                     126.98
+                  ],
+                  [
+                     "into",
+                     127.21,
+                     127.5
+                  ],
+                  [
+                     "our",
+                     127.5,
+                     127.64
+                  ],
+                  [
+                     "lives",
+                     127.64,
+                     128.46
+                  ],
+                  [
+                     "an",
+                     128.97,
+                     129.09
+                  ],
+                  [
+                     "instance",
+                     129.09,
+                     129.56
+                  ],
+                  [
+                     "like",
+                     129.56,
+                     129.72
+                  ],
+                  [
+                     "that",
+                     129.72,
+                     130
+                  ],
+                  [
+                     "might",
+                     130,
+                     130.26
+                  ],
+                  [
+                     "actually",
+                     130.38,
+                     130.74
+                  ],
+                  [
+                     "have",
+                     130.74,
+                     130.87
+                  ],
+                  [
+                     "consequences",
+                     130.87,
+                     132.06
+                  ]
+               ],
+               "confidence": 0.928,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.463
+                  ],
+                  [
+                     "one",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "things",
+                     0.985
+                  ],
+                  [
+                     "I",
+                     0.811
+                  ],
+                  [
+                     "discovered",
+                     0.999
+                  ],
+                  [
+                     "was",
+                     0.937
+                  ],
+                  [
+                     "that",
+                     0.999
+                  ],
+                  [
+                     "my",
+                     1
+                  ],
+                  [
+                     "treatment",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "machine",
+                     0.88
+                  ],
+                  [
+                     "was",
+                     0.576
+                  ],
+                  [
+                     "more",
+                     1
+                  ],
+                  [
+                     "than",
+                     1
+                  ],
+                  [
+                     "just",
+                     1
+                  ],
+                  [
+                     "an",
+                     1
+                  ],
+                  [
+                     "awkward",
+                     1
+                  ],
+                  [
+                     "moment",
+                     0.999
+                  ],
+                  [
+                     "in",
+                     0.668
+                  ],
+                  [
+                     "my",
+                     0.99
+                  ],
+                  [
+                     "living",
+                     1
+                  ],
+                  [
+                     "room",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "in",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "world",
+                     1
+                  ],
+                  [
+                     "where",
+                     0.782
+                  ],
+                  [
+                     "were",
+                     0.464
+                  ],
+                  [
+                     "increasingly",
+                     1
+                  ],
+                  [
+                     "integrating",
+                     0.61
+                  ],
+                  [
+                     "robots",
+                     1
+                  ],
+                  [
+                     "into",
+                     1
+                  ],
+                  [
+                     "our",
+                     1
+                  ],
+                  [
+                     "lives",
+                     0.998
+                  ],
+                  [
+                     "an",
+                     0.667
+                  ],
+                  [
+                     "instance",
+                     0.276
+                  ],
+                  [
+                     "like",
+                     0.88
+                  ],
+                  [
+                     "that",
+                     0.973
+                  ],
+                  [
+                     "might",
+                     1
+                  ],
+                  [
+                     "actually",
+                     1
+                  ],
+                  [
+                     "have",
+                     1
+                  ],
+                  [
+                     "consequences",
+                     0.997
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "because the first thing that I discovered is that it's not just me ",
+               "timestamps": [
+                  [
+                     "because",
+                     133.44,
+                     133.66
+                  ],
+                  [
+                     "the",
+                     133.66,
+                     133.75
+                  ],
+                  [
+                     "first",
+                     133.75,
+                     134.01
+                  ],
+                  [
+                     "thing",
+                     134.01,
+                     134.12
+                  ],
+                  [
+                     "that",
+                     134.12,
+                     134.25
+                  ],
+                  [
+                     "I",
+                     134.25,
+                     134.31
+                  ],
+                  [
+                     "discovered",
+                     134.31,
+                     135.1
+                  ],
+                  [
+                     "is",
+                     135.16,
+                     135.34
+                  ],
+                  [
+                     "that",
+                     135.34,
+                     135.52
+                  ],
+                  [
+                     "it's",
+                     135.55,
+                     135.76
+                  ],
+                  [
+                     "not",
+                     135.76,
+                     136.05
+                  ],
+                  [
+                     "just",
+                     136.05,
+                     136.38
+                  ],
+                  [
+                     "me",
+                     136.38,
+                     136.87
+                  ]
+               ],
+               "confidence": 0.996,
+               "word_confidence": [
+                  [
+                     "because",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "first",
+                     1
+                  ],
+                  [
+                     "thing",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "I",
+                     0.876
+                  ],
+                  [
+                     "discovered",
+                     0.995
+                  ],
+                  [
+                     "is",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "it's",
+                     1
+                  ],
+                  [
+                     "not",
+                     1
+                  ],
+                  [
+                     "just",
+                     1
+                  ],
+                  [
+                     "me",
+                     0.994
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "in two thousand and seven The Washington Post reported that the United States military was testing this robot that defused land mines and we worked with it was shaped like a stick insect you would walk around the mine field on its legs and every time I stepped on a mine one of the legs would blow up would continue on the other likes to blow up our minds ",
+               "timestamps": [
+                  [
+                     "in",
+                     139.24,
+                     139.39
+                  ],
+                  [
+                     "two",
+                     139.39,
+                     139.55
+                  ],
+                  [
+                     "thousand",
+                     139.55,
+                     139.9
+                  ],
+                  [
+                     "and",
+                     139.9,
+                     140.04
+                  ],
+                  [
+                     "seven",
+                     140.04,
+                     140.64
+                  ],
+                  [
+                     "The",
+                     140.73,
+                     140.86
+                  ],
+                  [
+                     "Washington",
+                     140.86,
+                     141.37
+                  ],
+                  [
+                     "Post",
+                     141.37,
+                     141.74
+                  ],
+                  [
+                     "reported",
+                     141.74,
+                     142.25
+                  ],
+                  [
+                     "that",
+                     142.25,
+                     142.41
+                  ],
+                  [
+                     "the",
+                     142.41,
+                     142.5
+                  ],
+                  [
+                     "United",
+                     142.5,
+                     142.89
+                  ],
+                  [
+                     "States",
+                     142.89,
+                     143.19
+                  ],
+                  [
+                     "military",
+                     143.19,
+                     144.04
+                  ],
+                  [
+                     "was",
+                     144.07,
+                     144.24
+                  ],
+                  [
+                     "testing",
+                     144.24,
+                     144.79
+                  ],
+                  [
+                     "this",
+                     144.79,
+                     145.12
+                  ],
+                  [
+                     "robot",
+                     145.29,
+                     145.86
+                  ],
+                  [
+                     "that",
+                     145.86,
+                     146
+                  ],
+                  [
+                     "defused",
+                     146,
+                     146.55
+                  ],
+                  [
+                     "land",
+                     146.55,
+                     146.93
+                  ],
+                  [
+                     "mines",
+                     146.93,
+                     147.28
+                  ],
+                  [
+                     "and",
+                     147.28,
+                     147.51
+                  ],
+                  [
+                     "we",
+                     147.51,
+                     147.64
+                  ],
+                  [
+                     "worked",
+                     147.64,
+                     147.89
+                  ],
+                  [
+                     "with",
+                     147.89,
+                     148.11
+                  ],
+                  [
+                     "it",
+                     148.37,
+                     148.46
+                  ],
+                  [
+                     "was",
+                     148.46,
+                     148.57
+                  ],
+                  [
+                     "shaped",
+                     148.57,
+                     148.95
+                  ],
+                  [
+                     "like",
+                     148.95,
+                     149.08
+                  ],
+                  [
+                     "a",
+                     149.08,
+                     149.15
+                  ],
+                  [
+                     "stick",
+                     149.15,
+                     149.54
+                  ],
+                  [
+                     "insect",
+                     149.54,
+                     150.05
+                  ],
+                  [
+                     "you",
+                     150.43,
+                     150.55
+                  ],
+                  [
+                     "would",
+                     150.55,
+                     150.68
+                  ],
+                  [
+                     "walk",
+                     150.68,
+                     150.93
+                  ],
+                  [
+                     "around",
+                     150.93,
+                     151.13
+                  ],
+                  [
+                     "the",
+                     151.13,
+                     151.19
+                  ],
+                  [
+                     "mine",
+                     151.19,
+                     151.48
+                  ],
+                  [
+                     "field",
+                     151.48,
+                     151.8
+                  ],
+                  [
+                     "on",
+                     151.8,
+                     151.89
+                  ],
+                  [
+                     "its",
+                     151.89,
+                     152.03
+                  ],
+                  [
+                     "legs",
+                     152.03,
+                     152.57
+                  ],
+                  [
+                     "and",
+                     152.89,
+                     153.07
+                  ],
+                  [
+                     "every",
+                     153.07,
+                     153.29
+                  ],
+                  [
+                     "time",
+                     153.29,
+                     153.46
+                  ],
+                  [
+                     "I",
+                     153.46,
+                     153.51
+                  ],
+                  [
+                     "stepped",
+                     153.51,
+                     153.88
+                  ],
+                  [
+                     "on",
+                     153.88,
+                     153.97
+                  ],
+                  [
+                     "a",
+                     153.97,
+                     154.02
+                  ],
+                  [
+                     "mine",
+                     154.02,
+                     154.4
+                  ],
+                  [
+                     "one",
+                     154.43,
+                     154.64
+                  ],
+                  [
+                     "of",
+                     154.64,
+                     154.71
+                  ],
+                  [
+                     "the",
+                     154.71,
+                     154.81
+                  ],
+                  [
+                     "legs",
+                     154.81,
+                     155.08
+                  ],
+                  [
+                     "would",
+                     155.08,
+                     155.2
+                  ],
+                  [
+                     "blow",
+                     155.2,
+                     155.43
+                  ],
+                  [
+                     "up",
+                     155.43,
+                     155.75
+                  ],
+                  [
+                     "would",
+                     155.86,
+                     156.02
+                  ],
+                  [
+                     "continue",
+                     156.02,
+                     156.51
+                  ],
+                  [
+                     "on",
+                     156.51,
+                     156.62
+                  ],
+                  [
+                     "the",
+                     156.62,
+                     156.69
+                  ],
+                  [
+                     "other",
+                     156.69,
+                     156.89
+                  ],
+                  [
+                     "likes",
+                     156.89,
+                     157.26
+                  ],
+                  [
+                     "to",
+                     157.26,
+                     157.38
+                  ],
+                  [
+                     "blow",
+                     157.38,
+                     157.56
+                  ],
+                  [
+                     "up",
+                     157.56,
+                     157.71
+                  ],
+                  [
+                     "our",
+                     157.71,
+                     157.81
+                  ],
+                  [
+                     "minds",
+                     157.81,
+                     158.36
+                  ]
+               ],
+               "confidence": 0.846,
+               "word_confidence": [
+                  [
+                     "in",
+                     1
+                  ],
+                  [
+                     "two",
+                     1
+                  ],
+                  [
+                     "thousand",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.805
+                  ],
+                  [
+                     "seven",
+                     0.995
+                  ],
+                  [
+                     "The",
+                     1
+                  ],
+                  [
+                     "Washington",
+                     1
+                  ],
+                  [
+                     "Post",
+                     1
+                  ],
+                  [
+                     "reported",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "United",
+                     1
+                  ],
+                  [
+                     "States",
+                     1
+                  ],
+                  [
+                     "military",
+                     0.997
+                  ],
+                  [
+                     "was",
+                     0.339
+                  ],
+                  [
+                     "testing",
+                     0.989
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "robot",
+                     1
+                  ],
+                  [
+                     "that",
+                     0.764
+                  ],
+                  [
+                     "defused",
+                     0.325
+                  ],
+                  [
+                     "land",
+                     0.86
+                  ],
+                  [
+                     "mines",
+                     0.86
+                  ],
+                  [
+                     "and",
+                     0.857
+                  ],
+                  [
+                     "we",
+                     0.681
+                  ],
+                  [
+                     "worked",
+                     0.568
+                  ],
+                  [
+                     "with",
+                     0.692
+                  ],
+                  [
+                     "it",
+                     0.087
+                  ],
+                  [
+                     "was",
+                     0.266
+                  ],
+                  [
+                     "shaped",
+                     0.691
+                  ],
+                  [
+                     "like",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "stick",
+                     0.956
+                  ],
+                  [
+                     "insect",
+                     0.812
+                  ],
+                  [
+                     "you",
+                     0.85
+                  ],
+                  [
+                     "would",
+                     0.988
+                  ],
+                  [
+                     "walk",
+                     1
+                  ],
+                  [
+                     "around",
+                     0.998
+                  ],
+                  [
+                     "the",
+                     0.428
+                  ],
+                  [
+                     "mine",
+                     0.659
+                  ],
+                  [
+                     "field",
+                     0.664
+                  ],
+                  [
+                     "on",
+                     0.723
+                  ],
+                  [
+                     "its",
+                     0.996
+                  ],
+                  [
+                     "legs",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.74
+                  ],
+                  [
+                     "every",
+                     0.763
+                  ],
+                  [
+                     "time",
+                     0.748
+                  ],
+                  [
+                     "I",
+                     0.252
+                  ],
+                  [
+                     "stepped",
+                     0.789
+                  ],
+                  [
+                     "on",
+                     0.981
+                  ],
+                  [
+                     "a",
+                     0.913
+                  ],
+                  [
+                     "mine",
+                     0.989
+                  ],
+                  [
+                     "one",
+                     0.965
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "legs",
+                     1
+                  ],
+                  [
+                     "would",
+                     0.608
+                  ],
+                  [
+                     "blow",
+                     1
+                  ],
+                  [
+                     "up",
+                     0.905
+                  ],
+                  [
+                     "would",
+                     0.632
+                  ],
+                  [
+                     "continue",
+                     1
+                  ],
+                  [
+                     "on",
+                     0.664
+                  ],
+                  [
+                     "the",
+                     0.988
+                  ],
+                  [
+                     "other",
+                     1
+                  ],
+                  [
+                     "likes",
+                     0.396
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "blow",
+                     0.413
+                  ],
+                  [
+                     "up",
+                     0.374
+                  ],
+                  [
+                     "our",
+                     0.116
+                  ],
+                  [
+                     "minds",
+                     0.678
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and the colonel who is in charge of this testing exercise in the calling it off ",
+               "timestamps": [
+                  [
+                     "and",
+                     159.22,
+                     159.49
+                  ],
+                  [
+                     "the",
+                     159.52,
+                     159.67
+                  ],
+                  [
+                     "colonel",
+                     159.67,
+                     160.12
+                  ],
+                  [
+                     "who",
+                     160.12,
+                     160.24
+                  ],
+                  [
+                     "is",
+                     160.24,
+                     160.34
+                  ],
+                  [
+                     "in",
+                     160.34,
+                     160.43
+                  ],
+                  [
+                     "charge",
+                     160.43,
+                     160.93
+                  ],
+                  [
+                     "of",
+                     160.93,
+                     161.01
+                  ],
+                  [
+                     "this",
+                     161.01,
+                     161.17
+                  ],
+                  [
+                     "testing",
+                     161.17,
+                     161.67
+                  ],
+                  [
+                     "exercise",
+                     161.67,
+                     162.67
+                  ],
+                  [
+                     "in",
+                     163.04,
+                     163.2
+                  ],
+                  [
+                     "the",
+                     163.2,
+                     163.31
+                  ],
+                  [
+                     "calling",
+                     163.31,
+                     163.79
+                  ],
+                  [
+                     "it",
+                     163.79,
+                     163.88
+                  ],
+                  [
+                     "off",
+                     163.88,
+                     164.42
+                  ]
+               ],
+               "confidence": 0.881,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.689
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "colonel",
+                     1
+                  ],
+                  [
+                     "who",
+                     0.553
+                  ],
+                  [
+                     "is",
+                     0.411
+                  ],
+                  [
+                     "in",
+                     1
+                  ],
+                  [
+                     "charge",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "testing",
+                     1
+                  ],
+                  [
+                     "exercise",
+                     0.79
+                  ],
+                  [
+                     "in",
+                     0.324
+                  ],
+                  [
+                     "the",
+                     0.528
+                  ],
+                  [
+                     "calling",
+                     1
+                  ],
+                  [
+                     "it",
+                     1
+                  ],
+                  [
+                     "off",
+                     0.993
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "because he says it's too in humane to watch this damage of robot drag itself along the mine field ",
+               "timestamps": [
+                  [
+                     "because",
+                     165.26,
+                     165.56
+                  ],
+                  [
+                     "he",
+                     165.56,
+                     165.73
+                  ],
+                  [
+                     "says",
+                     165.73,
+                     166.16
+                  ],
+                  [
+                     "it's",
+                     166.19,
+                     166.4
+                  ],
+                  [
+                     "too",
+                     166.4,
+                     166.75
+                  ],
+                  [
+                     "in",
+                     166.75,
+                     166.96
+                  ],
+                  [
+                     "humane",
+                     166.96,
+                     167.6
+                  ],
+                  [
+                     "to",
+                     167.6,
+                     167.81
+                  ],
+                  [
+                     "watch",
+                     167.81,
+                     168.3
+                  ],
+                  [
+                     "this",
+                     168.3,
+                     168.56
+                  ],
+                  [
+                     "damage",
+                     168.56,
+                     169
+                  ],
+                  [
+                     "of",
+                     169,
+                     169.16
+                  ],
+                  [
+                     "robot",
+                     169.16,
+                     169.61
+                  ],
+                  [
+                     "drag",
+                     169.61,
+                     170.04
+                  ],
+                  [
+                     "itself",
+                     170.04,
+                     170.44
+                  ],
+                  [
+                     "along",
+                     170.44,
+                     170.93
+                  ],
+                  [
+                     "the",
+                     171.31,
+                     171.42
+                  ],
+                  [
+                     "mine",
+                     171.42,
+                     171.68
+                  ],
+                  [
+                     "field",
+                     171.68,
+                     172.1
+                  ]
+               ],
+               "confidence": 0.696,
+               "word_confidence": [
+                  [
+                     "because",
+                     0.541
+                  ],
+                  [
+                     "he",
+                     0.752
+                  ],
+                  [
+                     "says",
+                     1
+                  ],
+                  [
+                     "it's",
+                     1
+                  ],
+                  [
+                     "too",
+                     0.851
+                  ],
+                  [
+                     "in",
+                     0.729
+                  ],
+                  [
+                     "humane",
+                     0.729
+                  ],
+                  [
+                     "to",
+                     0.957
+                  ],
+                  [
+                     "watch",
+                     0.762
+                  ],
+                  [
+                     "this",
+                     0.969
+                  ],
+                  [
+                     "damage",
+                     0.77
+                  ],
+                  [
+                     "of",
+                     0.572
+                  ],
+                  [
+                     "robot",
+                     0.881
+                  ],
+                  [
+                     "drag",
+                     0.198
+                  ],
+                  [
+                     "itself",
+                     0.6
+                  ],
+                  [
+                     "along",
+                     0.612
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "mine",
+                     0.393
+                  ],
+                  [
+                     "field",
+                     0.328
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "now what would cause a hardened military officer and someone like myself ",
+               "timestamps": [
+                  [
+                     "now",
+                     174.97,
+                     175.17
+                  ],
+                  [
+                     "what",
+                     175.17,
+                     175.39
+                  ],
+                  [
+                     "would",
+                     175.39,
+                     175.54
+                  ],
+                  [
+                     "cause",
+                     175.54,
+                     176.21
+                  ],
+                  [
+                     "a",
+                     176.24,
+                     176.36
+                  ],
+                  [
+                     "hardened",
+                     176.36,
+                     176.94
+                  ],
+                  [
+                     "military",
+                     176.94,
+                     177.65
+                  ],
+                  [
+                     "officer",
+                     177.65,
+                     178.5
+                  ],
+                  [
+                     "and",
+                     178.83,
+                     179.09
+                  ],
+                  [
+                     "someone",
+                     179.09,
+                     179.43
+                  ],
+                  [
+                     "like",
+                     179.43,
+                     179.59
+                  ],
+                  [
+                     "myself",
+                     179.59,
+                     180.33
+                  ]
+               ],
+               "confidence": 0.858,
+               "word_confidence": [
+                  [
+                     "now",
+                     0.382
+                  ],
+                  [
+                     "what",
+                     0.972
+                  ],
+                  [
+                     "would",
+                     0.341
+                  ],
+                  [
+                     "cause",
+                     0.868
+                  ],
+                  [
+                     "a",
+                     0.441
+                  ],
+                  [
+                     "hardened",
+                     0.806
+                  ],
+                  [
+                     "military",
+                     0.984
+                  ],
+                  [
+                     "officer",
+                     0.963
+                  ],
+                  [
+                     "and",
+                     0.357
+                  ],
+                  [
+                     "someone",
+                     0.995
+                  ],
+                  [
+                     "like",
+                     1
+                  ],
+                  [
+                     "myself",
+                     0.999
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "to have this response to robots ",
+               "timestamps": [
+                  [
+                     "to",
+                     180.95,
+                     181.08
+                  ],
+                  [
+                     "have",
+                     181.08,
+                     181.27
+                  ],
+                  [
+                     "this",
+                     181.27,
+                     181.41
+                  ],
+                  [
+                     "response",
+                     181.41,
+                     181.91
+                  ],
+                  [
+                     "to",
+                     181.91,
+                     182.04
+                  ],
+                  [
+                     "robots",
+                     182.04,
+                     182.75
+                  ]
+               ],
+               "confidence": 0.98,
+               "word_confidence": [
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "have",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "response",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.746
+                  ],
+                  [
+                     "robots",
+                     0.995
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "well of course for prime by science fiction pop culture to really want to personify these things but it goes a little bit deeper than that ",
+               "timestamps": [
+                  [
+                     "well",
+                     183.59,
+                     183.94
+                  ],
+                  [
+                     "of",
+                     184.07,
+                     184.2
+                  ],
+                  [
+                     "course",
+                     184.2,
+                     184.47
+                  ],
+                  [
+                     "for",
+                     184.47,
+                     184.61
+                  ],
+                  [
+                     "prime",
+                     184.61,
+                     185.16
+                  ],
+                  [
+                     "by",
+                     185.16,
+                     185.3
+                  ],
+                  [
+                     "science",
+                     185.3,
+                     185.74
+                  ],
+                  [
+                     "fiction",
+                     185.74,
+                     186.07
+                  ],
+                  [
+                     "pop",
+                     186.07,
+                     186.42
+                  ],
+                  [
+                     "culture",
+                     186.42,
+                     186.84
+                  ],
+                  [
+                     "to",
+                     186.84,
+                     186.95
+                  ],
+                  [
+                     "really",
+                     186.95,
+                     187.18
+                  ],
+                  [
+                     "want",
+                     187.18,
+                     187.32
+                  ],
+                  [
+                     "to",
+                     187.32,
+                     187.38
+                  ],
+                  [
+                     "personify",
+                     187.38,
+                     188.03
+                  ],
+                  [
+                     "these",
+                     188.03,
+                     188.29
+                  ],
+                  [
+                     "things",
+                     188.29,
+                     188.92
+                  ],
+                  [
+                     "but",
+                     189.47,
+                     189.72
+                  ],
+                  [
+                     "it",
+                     189.76,
+                     189.87
+                  ],
+                  [
+                     "goes",
+                     189.87,
+                     190.05
+                  ],
+                  [
+                     "a",
+                     190.05,
+                     190.12
+                  ],
+                  [
+                     "little",
+                     190.12,
+                     190.33
+                  ],
+                  [
+                     "bit",
+                     190.33,
+                     190.48
+                  ],
+                  [
+                     "deeper",
+                     190.48,
+                     190.76
+                  ],
+                  [
+                     "than",
+                     190.76,
+                     190.92
+                  ],
+                  [
+                     "that",
+                     190.92,
+                     191.13
+                  ]
+               ],
+               "confidence": 0.774,
+               "word_confidence": [
+                  [
+                     "well",
+                     0.516
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "course",
+                     1
+                  ],
+                  [
+                     "for",
+                     0.666
+                  ],
+                  [
+                     "prime",
+                     0.576
+                  ],
+                  [
+                     "by",
+                     0.861
+                  ],
+                  [
+                     "science",
+                     0.758
+                  ],
+                  [
+                     "fiction",
+                     0.928
+                  ],
+                  [
+                     "pop",
+                     0.983
+                  ],
+                  [
+                     "culture",
+                     0.962
+                  ],
+                  [
+                     "to",
+                     0.226
+                  ],
+                  [
+                     "really",
+                     0.982
+                  ],
+                  [
+                     "want",
+                     0.38
+                  ],
+                  [
+                     "to",
+                     0.356
+                  ],
+                  [
+                     "personify",
+                     0.616
+                  ],
+                  [
+                     "these",
+                     0.774
+                  ],
+                  [
+                     "things",
+                     1
+                  ],
+                  [
+                     "but",
+                     0.952
+                  ],
+                  [
+                     "it",
+                     0.549
+                  ],
+                  [
+                     "goes",
+                     0.776
+                  ],
+                  [
+                     "a",
+                     0.97
+                  ],
+                  [
+                     "little",
+                     1
+                  ],
+                  [
+                     "bit",
+                     0.887
+                  ],
+                  [
+                     "deeper",
+                     0.637
+                  ],
+                  [
+                     "than",
+                     0.778
+                  ],
+                  [
+                     "that",
+                     0.335
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "it turns out that we're biologically hard wired to project intent and life on to any movement in our physical space it seems a communist ",
+               "timestamps": [
+                  [
+                     "it",
+                     192.24,
+                     192.37
+                  ],
+                  [
+                     "turns",
+                     192.37,
+                     192.68
+                  ],
+                  [
+                     "out",
+                     192.68,
+                     192.8
+                  ],
+                  [
+                     "that",
+                     192.8,
+                     192.92
+                  ],
+                  [
+                     "we're",
+                     192.92,
+                     193.06
+                  ],
+                  [
+                     "biologically",
+                     193.06,
+                     193.94
+                  ],
+                  [
+                     "hard",
+                     193.94,
+                     194.47
+                  ],
+                  [
+                     "wired",
+                     194.47,
+                     194.93
+                  ],
+                  [
+                     "to",
+                     194.93,
+                     195.08
+                  ],
+                  [
+                     "project",
+                     195.08,
+                     195.79
+                  ],
+                  [
+                     "intent",
+                     196.1,
+                     196.85
+                  ],
+                  [
+                     "and",
+                     196.88,
+                     197.19
+                  ],
+                  [
+                     "life",
+                     197.19,
+                     197.59
+                  ],
+                  [
+                     "on",
+                     197.59,
+                     197.79
+                  ],
+                  [
+                     "to",
+                     197.79,
+                     198.24
+                  ],
+                  [
+                     "any",
+                     198.57,
+                     198.78
+                  ],
+                  [
+                     "movement",
+                     198.78,
+                     199.37
+                  ],
+                  [
+                     "in",
+                     199.37,
+                     199.46
+                  ],
+                  [
+                     "our",
+                     199.46,
+                     199.57
+                  ],
+                  [
+                     "physical",
+                     199.57,
+                     200.11
+                  ],
+                  [
+                     "space",
+                     200.11,
+                     200.5
+                  ],
+                  [
+                     "it",
+                     200.5,
+                     200.65
+                  ],
+                  [
+                     "seems",
+                     200.65,
+                     201.13
+                  ],
+                  [
+                     "a",
+                     201.13,
+                     201.2
+                  ],
+                  [
+                     "communist",
+                     201.2,
+                     201.89
+                  ]
+               ],
+               "confidence": 0.826,
+               "word_confidence": [
+                  [
+                     "it",
+                     1
+                  ],
+                  [
+                     "turns",
+                     0.787
+                  ],
+                  [
+                     "out",
+                     0.982
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "we're",
+                     0.358
+                  ],
+                  [
+                     "biologically",
+                     1
+                  ],
+                  [
+                     "hard",
+                     0.497
+                  ],
+                  [
+                     "wired",
+                     0.497
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "project",
+                     1
+                  ],
+                  [
+                     "intent",
+                     0.806
+                  ],
+                  [
+                     "and",
+                     0.86
+                  ],
+                  [
+                     "life",
+                     0.905
+                  ],
+                  [
+                     "on",
+                     0.797
+                  ],
+                  [
+                     "to",
+                     0.8
+                  ],
+                  [
+                     "any",
+                     1
+                  ],
+                  [
+                     "movement",
+                     1
+                  ],
+                  [
+                     "in",
+                     0.64
+                  ],
+                  [
+                     "our",
+                     0.776
+                  ],
+                  [
+                     "physical",
+                     1
+                  ],
+                  [
+                     "space",
+                     0.74
+                  ],
+                  [
+                     "it",
+                     0.391
+                  ],
+                  [
+                     "seems",
+                     0.984
+                  ],
+                  [
+                     "a",
+                     0.231
+                  ],
+                  [
+                     "communist",
+                     0.655
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "some people treat all sorts of robots like their life ",
+               "timestamps": [
+                  [
+                     "some",
+                     203.2,
+                     203.39
+                  ],
+                  [
+                     "people",
+                     203.39,
+                     203.74
+                  ],
+                  [
+                     "treat",
+                     203.74,
+                     203.99
+                  ],
+                  [
+                     "all",
+                     204.02,
+                     204.2
+                  ],
+                  [
+                     "sorts",
+                     204.2,
+                     204.46
+                  ],
+                  [
+                     "of",
+                     204.46,
+                     204.57
+                  ],
+                  [
+                     "robots",
+                     204.57,
+                     204.93
+                  ],
+                  [
+                     "like",
+                     204.93,
+                     205.1
+                  ],
+                  [
+                     "their",
+                     205.1,
+                     205.28
+                  ],
+                  [
+                     "life",
+                     205.28,
+                     205.85
+                  ]
+               ],
+               "confidence": 0.66,
+               "word_confidence": [
+                  [
+                     "some",
+                     0.44
+                  ],
+                  [
+                     "people",
+                     0.855
+                  ],
+                  [
+                     "treat",
+                     1
+                  ],
+                  [
+                     "all",
+                     0.872
+                  ],
+                  [
+                     "sorts",
+                     0.38
+                  ],
+                  [
+                     "of",
+                     0.48
+                  ],
+                  [
+                     "robots",
+                     0.766
+                  ],
+                  [
+                     "like",
+                     0.841
+                  ],
+                  [
+                     "their",
+                     0.893
+                  ],
+                  [
+                     "life",
+                     0.365
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "these bomb disposal units get names they get medals of honor they've had funerals for them with gun salute ",
+               "timestamps": [
+                  [
+                     "these",
+                     206.69,
+                     206.91
+                  ],
+                  [
+                     "bomb",
+                     206.91,
+                     207.23
+                  ],
+                  [
+                     "disposal",
+                     207.23,
+                     208
+                  ],
+                  [
+                     "units",
+                     208.03,
+                     208.56
+                  ],
+                  [
+                     "get",
+                     208.56,
+                     208.76
+                  ],
+                  [
+                     "names",
+                     208.76,
+                     209.35
+                  ],
+                  [
+                     "they",
+                     209.38,
+                     209.53
+                  ],
+                  [
+                     "get",
+                     209.53,
+                     209.72
+                  ],
+                  [
+                     "medals",
+                     209.72,
+                     210.15
+                  ],
+                  [
+                     "of",
+                     210.15,
+                     210.26
+                  ],
+                  [
+                     "honor",
+                     210.26,
+                     210.77
+                  ],
+                  [
+                     "they've",
+                     211.09,
+                     211.27
+                  ],
+                  [
+                     "had",
+                     211.27,
+                     211.4
+                  ],
+                  [
+                     "funerals",
+                     211.4,
+                     212.01
+                  ],
+                  [
+                     "for",
+                     212.01,
+                     212.17
+                  ],
+                  [
+                     "them",
+                     212.17,
+                     212.34
+                  ],
+                  [
+                     "with",
+                     212.34,
+                     212.53
+                  ],
+                  [
+                     "gun",
+                     212.53,
+                     212.77
+                  ],
+                  [
+                     "salute",
+                     212.77,
+                     213.18
+                  ]
+               ],
+               "confidence": 0.85,
+               "word_confidence": [
+                  [
+                     "these",
+                     0.777
+                  ],
+                  [
+                     "bomb",
+                     1
+                  ],
+                  [
+                     "disposal",
+                     1
+                  ],
+                  [
+                     "units",
+                     0.299
+                  ],
+                  [
+                     "get",
+                     0.47
+                  ],
+                  [
+                     "names",
+                     0.993
+                  ],
+                  [
+                     "they",
+                     1
+                  ],
+                  [
+                     "get",
+                     0.764
+                  ],
+                  [
+                     "medals",
+                     0.944
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "honor",
+                     0.989
+                  ],
+                  [
+                     "they've",
+                     0.627
+                  ],
+                  [
+                     "had",
+                     0.959
+                  ],
+                  [
+                     "funerals",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "them",
+                     0.613
+                  ],
+                  [
+                     "with",
+                     0.794
+                  ],
+                  [
+                     "gun",
+                     0.912
+                  ],
+                  [
+                     "salute",
+                     0.728
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and research shows that we do this even with very simple household robots like the rumor vacuum cleaner ",
+               "timestamps": [
+                  [
+                     "and",
+                     214.35,
+                     214.59
+                  ],
+                  [
+                     "research",
+                     214.95,
+                     215.37
+                  ],
+                  [
+                     "shows",
+                     215.37,
+                     215.57
+                  ],
+                  [
+                     "that",
+                     215.57,
+                     215.66
+                  ],
+                  [
+                     "we",
+                     215.66,
+                     215.76
+                  ],
+                  [
+                     "do",
+                     215.76,
+                     215.86
+                  ],
+                  [
+                     "this",
+                     215.86,
+                     216.03
+                  ],
+                  [
+                     "even",
+                     216.03,
+                     216.31
+                  ],
+                  [
+                     "with",
+                     216.31,
+                     216.44
+                  ],
+                  [
+                     "very",
+                     216.44,
+                     216.78
+                  ],
+                  [
+                     "simple",
+                     216.78,
+                     217.16
+                  ],
+                  [
+                     "household",
+                     217.16,
+                     217.75
+                  ],
+                  [
+                     "robots",
+                     217.75,
+                     218.25
+                  ],
+                  [
+                     "like",
+                     218.25,
+                     218.57
+                  ],
+                  [
+                     "the",
+                     218.83,
+                     218.98
+                  ],
+                  [
+                     "rumor",
+                     218.98,
+                     219.4
+                  ],
+                  [
+                     "vacuum",
+                     219.4,
+                     219.81
+                  ],
+                  [
+                     "cleaner",
+                     219.81,
+                     220.3
+                  ]
+               ],
+               "confidence": 0.859,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.835
+                  ],
+                  [
+                     "research",
+                     0.793
+                  ],
+                  [
+                     "shows",
+                     0.476
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "we",
+                     0.972
+                  ],
+                  [
+                     "do",
+                     0.847
+                  ],
+                  [
+                     "this",
+                     0.973
+                  ],
+                  [
+                     "even",
+                     0.976
+                  ],
+                  [
+                     "with",
+                     0.974
+                  ],
+                  [
+                     "very",
+                     0.912
+                  ],
+                  [
+                     "simple",
+                     1
+                  ],
+                  [
+                     "household",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.936
+                  ],
+                  [
+                     "like",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "rumor",
+                     0.28
+                  ],
+                  [
+                     "vacuum",
+                     0.979
+                  ],
+                  [
+                     "cleaner",
+                     0.769
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "just the desk that roams around your floor to clean it which is the fact that it's moving around on its own will cause people to name the room and feel bad for the room but when it gets stuck under the couch ",
+               "timestamps": [
+                  [
+                     "just",
+                     221.68,
+                     221.9
+                  ],
+                  [
+                     "the",
+                     221.9,
+                     221.99
+                  ],
+                  [
+                     "desk",
+                     221.99,
+                     222.48
+                  ],
+                  [
+                     "that",
+                     222.48,
+                     222.68
+                  ],
+                  [
+                     "roams",
+                     222.68,
+                     222.97
+                  ],
+                  [
+                     "around",
+                     222.97,
+                     223.24
+                  ],
+                  [
+                     "your",
+                     223.24,
+                     223.35
+                  ],
+                  [
+                     "floor",
+                     223.35,
+                     223.77
+                  ],
+                  [
+                     "to",
+                     223.77,
+                     223.86
+                  ],
+                  [
+                     "clean",
+                     223.86,
+                     224.23
+                  ],
+                  [
+                     "it",
+                     224.23,
+                     224.45
+                  ],
+                  [
+                     "which",
+                     224.77,
+                     224.9
+                  ],
+                  [
+                     "is",
+                     224.9,
+                     225
+                  ],
+                  [
+                     "the",
+                     225,
+                     225.1
+                  ],
+                  [
+                     "fact",
+                     225.1,
+                     225.43
+                  ],
+                  [
+                     "that",
+                     225.43,
+                     225.56
+                  ],
+                  [
+                     "it's",
+                     225.56,
+                     225.72
+                  ],
+                  [
+                     "moving",
+                     225.72,
+                     226.22
+                  ],
+                  [
+                     "around",
+                     226.22,
+                     226.54
+                  ],
+                  [
+                     "on",
+                     226.54,
+                     226.66
+                  ],
+                  [
+                     "its",
+                     226.66,
+                     226.78
+                  ],
+                  [
+                     "own",
+                     226.78,
+                     227.09
+                  ],
+                  [
+                     "will",
+                     227.09,
+                     227.21
+                  ],
+                  [
+                     "cause",
+                     227.21,
+                     227.53
+                  ],
+                  [
+                     "people",
+                     227.53,
+                     227.78
+                  ],
+                  [
+                     "to",
+                     227.78,
+                     227.96
+                  ],
+                  [
+                     "name",
+                     227.96,
+                     228.36
+                  ],
+                  [
+                     "the",
+                     228.36,
+                     228.48
+                  ],
+                  [
+                     "room",
+                     228.48,
+                     228.81
+                  ],
+                  [
+                     "and",
+                     229.31,
+                     229.48
+                  ],
+                  [
+                     "feel",
+                     229.48,
+                     229.7
+                  ],
+                  [
+                     "bad",
+                     229.7,
+                     230.11
+                  ],
+                  [
+                     "for",
+                     230.11,
+                     230.27
+                  ],
+                  [
+                     "the",
+                     230.27,
+                     230.38
+                  ],
+                  [
+                     "room",
+                     230.38,
+                     230.59
+                  ],
+                  [
+                     "but",
+                     230.59,
+                     230.75
+                  ],
+                  [
+                     "when",
+                     230.75,
+                     230.87
+                  ],
+                  [
+                     "it",
+                     230.87,
+                     230.93
+                  ],
+                  [
+                     "gets",
+                     230.93,
+                     231.09
+                  ],
+                  [
+                     "stuck",
+                     231.09,
+                     231.43
+                  ],
+                  [
+                     "under",
+                     231.43,
+                     231.6
+                  ],
+                  [
+                     "the",
+                     231.6,
+                     231.72
+                  ],
+                  [
+                     "couch",
+                     231.72,
+                     232.45
+                  ]
+               ],
+               "confidence": 0.845,
+               "word_confidence": [
+                  [
+                     "just",
+                     1
+                  ],
+                  [
+                     "the",
+                     0.416
+                  ],
+                  [
+                     "desk",
+                     0.485
+                  ],
+                  [
+                     "that",
+                     0.994
+                  ],
+                  [
+                     "roams",
+                     0.398
+                  ],
+                  [
+                     "around",
+                     1
+                  ],
+                  [
+                     "your",
+                     0.762
+                  ],
+                  [
+                     "floor",
+                     0.286
+                  ],
+                  [
+                     "to",
+                     0.286
+                  ],
+                  [
+                     "clean",
+                     0.883
+                  ],
+                  [
+                     "it",
+                     0.924
+                  ],
+                  [
+                     "which",
+                     0.436
+                  ],
+                  [
+                     "is",
+                     0.499
+                  ],
+                  [
+                     "the",
+                     0.849
+                  ],
+                  [
+                     "fact",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "it's",
+                     0.872
+                  ],
+                  [
+                     "moving",
+                     1
+                  ],
+                  [
+                     "around",
+                     1
+                  ],
+                  [
+                     "on",
+                     0.976
+                  ],
+                  [
+                     "its",
+                     0.713
+                  ],
+                  [
+                     "own",
+                     0.99
+                  ],
+                  [
+                     "will",
+                     0.767
+                  ],
+                  [
+                     "cause",
+                     1
+                  ],
+                  [
+                     "people",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "name",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "room",
+                     0.745
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "feel",
+                     1
+                  ],
+                  [
+                     "bad",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "room",
+                     0.708
+                  ],
+                  [
+                     "but",
+                     0.608
+                  ],
+                  [
+                     "when",
+                     0.833
+                  ],
+                  [
+                     "it",
+                     0.22
+                  ],
+                  [
+                     "gets",
+                     0.356
+                  ],
+                  [
+                     "stuck",
+                     1
+                  ],
+                  [
+                     "under",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "couch",
+                     0.995
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and we can design robot specifically to invoke this response using our eyes and faces or movements the people automatically subconsciously associate with states of mind ",
+               "timestamps": [
+                  [
+                     "and",
+                     234.43,
+                     234.59
+                  ],
+                  [
+                     "we",
+                     234.59,
+                     234.71
+                  ],
+                  [
+                     "can",
+                     234.71,
+                     234.85
+                  ],
+                  [
+                     "design",
+                     234.85,
+                     235.28
+                  ],
+                  [
+                     "robot",
+                     235.28,
+                     235.65
+                  ],
+                  [
+                     "specifically",
+                     235.65,
+                     236.48
+                  ],
+                  [
+                     "to",
+                     236.48,
+                     236.63
+                  ],
+                  [
+                     "invoke",
+                     236.63,
+                     236.99
+                  ],
+                  [
+                     "this",
+                     236.99,
+                     237.18
+                  ],
+                  [
+                     "response",
+                     237.18,
+                     237.74
+                  ],
+                  [
+                     "using",
+                     237.74,
+                     238.14
+                  ],
+                  [
+                     "our",
+                     238.2,
+                     238.37
+                  ],
+                  [
+                     "eyes",
+                     238.37,
+                     238.91
+                  ],
+                  [
+                     "and",
+                     239.18,
+                     239.36
+                  ],
+                  [
+                     "faces",
+                     239.36,
+                     240.22
+                  ],
+                  [
+                     "or",
+                     240.3,
+                     240.6
+                  ],
+                  [
+                     "movements",
+                     240.6,
+                     241.26
+                  ],
+                  [
+                     "the",
+                     241.26,
+                     241.37
+                  ],
+                  [
+                     "people",
+                     241.37,
+                     241.66
+                  ],
+                  [
+                     "automatically",
+                     241.66,
+                     242.51
+                  ],
+                  [
+                     "subconsciously",
+                     242.51,
+                     243.45
+                  ],
+                  [
+                     "associate",
+                     243.45,
+                     244.37
+                  ],
+                  [
+                     "with",
+                     244.49,
+                     244.73
+                  ],
+                  [
+                     "states",
+                     244.73,
+                     245.06
+                  ],
+                  [
+                     "of",
+                     245.06,
+                     245.17
+                  ],
+                  [
+                     "mind",
+                     245.17,
+                     245.71
+                  ]
+               ],
+               "confidence": 0.824,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "can",
+                     1
+                  ],
+                  [
+                     "design",
+                     0.542
+                  ],
+                  [
+                     "robot",
+                     0.403
+                  ],
+                  [
+                     "specifically",
+                     0.975
+                  ],
+                  [
+                     "to",
+                     0.995
+                  ],
+                  [
+                     "invoke",
+                     0.231
+                  ],
+                  [
+                     "this",
+                     0.977
+                  ],
+                  [
+                     "response",
+                     0.992
+                  ],
+                  [
+                     "using",
+                     0.995
+                  ],
+                  [
+                     "our",
+                     0.645
+                  ],
+                  [
+                     "eyes",
+                     0.866
+                  ],
+                  [
+                     "and",
+                     0.395
+                  ],
+                  [
+                     "faces",
+                     0.855
+                  ],
+                  [
+                     "or",
+                     0.516
+                  ],
+                  [
+                     "movements",
+                     0.817
+                  ],
+                  [
+                     "the",
+                     0.774
+                  ],
+                  [
+                     "people",
+                     0.988
+                  ],
+                  [
+                     "automatically",
+                     0.972
+                  ],
+                  [
+                     "subconsciously",
+                     1
+                  ],
+                  [
+                     "associate",
+                     1
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "states",
+                     0.608
+                  ],
+                  [
+                     "of",
+                     0.971
+                  ],
+                  [
+                     "mind",
+                     0.349
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and there's an entire body of research called human robot interaction that really shows how well this works so for example researchers at Stanford University found out that it makes people really uncomfortable when you ask them to touch a robust private parts ",
+               "timestamps": [
+                  [
+                     "and",
+                     246.57,
+                     246.71
+                  ],
+                  [
+                     "there's",
+                     246.71,
+                     246.85
+                  ],
+                  [
+                     "an",
+                     246.85,
+                     246.95
+                  ],
+                  [
+                     "entire",
+                     246.95,
+                     247.34
+                  ],
+                  [
+                     "body",
+                     247.34,
+                     247.57
+                  ],
+                  [
+                     "of",
+                     247.57,
+                     247.68
+                  ],
+                  [
+                     "research",
+                     247.68,
+                     248.09
+                  ],
+                  [
+                     "called",
+                     248.09,
+                     248.32
+                  ],
+                  [
+                     "human",
+                     248.32,
+                     248.56
+                  ],
+                  [
+                     "robot",
+                     248.56,
+                     248.85
+                  ],
+                  [
+                     "interaction",
+                     248.85,
+                     249.34
+                  ],
+                  [
+                     "that",
+                     249.34,
+                     249.54
+                  ],
+                  [
+                     "really",
+                     249.65,
+                     249.9
+                  ],
+                  [
+                     "shows",
+                     249.9,
+                     250.38
+                  ],
+                  [
+                     "how",
+                     250.38,
+                     250.51
+                  ],
+                  [
+                     "well",
+                     250.51,
+                     250.69
+                  ],
+                  [
+                     "this",
+                     250.69,
+                     250.87
+                  ],
+                  [
+                     "works",
+                     250.87,
+                     251.33
+                  ],
+                  [
+                     "so",
+                     251.67,
+                     251.85
+                  ],
+                  [
+                     "for",
+                     251.85,
+                     252.01
+                  ],
+                  [
+                     "example",
+                     252.01,
+                     252.54
+                  ],
+                  [
+                     "researchers",
+                     252.54,
+                     253.11
+                  ],
+                  [
+                     "at",
+                     253.11,
+                     253.31
+                  ],
+                  [
+                     "Stanford",
+                     253.41,
+                     253.96
+                  ],
+                  [
+                     "University",
+                     253.96,
+                     254.46
+                  ],
+                  [
+                     "found",
+                     254.46,
+                     254.74
+                  ],
+                  [
+                     "out",
+                     254.74,
+                     254.92
+                  ],
+                  [
+                     "that",
+                     254.92,
+                     255.03
+                  ],
+                  [
+                     "it",
+                     255.03,
+                     255.09
+                  ],
+                  [
+                     "makes",
+                     255.09,
+                     255.3
+                  ],
+                  [
+                     "people",
+                     255.3,
+                     255.63
+                  ],
+                  [
+                     "really",
+                     255.63,
+                     255.9
+                  ],
+                  [
+                     "uncomfortable",
+                     255.9,
+                     256.55
+                  ],
+                  [
+                     "when",
+                     256.55,
+                     256.67
+                  ],
+                  [
+                     "you",
+                     256.67,
+                     256.75
+                  ],
+                  [
+                     "ask",
+                     256.75,
+                     257.04
+                  ],
+                  [
+                     "them",
+                     257.04,
+                     257.15
+                  ],
+                  [
+                     "to",
+                     257.15,
+                     257.26
+                  ],
+                  [
+                     "touch",
+                     257.26,
+                     257.52
+                  ],
+                  [
+                     "a",
+                     257.52,
+                     257.59
+                  ],
+                  [
+                     "robust",
+                     257.59,
+                     257.98
+                  ],
+                  [
+                     "private",
+                     257.98,
+                     258.36
+                  ],
+                  [
+                     "parts",
+                     258.36,
+                     258.95
+                  ]
+               ],
+               "confidence": 0.902,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.989
+                  ],
+                  [
+                     "there's",
+                     0.575
+                  ],
+                  [
+                     "an",
+                     0.968
+                  ],
+                  [
+                     "entire",
+                     1
+                  ],
+                  [
+                     "body",
+                     1
+                  ],
+                  [
+                     "of",
+                     0.801
+                  ],
+                  [
+                     "research",
+                     1
+                  ],
+                  [
+                     "called",
+                     0.839
+                  ],
+                  [
+                     "human",
+                     0.993
+                  ],
+                  [
+                     "robot",
+                     1
+                  ],
+                  [
+                     "interaction",
+                     1
+                  ],
+                  [
+                     "that",
+                     0.575
+                  ],
+                  [
+                     "really",
+                     1
+                  ],
+                  [
+                     "shows",
+                     1
+                  ],
+                  [
+                     "how",
+                     1
+                  ],
+                  [
+                     "well",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "works",
+                     1
+                  ],
+                  [
+                     "so",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "example",
+                     1
+                  ],
+                  [
+                     "researchers",
+                     1
+                  ],
+                  [
+                     "at",
+                     1
+                  ],
+                  [
+                     "Stanford",
+                     1
+                  ],
+                  [
+                     "University",
+                     1
+                  ],
+                  [
+                     "found",
+                     1
+                  ],
+                  [
+                     "out",
+                     1
+                  ],
+                  [
+                     "that",
+                     0.99
+                  ],
+                  [
+                     "it",
+                     0.548
+                  ],
+                  [
+                     "makes",
+                     1
+                  ],
+                  [
+                     "people",
+                     1
+                  ],
+                  [
+                     "really",
+                     1
+                  ],
+                  [
+                     "uncomfortable",
+                     0.818
+                  ],
+                  [
+                     "when",
+                     0.711
+                  ],
+                  [
+                     "you",
+                     0.847
+                  ],
+                  [
+                     "ask",
+                     0.638
+                  ],
+                  [
+                     "them",
+                     0.633
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "touch",
+                     0.973
+                  ],
+                  [
+                     "a",
+                     0.378
+                  ],
+                  [
+                     "robust",
+                     0.058
+                  ],
+                  [
+                     "private",
+                     1
+                  ],
+                  [
+                     "parts",
+                     0.681
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "so from this but from many other studies we know we know the people respond to the cues given to them by these life like machines even if they know that they're not real ",
+               "timestamps": [
+                  [
+                     "so",
+                     261.63,
+                     261.73
+                  ],
+                  [
+                     "from",
+                     261.73,
+                     261.92
+                  ],
+                  [
+                     "this",
+                     261.92,
+                     262.08
+                  ],
+                  [
+                     "but",
+                     262.08,
+                     262.26
+                  ],
+                  [
+                     "from",
+                     262.26,
+                     262.45
+                  ],
+                  [
+                     "many",
+                     262.45,
+                     262.79
+                  ],
+                  [
+                     "other",
+                     262.79,
+                     262.96
+                  ],
+                  [
+                     "studies",
+                     262.96,
+                     263.36
+                  ],
+                  [
+                     "we",
+                     263.36,
+                     263.55
+                  ],
+                  [
+                     "know",
+                     263.55,
+                     264.11
+                  ],
+                  [
+                     "we",
+                     264.39,
+                     264.65
+                  ],
+                  [
+                     "know",
+                     264.65,
+                     265.03
+                  ],
+                  [
+                     "the",
+                     265.03,
+                     265.22
+                  ],
+                  [
+                     "people",
+                     265.22,
+                     265.77
+                  ],
+                  [
+                     "respond",
+                     265.77,
+                     266.41
+                  ],
+                  [
+                     "to",
+                     266.41,
+                     266.51
+                  ],
+                  [
+                     "the",
+                     266.51,
+                     266.63
+                  ],
+                  [
+                     "cues",
+                     266.63,
+                     267.24
+                  ],
+                  [
+                     "given",
+                     267.27,
+                     267.55
+                  ],
+                  [
+                     "to",
+                     267.55,
+                     267.66
+                  ],
+                  [
+                     "them",
+                     267.66,
+                     267.84
+                  ],
+                  [
+                     "by",
+                     267.84,
+                     267.98
+                  ],
+                  [
+                     "these",
+                     267.98,
+                     268.2
+                  ],
+                  [
+                     "life",
+                     268.2,
+                     268.5
+                  ],
+                  [
+                     "like",
+                     268.5,
+                     268.68
+                  ],
+                  [
+                     "machines",
+                     268.68,
+                     269.45
+                  ],
+                  [
+                     "even",
+                     269.88,
+                     270.19
+                  ],
+                  [
+                     "if",
+                     270.19,
+                     270.29
+                  ],
+                  [
+                     "they",
+                     270.29,
+                     270.4
+                  ],
+                  [
+                     "know",
+                     270.4,
+                     270.64
+                  ],
+                  [
+                     "that",
+                     270.64,
+                     270.82
+                  ],
+                  [
+                     "they're",
+                     270.82,
+                     271
+                  ],
+                  [
+                     "not",
+                     271,
+                     271.24
+                  ],
+                  [
+                     "real",
+                     271.24,
+                     271.59
+                  ]
+               ],
+               "confidence": 0.869,
+               "word_confidence": [
+                  [
+                     "so",
+                     0.234
+                  ],
+                  [
+                     "from",
+                     0.863
+                  ],
+                  [
+                     "this",
+                     0.472
+                  ],
+                  [
+                     "but",
+                     0.651
+                  ],
+                  [
+                     "from",
+                     0.524
+                  ],
+                  [
+                     "many",
+                     0.94
+                  ],
+                  [
+                     "other",
+                     0.841
+                  ],
+                  [
+                     "studies",
+                     0.924
+                  ],
+                  [
+                     "we",
+                     0.947
+                  ],
+                  [
+                     "know",
+                     0.384
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "know",
+                     0.984
+                  ],
+                  [
+                     "the",
+                     0.538
+                  ],
+                  [
+                     "people",
+                     0.953
+                  ],
+                  [
+                     "respond",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "cues",
+                     0.999
+                  ],
+                  [
+                     "given",
+                     0.968
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "them",
+                     1
+                  ],
+                  [
+                     "by",
+                     1
+                  ],
+                  [
+                     "these",
+                     0.383
+                  ],
+                  [
+                     "life",
+                     0.823
+                  ],
+                  [
+                     "like",
+                     0.857
+                  ],
+                  [
+                     "machines",
+                     0.99
+                  ],
+                  [
+                     "even",
+                     1
+                  ],
+                  [
+                     "if",
+                     0.56
+                  ],
+                  [
+                     "they",
+                     1
+                  ],
+                  [
+                     "know",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "they're",
+                     0.785
+                  ],
+                  [
+                     "not",
+                     1
+                  ],
+                  [
+                     "real",
+                     0.992
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "now we're headed towards a world where robots are everywhere robotic technology is moving out from behind factory walls it's entering workplaces households and as these machines that can fence and make autonomous decisions and learn enter into the shared spaces I think that maybe the best analogy we have for this is our relationship with animals thousands of years ago we started to domesticate animals and we train them for work and weaponry and companionship and throughout history was treated some animals like tools or like products and other animals we treated with kindness we've given a place in society as our companions ",
+               "timestamps": [
+                  [
+                     "now",
+                     273.6,
+                     274.14
+                  ],
+                  [
+                     "we're",
+                     274.49,
+                     274.66
+                  ],
+                  [
+                     "headed",
+                     274.66,
+                     274.95
+                  ],
+                  [
+                     "towards",
+                     274.95,
+                     275.2
+                  ],
+                  [
+                     "a",
+                     275.2,
+                     275.26
+                  ],
+                  [
+                     "world",
+                     275.26,
+                     275.69
+                  ],
+                  [
+                     "where",
+                     275.69,
+                     275.85
+                  ],
+                  [
+                     "robots",
+                     275.85,
+                     276.32
+                  ],
+                  [
+                     "are",
+                     276.32,
+                     276.52
+                  ],
+                  [
+                     "everywhere",
+                     276.55,
+                     277.13
+                  ],
+                  [
+                     "robotic",
+                     277.66,
+                     278.03
+                  ],
+                  [
+                     "technology",
+                     278.03,
+                     278.57
+                  ],
+                  [
+                     "is",
+                     278.57,
+                     278.82
+                  ],
+                  [
+                     "moving",
+                     278.82,
+                     279.21
+                  ],
+                  [
+                     "out",
+                     279.21,
+                     279.4
+                  ],
+                  [
+                     "from",
+                     279.4,
+                     279.55
+                  ],
+                  [
+                     "behind",
+                     279.55,
+                     279.82
+                  ],
+                  [
+                     "factory",
+                     279.82,
+                     280.24
+                  ],
+                  [
+                     "walls",
+                     280.24,
+                     280.76
+                  ],
+                  [
+                     "it's",
+                     280.76,
+                     280.95
+                  ],
+                  [
+                     "entering",
+                     280.95,
+                     281.38
+                  ],
+                  [
+                     "workplaces",
+                     281.41,
+                     282.31
+                  ],
+                  [
+                     "households",
+                     282.31,
+                     283.32
+                  ],
+                  [
+                     "and",
+                     283.82,
+                     284.1
+                  ],
+                  [
+                     "as",
+                     284.13,
+                     284.33
+                  ],
+                  [
+                     "these",
+                     284.33,
+                     284.53
+                  ],
+                  [
+                     "machines",
+                     284.53,
+                     285.21
+                  ],
+                  [
+                     "that",
+                     285.21,
+                     285.36
+                  ],
+                  [
+                     "can",
+                     285.36,
+                     285.86
+                  ],
+                  [
+                     "fence",
+                     285.89,
+                     286.57
+                  ],
+                  [
+                     "and",
+                     286.57,
+                     286.98
+                  ],
+                  [
+                     "make",
+                     287.21,
+                     287.43
+                  ],
+                  [
+                     "autonomous",
+                     287.43,
+                     288.01
+                  ],
+                  [
+                     "decisions",
+                     288.01,
+                     288.67
+                  ],
+                  [
+                     "and",
+                     288.67,
+                     288.91
+                  ],
+                  [
+                     "learn",
+                     288.91,
+                     289.54
+                  ],
+                  [
+                     "enter",
+                     290.05,
+                     290.37
+                  ],
+                  [
+                     "into",
+                     290.37,
+                     290.57
+                  ],
+                  [
+                     "the",
+                     290.57,
+                     290.7
+                  ],
+                  [
+                     "shared",
+                     290.7,
+                     291.07
+                  ],
+                  [
+                     "spaces",
+                     291.07,
+                     292.1
+                  ],
+                  [
+                     "I",
+                     292.64,
+                     292.76
+                  ],
+                  [
+                     "think",
+                     292.76,
+                     292.99
+                  ],
+                  [
+                     "that",
+                     292.99,
+                     293.18
+                  ],
+                  [
+                     "maybe",
+                     293.18,
+                     293.41
+                  ],
+                  [
+                     "the",
+                     293.41,
+                     293.51
+                  ],
+                  [
+                     "best",
+                     293.51,
+                     293.75
+                  ],
+                  [
+                     "analogy",
+                     293.75,
+                     294.31
+                  ],
+                  [
+                     "we",
+                     294.31,
+                     294.42
+                  ],
+                  [
+                     "have",
+                     294.42,
+                     294.7
+                  ],
+                  [
+                     "for",
+                     294.7,
+                     294.83
+                  ],
+                  [
+                     "this",
+                     294.83,
+                     295.06
+                  ],
+                  [
+                     "is",
+                     295.06,
+                     295.18
+                  ],
+                  [
+                     "our",
+                     295.18,
+                     295.31
+                  ],
+                  [
+                     "relationship",
+                     295.31,
+                     296.02
+                  ],
+                  [
+                     "with",
+                     296.02,
+                     296.2
+                  ],
+                  [
+                     "animals",
+                     296.23,
+                     296.99
+                  ],
+                  [
+                     "thousands",
+                     297.48,
+                     297.97
+                  ],
+                  [
+                     "of",
+                     297.97,
+                     298.06
+                  ],
+                  [
+                     "years",
+                     298.06,
+                     298.3
+                  ],
+                  [
+                     "ago",
+                     298.3,
+                     298.84
+                  ],
+                  [
+                     "we",
+                     299.11,
+                     299.44
+                  ],
+                  [
+                     "started",
+                     299.44,
+                     299.76
+                  ],
+                  [
+                     "to",
+                     299.76,
+                     299.85
+                  ],
+                  [
+                     "domesticate",
+                     299.85,
+                     300.47
+                  ],
+                  [
+                     "animals",
+                     300.47,
+                     301.15
+                  ],
+                  [
+                     "and",
+                     301.41,
+                     301.54
+                  ],
+                  [
+                     "we",
+                     301.54,
+                     301.64
+                  ],
+                  [
+                     "train",
+                     301.64,
+                     301.96
+                  ],
+                  [
+                     "them",
+                     301.96,
+                     302.12
+                  ],
+                  [
+                     "for",
+                     302.12,
+                     302.3
+                  ],
+                  [
+                     "work",
+                     302.3,
+                     302.88
+                  ],
+                  [
+                     "and",
+                     302.91,
+                     303.14
+                  ],
+                  [
+                     "weaponry",
+                     303.14,
+                     303.83
+                  ],
+                  [
+                     "and",
+                     303.86,
+                     303.97
+                  ],
+                  [
+                     "companionship",
+                     303.97,
+                     304.88
+                  ],
+                  [
+                     "and",
+                     305.51,
+                     305.66
+                  ],
+                  [
+                     "throughout",
+                     305.66,
+                     305.9
+                  ],
+                  [
+                     "history",
+                     305.9,
+                     306.42
+                  ],
+                  [
+                     "was",
+                     306.42,
+                     306.57
+                  ],
+                  [
+                     "treated",
+                     306.57,
+                     306.92
+                  ],
+                  [
+                     "some",
+                     306.92,
+                     307.17
+                  ],
+                  [
+                     "animals",
+                     307.17,
+                     307.74
+                  ],
+                  [
+                     "like",
+                     307.74,
+                     307.93
+                  ],
+                  [
+                     "tools",
+                     307.93,
+                     308.58
+                  ],
+                  [
+                     "or",
+                     308.88,
+                     309.04
+                  ],
+                  [
+                     "like",
+                     309.04,
+                     309.23
+                  ],
+                  [
+                     "products",
+                     309.23,
+                     310.06
+                  ],
+                  [
+                     "and",
+                     310.47,
+                     310.73
+                  ],
+                  [
+                     "other",
+                     310.76,
+                     310.96
+                  ],
+                  [
+                     "animals",
+                     310.96,
+                     311.31
+                  ],
+                  [
+                     "we",
+                     311.31,
+                     311.44
+                  ],
+                  [
+                     "treated",
+                     311.44,
+                     311.71
+                  ],
+                  [
+                     "with",
+                     311.71,
+                     311.86
+                  ],
+                  [
+                     "kindness",
+                     311.86,
+                     312.56
+                  ],
+                  [
+                     "we've",
+                     312.59,
+                     312.85
+                  ],
+                  [
+                     "given",
+                     312.85,
+                     313.08
+                  ],
+                  [
+                     "a",
+                     313.08,
+                     313.14
+                  ],
+                  [
+                     "place",
+                     313.14,
+                     313.53
+                  ],
+                  [
+                     "in",
+                     313.53,
+                     313.62
+                  ],
+                  [
+                     "society",
+                     313.62,
+                     314.11
+                  ],
+                  [
+                     "as",
+                     314.11,
+                     314.21
+                  ],
+                  [
+                     "our",
+                     314.21,
+                     314.31
+                  ],
+                  [
+                     "companions",
+                     314.31,
+                     315.17
+                  ]
+               ],
+               "confidence": 0.903,
+               "word_confidence": [
+                  [
+                     "now",
+                     0.999
+                  ],
+                  [
+                     "we're",
+                     0.706
+                  ],
+                  [
+                     "headed",
+                     1
+                  ],
+                  [
+                     "towards",
+                     0.729
+                  ],
+                  [
+                     "a",
+                     0.692
+                  ],
+                  [
+                     "world",
+                     0.993
+                  ],
+                  [
+                     "where",
+                     1
+                  ],
+                  [
+                     "robots",
+                     1
+                  ],
+                  [
+                     "are",
+                     1
+                  ],
+                  [
+                     "everywhere",
+                     0.996
+                  ],
+                  [
+                     "robotic",
+                     1
+                  ],
+                  [
+                     "technology",
+                     1
+                  ],
+                  [
+                     "is",
+                     1
+                  ],
+                  [
+                     "moving",
+                     1
+                  ],
+                  [
+                     "out",
+                     1
+                  ],
+                  [
+                     "from",
+                     1
+                  ],
+                  [
+                     "behind",
+                     0.983
+                  ],
+                  [
+                     "factory",
+                     0.995
+                  ],
+                  [
+                     "walls",
+                     0.974
+                  ],
+                  [
+                     "it's",
+                     0.759
+                  ],
+                  [
+                     "entering",
+                     0.91
+                  ],
+                  [
+                     "workplaces",
+                     0.077
+                  ],
+                  [
+                     "households",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.897
+                  ],
+                  [
+                     "as",
+                     0.876
+                  ],
+                  [
+                     "these",
+                     1
+                  ],
+                  [
+                     "machines",
+                     1
+                  ],
+                  [
+                     "that",
+                     0.624
+                  ],
+                  [
+                     "can",
+                     1
+                  ],
+                  [
+                     "fence",
+                     0.598
+                  ],
+                  [
+                     "and",
+                     0.859
+                  ],
+                  [
+                     "make",
+                     1
+                  ],
+                  [
+                     "autonomous",
+                     1
+                  ],
+                  [
+                     "decisions",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.396
+                  ],
+                  [
+                     "learn",
+                     0.519
+                  ],
+                  [
+                     "enter",
+                     0.77
+                  ],
+                  [
+                     "into",
+                     0.898
+                  ],
+                  [
+                     "the",
+                     0.566
+                  ],
+                  [
+                     "shared",
+                     0.941
+                  ],
+                  [
+                     "spaces",
+                     0.996
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "think",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "maybe",
+                     0.772
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "best",
+                     1
+                  ],
+                  [
+                     "analogy",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "have",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "is",
+                     0.799
+                  ],
+                  [
+                     "our",
+                     0.761
+                  ],
+                  [
+                     "relationship",
+                     1
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "animals",
+                     0.997
+                  ],
+                  [
+                     "thousands",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "years",
+                     1
+                  ],
+                  [
+                     "ago",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "started",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "domesticate",
+                     0.843
+                  ],
+                  [
+                     "animals",
+                     0.991
+                  ],
+                  [
+                     "and",
+                     0.687
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "train",
+                     0.841
+                  ],
+                  [
+                     "them",
+                     0.97
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "work",
+                     0.994
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "weaponry",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.598
+                  ],
+                  [
+                     "companionship",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "throughout",
+                     0.637
+                  ],
+                  [
+                     "history",
+                     0.987
+                  ],
+                  [
+                     "was",
+                     0.271
+                  ],
+                  [
+                     "treated",
+                     0.577
+                  ],
+                  [
+                     "some",
+                     1
+                  ],
+                  [
+                     "animals",
+                     1
+                  ],
+                  [
+                     "like",
+                     0.97
+                  ],
+                  [
+                     "tools",
+                     0.977
+                  ],
+                  [
+                     "or",
+                     0.438
+                  ],
+                  [
+                     "like",
+                     0.736
+                  ],
+                  [
+                     "products",
+                     0.999
+                  ],
+                  [
+                     "and",
+                     0.86
+                  ],
+                  [
+                     "other",
+                     0.976
+                  ],
+                  [
+                     "animals",
+                     0.735
+                  ],
+                  [
+                     "we",
+                     0.891
+                  ],
+                  [
+                     "treated",
+                     0.714
+                  ],
+                  [
+                     "with",
+                     0.982
+                  ],
+                  [
+                     "kindness",
+                     1
+                  ],
+                  [
+                     "we've",
+                     0.343
+                  ],
+                  [
+                     "given",
+                     0.98
+                  ],
+                  [
+                     "a",
+                     0.61
+                  ],
+                  [
+                     "place",
+                     0.989
+                  ],
+                  [
+                     "in",
+                     1
+                  ],
+                  [
+                     "society",
+                     0.948
+                  ],
+                  [
+                     "as",
+                     0.584
+                  ],
+                  [
+                     "our",
+                     0.999
+                  ],
+                  [
+                     "companions",
+                     0.998
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "I think it's plausible we might start to integrate robots in similar ways ",
+               "timestamps": [
+                  [
+                     "I",
+                     315.8,
+                     315.92
+                  ],
+                  [
+                     "think",
+                     315.92,
+                     316.09
+                  ],
+                  [
+                     "it's",
+                     316.09,
+                     316.2
+                  ],
+                  [
+                     "plausible",
+                     316.2,
+                     316.68
+                  ],
+                  [
+                     "we",
+                     316.68,
+                     316.81
+                  ],
+                  [
+                     "might",
+                     316.81,
+                     317.01
+                  ],
+                  [
+                     "start",
+                     317.01,
+                     317.25
+                  ],
+                  [
+                     "to",
+                     317.25,
+                     317.34
+                  ],
+                  [
+                     "integrate",
+                     317.34,
+                     317.78
+                  ],
+                  [
+                     "robots",
+                     317.78,
+                     318.36
+                  ],
+                  [
+                     "in",
+                     318.36,
+                     318.49
+                  ],
+                  [
+                     "similar",
+                     318.49,
+                     318.91
+                  ],
+                  [
+                     "ways",
+                     318.91,
+                     319.56
+                  ]
+               ],
+               "confidence": 0.808,
+               "word_confidence": [
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "think",
+                     1
+                  ],
+                  [
+                     "it's",
+                     0.723
+                  ],
+                  [
+                     "plausible",
+                     0.591
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "might",
+                     1
+                  ],
+                  [
+                     "start",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "integrate",
+                     0.81
+                  ],
+                  [
+                     "robots",
+                     0.99
+                  ],
+                  [
+                     "in",
+                     0.603
+                  ],
+                  [
+                     "similar",
+                     0.974
+                  ],
+                  [
+                     "ways",
+                     0.473
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "ensure ",
+               "timestamps": [[
+                  "ensure",
+                  321.45,
+                  322.04
+               ]],
+               "confidence": 0.221,
+               "word_confidence": [[
+                  "ensure",
+                  0.221
+               ]]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "animals are live robots are not and I can tell you from working with roboticist that were pretty far away from developing robust I can feel anything ",
+               "timestamps": [
+                  [
+                     "animals",
+                     323.02,
+                     323.5
+                  ],
+                  [
+                     "are",
+                     323.5,
+                     323.71
+                  ],
+                  [
+                     "live",
+                     323.71,
+                     324.16
+                  ],
+                  [
+                     "robots",
+                     324.6,
+                     325.01
+                  ],
+                  [
+                     "are",
+                     325.01,
+                     325.11
+                  ],
+                  [
+                     "not",
+                     325.11,
+                     325.38
+                  ],
+                  [
+                     "and",
+                     327.62,
+                     327.81
+                  ],
+                  [
+                     "I",
+                     327.81,
+                     327.87
+                  ],
+                  [
+                     "can",
+                     327.87,
+                     328.02
+                  ],
+                  [
+                     "tell",
+                     328.02,
+                     328.24
+                  ],
+                  [
+                     "you",
+                     328.24,
+                     328.33
+                  ],
+                  [
+                     "from",
+                     328.33,
+                     328.57
+                  ],
+                  [
+                     "working",
+                     328.57,
+                     328.92
+                  ],
+                  [
+                     "with",
+                     328.92,
+                     329.04
+                  ],
+                  [
+                     "roboticist",
+                     329.04,
+                     329.68
+                  ],
+                  [
+                     "that",
+                     329.68,
+                     329.8
+                  ],
+                  [
+                     "were",
+                     329.8,
+                     330.01
+                  ],
+                  [
+                     "pretty",
+                     330.23,
+                     330.5
+                  ],
+                  [
+                     "far",
+                     330.5,
+                     330.72
+                  ],
+                  [
+                     "away",
+                     330.72,
+                     330.99
+                  ],
+                  [
+                     "from",
+                     330.99,
+                     331.22
+                  ],
+                  [
+                     "developing",
+                     331.22,
+                     331.69
+                  ],
+                  [
+                     "robust",
+                     331.69,
+                     332.08
+                  ],
+                  [
+                     "I",
+                     332.08,
+                     332.12
+                  ],
+                  [
+                     "can",
+                     332.12,
+                     332.27
+                  ],
+                  [
+                     "feel",
+                     332.27,
+                     332.66
+                  ],
+                  [
+                     "anything",
+                     332.66,
+                     333.19
+                  ]
+               ],
+               "confidence": 0.782,
+               "word_confidence": [
+                  [
+                     "animals",
+                     1
+                  ],
+                  [
+                     "are",
+                     0.939
+                  ],
+                  [
+                     "live",
+                     0.613
+                  ],
+                  [
+                     "robots",
+                     1
+                  ],
+                  [
+                     "are",
+                     0.577
+                  ],
+                  [
+                     "not",
+                     0.99
+                  ],
+                  [
+                     "and",
+                     0.703
+                  ],
+                  [
+                     "I",
+                     0.962
+                  ],
+                  [
+                     "can",
+                     1
+                  ],
+                  [
+                     "tell",
+                     1
+                  ],
+                  [
+                     "you",
+                     1
+                  ],
+                  [
+                     "from",
+                     1
+                  ],
+                  [
+                     "working",
+                     1
+                  ],
+                  [
+                     "with",
+                     0.882
+                  ],
+                  [
+                     "roboticist",
+                     0.081
+                  ],
+                  [
+                     "that",
+                     0.295
+                  ],
+                  [
+                     "were",
+                     0.307
+                  ],
+                  [
+                     "pretty",
+                     1
+                  ],
+                  [
+                     "far",
+                     1
+                  ],
+                  [
+                     "away",
+                     1
+                  ],
+                  [
+                     "from",
+                     1
+                  ],
+                  [
+                     "developing",
+                     1
+                  ],
+                  [
+                     "robust",
+                     0.641
+                  ],
+                  [
+                     "I",
+                     0.083
+                  ],
+                  [
+                     "can",
+                     0.5
+                  ],
+                  [
+                     "feel",
+                     0.563
+                  ],
+                  [
+                     "anything",
+                     0.928
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "but we feel for them ",
+               "timestamps": [
+                  [
+                     "but",
+                     335.03,
+                     335.24
+                  ],
+                  [
+                     "we",
+                     335.24,
+                     335.49
+                  ],
+                  [
+                     "feel",
+                     335.49,
+                     335.76
+                  ],
+                  [
+                     "for",
+                     335.76,
+                     335.95
+                  ],
+                  [
+                     "them",
+                     335.95,
+                     336.43
+                  ]
+               ],
+               "confidence": 0.956,
+               "word_confidence": [
+                  [
+                     "but",
+                     0.715
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "feel",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "them",
+                     0.995
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and that matters because if we're trying to integrate robots into the shared spaces we need to understand that people will treat them differently than other devices ",
+               "timestamps": [
+                  [
+                     "and",
+                     337.79,
+                     338.01
+                  ],
+                  [
+                     "that",
+                     338.01,
+                     338.2
+                  ],
+                  [
+                     "matters",
+                     338.2,
+                     338.98
+                  ],
+                  [
+                     "because",
+                     339.01,
+                     339.53
+                  ],
+                  [
+                     "if",
+                     339.56,
+                     339.76
+                  ],
+                  [
+                     "we're",
+                     339.76,
+                     339.86
+                  ],
+                  [
+                     "trying",
+                     339.86,
+                     340.16
+                  ],
+                  [
+                     "to",
+                     340.16,
+                     340.26
+                  ],
+                  [
+                     "integrate",
+                     340.29,
+                     340.94
+                  ],
+                  [
+                     "robots",
+                     340.94,
+                     341.4
+                  ],
+                  [
+                     "into",
+                     341.4,
+                     341.56
+                  ],
+                  [
+                     "the",
+                     341.56,
+                     341.67
+                  ],
+                  [
+                     "shared",
+                     341.67,
+                     342.03
+                  ],
+                  [
+                     "spaces",
+                     342.03,
+                     342.68
+                  ],
+                  [
+                     "we",
+                     342.68,
+                     342.79
+                  ],
+                  [
+                     "need",
+                     342.79,
+                     342.96
+                  ],
+                  [
+                     "to",
+                     342.96,
+                     343.05
+                  ],
+                  [
+                     "understand",
+                     343.05,
+                     343.8
+                  ],
+                  [
+                     "that",
+                     343.8,
+                     343.93
+                  ],
+                  [
+                     "people",
+                     343.93,
+                     344.24
+                  ],
+                  [
+                     "will",
+                     344.24,
+                     344.37
+                  ],
+                  [
+                     "treat",
+                     344.37,
+                     344.61
+                  ],
+                  [
+                     "them",
+                     344.61,
+                     344.76
+                  ],
+                  [
+                     "differently",
+                     344.76,
+                     345.36
+                  ],
+                  [
+                     "than",
+                     345.36,
+                     345.51
+                  ],
+                  [
+                     "other",
+                     345.51,
+                     345.73
+                  ],
+                  [
+                     "devices",
+                     345.73,
+                     346.6
+                  ]
+               ],
+               "confidence": 0.928,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.916
+                  ],
+                  [
+                     "that",
+                     0.6
+                  ],
+                  [
+                     "matters",
+                     0.994
+                  ],
+                  [
+                     "because",
+                     1
+                  ],
+                  [
+                     "if",
+                     1
+                  ],
+                  [
+                     "we're",
+                     0.76
+                  ],
+                  [
+                     "trying",
+                     0.997
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "integrate",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.937
+                  ],
+                  [
+                     "into",
+                     0.409
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "shared",
+                     1
+                  ],
+                  [
+                     "spaces",
+                     0.658
+                  ],
+                  [
+                     "we",
+                     0.856
+                  ],
+                  [
+                     "need",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "understand",
+                     1
+                  ],
+                  [
+                     "that",
+                     0.673
+                  ],
+                  [
+                     "people",
+                     1
+                  ],
+                  [
+                     "will",
+                     0.599
+                  ],
+                  [
+                     "treat",
+                     0.986
+                  ],
+                  [
+                     "them",
+                     1
+                  ],
+                  [
+                     "differently",
+                     1
+                  ],
+                  [
+                     "than",
+                     1
+                  ],
+                  [
+                     "other",
+                     1
+                  ],
+                  [
+                     "devices",
+                     0.949
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and that in some cases for example the case of a soldier who becomes emotionally attached to the robot that they work with that can be anything from an efficient too dangerous ",
+               "timestamps": [
+                  [
+                     "and",
+                     347.33,
+                     347.51
+                  ],
+                  [
+                     "that",
+                     347.51,
+                     347.64
+                  ],
+                  [
+                     "in",
+                     347.64,
+                     347.75
+                  ],
+                  [
+                     "some",
+                     347.75,
+                     348.04
+                  ],
+                  [
+                     "cases",
+                     348.04,
+                     348.94
+                  ],
+                  [
+                     "for",
+                     349.2,
+                     349.35
+                  ],
+                  [
+                     "example",
+                     349.35,
+                     349.97
+                  ],
+                  [
+                     "the",
+                     349.97,
+                     350.09
+                  ],
+                  [
+                     "case",
+                     350.09,
+                     350.37
+                  ],
+                  [
+                     "of",
+                     350.37,
+                     350.45
+                  ],
+                  [
+                     "a",
+                     350.45,
+                     350.52
+                  ],
+                  [
+                     "soldier",
+                     350.52,
+                     350.98
+                  ],
+                  [
+                     "who",
+                     350.98,
+                     351.08
+                  ],
+                  [
+                     "becomes",
+                     351.08,
+                     351.41
+                  ],
+                  [
+                     "emotionally",
+                     351.41,
+                     351.98
+                  ],
+                  [
+                     "attached",
+                     351.98,
+                     352.51
+                  ],
+                  [
+                     "to",
+                     352.51,
+                     352.6
+                  ],
+                  [
+                     "the",
+                     352.6,
+                     352.73
+                  ],
+                  [
+                     "robot",
+                     352.73,
+                     353.1
+                  ],
+                  [
+                     "that",
+                     353.1,
+                     353.21
+                  ],
+                  [
+                     "they",
+                     353.21,
+                     353.31
+                  ],
+                  [
+                     "work",
+                     353.31,
+                     353.59
+                  ],
+                  [
+                     "with",
+                     353.59,
+                     354.02
+                  ],
+                  [
+                     "that",
+                     354.49,
+                     354.66
+                  ],
+                  [
+                     "can",
+                     354.66,
+                     354.79
+                  ],
+                  [
+                     "be",
+                     354.79,
+                     354.89
+                  ],
+                  [
+                     "anything",
+                     354.89,
+                     355.28
+                  ],
+                  [
+                     "from",
+                     355.28,
+                     355.46
+                  ],
+                  [
+                     "an",
+                     355.46,
+                     355.61
+                  ],
+                  [
+                     "efficient",
+                     355.61,
+                     356.03
+                  ],
+                  [
+                     "too",
+                     356.03,
+                     356.14
+                  ],
+                  [
+                     "dangerous",
+                     356.14,
+                     356.94
+                  ]
+               ],
+               "confidence": 0.967,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "that",
+                     0.799
+                  ],
+                  [
+                     "in",
+                     1
+                  ],
+                  [
+                     "some",
+                     1
+                  ],
+                  [
+                     "cases",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "example",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "case",
+                     1
+                  ],
+                  [
+                     "of",
+                     0.977
+                  ],
+                  [
+                     "a",
+                     0.819
+                  ],
+                  [
+                     "soldier",
+                     1
+                  ],
+                  [
+                     "who",
+                     1
+                  ],
+                  [
+                     "becomes",
+                     1
+                  ],
+                  [
+                     "emotionally",
+                     1
+                  ],
+                  [
+                     "attached",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "robot",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "they",
+                     1
+                  ],
+                  [
+                     "work",
+                     1
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "can",
+                     1
+                  ],
+                  [
+                     "be",
+                     1
+                  ],
+                  [
+                     "anything",
+                     1
+                  ],
+                  [
+                     "from",
+                     0.982
+                  ],
+                  [
+                     "an",
+                     0.339
+                  ],
+                  [
+                     "efficient",
+                     0.69
+                  ],
+                  [
+                     "too",
+                     0.892
+                  ],
+                  [
+                     "dangerous",
+                     0.991
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "but in other cases it can actually be useful to foster this emotional connection to robots ",
+               "timestamps": [
+                  [
+                     "but",
+                     358.51,
+                     358.68
+                  ],
+                  [
+                     "in",
+                     358.68,
+                     358.78
+                  ],
+                  [
+                     "other",
+                     358.78,
+                     359
+                  ],
+                  [
+                     "cases",
+                     359,
+                     359.41
+                  ],
+                  [
+                     "it",
+                     359.41,
+                     359.48
+                  ],
+                  [
+                     "can",
+                     359.48,
+                     359.61
+                  ],
+                  [
+                     "actually",
+                     359.61,
+                     359.93
+                  ],
+                  [
+                     "be",
+                     359.93,
+                     360.09
+                  ],
+                  [
+                     "useful",
+                     360.09,
+                     360.67
+                  ],
+                  [
+                     "to",
+                     360.67,
+                     360.75
+                  ],
+                  [
+                     "foster",
+                     360.75,
+                     361.33
+                  ],
+                  [
+                     "this",
+                     361.33,
+                     361.49
+                  ],
+                  [
+                     "emotional",
+                     361.49,
+                     361.92
+                  ],
+                  [
+                     "connection",
+                     361.92,
+                     362.43
+                  ],
+                  [
+                     "to",
+                     362.43,
+                     362.56
+                  ],
+                  [
+                     "robots",
+                     362.56,
+                     363.23
+                  ]
+               ],
+               "confidence": 0.862,
+               "word_confidence": [
+                  [
+                     "but",
+                     1
+                  ],
+                  [
+                     "in",
+                     1
+                  ],
+                  [
+                     "other",
+                     1
+                  ],
+                  [
+                     "cases",
+                     0.969
+                  ],
+                  [
+                     "it",
+                     0.23
+                  ],
+                  [
+                     "can",
+                     1
+                  ],
+                  [
+                     "actually",
+                     1
+                  ],
+                  [
+                     "be",
+                     1
+                  ],
+                  [
+                     "useful",
+                     0.823
+                  ],
+                  [
+                     "to",
+                     0.538
+                  ],
+                  [
+                     "foster",
+                     0.991
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "emotional",
+                     1
+                  ],
+                  [
+                     "connection",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.972
+                  ],
+                  [
+                     "robots",
+                     0.35
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "we're already seeing some great use cases for example robots working with autistic children to engage them in ways that we haven't seen previously or robots working with teachers to engage kids in learning with new results ",
+               "timestamps": [
+                  [
+                     "we're",
+                     364.15,
+                     364.33
+                  ],
+                  [
+                     "already",
+                     364.33,
+                     364.61
+                  ],
+                  [
+                     "seeing",
+                     364.61,
+                     364.93
+                  ],
+                  [
+                     "some",
+                     364.93,
+                     365.13
+                  ],
+                  [
+                     "great",
+                     365.13,
+                     365.46
+                  ],
+                  [
+                     "use",
+                     365.46,
+                     365.72
+                  ],
+                  [
+                     "cases",
+                     365.72,
+                     366.23
+                  ],
+                  [
+                     "for",
+                     366.23,
+                     366.37
+                  ],
+                  [
+                     "example",
+                     366.37,
+                     366.84
+                  ],
+                  [
+                     "robots",
+                     366.84,
+                     367.27
+                  ],
+                  [
+                     "working",
+                     367.27,
+                     367.57
+                  ],
+                  [
+                     "with",
+                     367.57,
+                     367.78
+                  ],
+                  [
+                     "autistic",
+                     367.78,
+                     368.4
+                  ],
+                  [
+                     "children",
+                     368.4,
+                     368.92
+                  ],
+                  [
+                     "to",
+                     368.92,
+                     369.11
+                  ],
+                  [
+                     "engage",
+                     369.11,
+                     369.62
+                  ],
+                  [
+                     "them",
+                     369.62,
+                     369.91
+                  ],
+                  [
+                     "in",
+                     369.91,
+                     370.02
+                  ],
+                  [
+                     "ways",
+                     370.02,
+                     370.37
+                  ],
+                  [
+                     "that",
+                     370.37,
+                     370.47
+                  ],
+                  [
+                     "we",
+                     370.47,
+                     370.56
+                  ],
+                  [
+                     "haven't",
+                     370.56,
+                     370.95
+                  ],
+                  [
+                     "seen",
+                     370.95,
+                     371.16
+                  ],
+                  [
+                     "previously",
+                     371.16,
+                     372.03
+                  ],
+                  [
+                     "or",
+                     372.49,
+                     372.78
+                  ],
+                  [
+                     "robots",
+                     372.78,
+                     373.14
+                  ],
+                  [
+                     "working",
+                     373.14,
+                     373.49
+                  ],
+                  [
+                     "with",
+                     373.49,
+                     373.64
+                  ],
+                  [
+                     "teachers",
+                     373.64,
+                     374.2
+                  ],
+                  [
+                     "to",
+                     374.2,
+                     374.34
+                  ],
+                  [
+                     "engage",
+                     374.34,
+                     374.73
+                  ],
+                  [
+                     "kids",
+                     374.73,
+                     375
+                  ],
+                  [
+                     "in",
+                     375,
+                     375.12
+                  ],
+                  [
+                     "learning",
+                     375.12,
+                     375.56
+                  ],
+                  [
+                     "with",
+                     375.56,
+                     375.76
+                  ],
+                  [
+                     "new",
+                     375.76,
+                     375.87
+                  ],
+                  [
+                     "results",
+                     375.87,
+                     376.57
+                  ]
+               ],
+               "confidence": 0.959,
+               "word_confidence": [
+                  [
+                     "we're",
+                     0.817
+                  ],
+                  [
+                     "already",
+                     1
+                  ],
+                  [
+                     "seeing",
+                     1
+                  ],
+                  [
+                     "some",
+                     0.78
+                  ],
+                  [
+                     "great",
+                     0.994
+                  ],
+                  [
+                     "use",
+                     0.996
+                  ],
+                  [
+                     "cases",
+                     0.8
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "example",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.864
+                  ],
+                  [
+                     "working",
+                     1
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "autistic",
+                     1
+                  ],
+                  [
+                     "children",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.954
+                  ],
+                  [
+                     "engage",
+                     0.997
+                  ],
+                  [
+                     "them",
+                     0.993
+                  ],
+                  [
+                     "in",
+                     0.8
+                  ],
+                  [
+                     "ways",
+                     0.757
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "haven't",
+                     1
+                  ],
+                  [
+                     "seen",
+                     1
+                  ],
+                  [
+                     "previously",
+                     0.997
+                  ],
+                  [
+                     "or",
+                     0.896
+                  ],
+                  [
+                     "robots",
+                     0.933
+                  ],
+                  [
+                     "working",
+                     1
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "teachers",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "engage",
+                     1
+                  ],
+                  [
+                     "kids",
+                     1
+                  ],
+                  [
+                     "in",
+                     0.749
+                  ],
+                  [
+                     "learning",
+                     0.937
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "new",
+                     0.847
+                  ],
+                  [
+                     "results",
+                     0.993
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and it's not just for kids ",
+               "timestamps": [
+                  [
+                     "and",
+                     377.41,
+                     377.55
+                  ],
+                  [
+                     "it's",
+                     377.55,
+                     377.68
+                  ],
+                  [
+                     "not",
+                     377.68,
+                     377.88
+                  ],
+                  [
+                     "just",
+                     377.88,
+                     378.05
+                  ],
+                  [
+                     "for",
+                     378.05,
+                     378.16
+                  ],
+                  [
+                     "kids",
+                     378.16,
+                     378.84
+                  ]
+               ],
+               "confidence": 0.915,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "it's",
+                     1
+                  ],
+                  [
+                     "not",
+                     1
+                  ],
+                  [
+                     "just",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "kids",
+                     0.822
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "early studies show that robots can help doctors and patients in health care settings ",
+               "timestamps": [
+                  [
+                     "early",
+                     379.72,
+                     380.03
+                  ],
+                  [
+                     "studies",
+                     380.03,
+                     380.4
+                  ],
+                  [
+                     "show",
+                     380.4,
+                     380.7
+                  ],
+                  [
+                     "that",
+                     380.7,
+                     381.03
+                  ],
+                  [
+                     "robots",
+                     381.06,
+                     381.39
+                  ],
+                  [
+                     "can",
+                     381.39,
+                     381.54
+                  ],
+                  [
+                     "help",
+                     381.54,
+                     381.75
+                  ],
+                  [
+                     "doctors",
+                     381.75,
+                     382.25
+                  ],
+                  [
+                     "and",
+                     382.25,
+                     382.38
+                  ],
+                  [
+                     "patients",
+                     382.38,
+                     382.98
+                  ],
+                  [
+                     "in",
+                     382.98,
+                     383.08
+                  ],
+                  [
+                     "health",
+                     383.08,
+                     383.42
+                  ],
+                  [
+                     "care",
+                     383.42,
+                     383.65
+                  ],
+                  [
+                     "settings",
+                     383.65,
+                     384.37
+                  ]
+               ],
+               "confidence": 0.891,
+               "word_confidence": [
+                  [
+                     "early",
+                     1
+                  ],
+                  [
+                     "studies",
+                     1
+                  ],
+                  [
+                     "show",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.21
+                  ],
+                  [
+                     "can",
+                     0.984
+                  ],
+                  [
+                     "help",
+                     0.965
+                  ],
+                  [
+                     "doctors",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "patients",
+                     1
+                  ],
+                  [
+                     "in",
+                     0.449
+                  ],
+                  [
+                     "health",
+                     0.677
+                  ],
+                  [
+                     "care",
+                     0.718
+                  ],
+                  [
+                     "settings",
+                     0.998
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "this is the part baby seal robot is used in nursing homes and with dementia patients been around for awhile and I remember years ago being at a party and telling someone about this robot ",
+               "timestamps": [
+                  [
+                     "this",
+                     385.53,
+                     385.72
+                  ],
+                  [
+                     "is",
+                     385.72,
+                     385.89
+                  ],
+                  [
+                     "the",
+                     385.89,
+                     385.98
+                  ],
+                  [
+                     "part",
+                     385.98,
+                     386.41
+                  ],
+                  [
+                     "baby",
+                     386.41,
+                     386.64
+                  ],
+                  [
+                     "seal",
+                     386.64,
+                     386.91
+                  ],
+                  [
+                     "robot",
+                     386.91,
+                     387.32
+                  ],
+                  [
+                     "is",
+                     387.35,
+                     387.52
+                  ],
+                  [
+                     "used",
+                     387.52,
+                     387.86
+                  ],
+                  [
+                     "in",
+                     387.89,
+                     388.05
+                  ],
+                  [
+                     "nursing",
+                     388.05,
+                     388.45
+                  ],
+                  [
+                     "homes",
+                     388.45,
+                     388.91
+                  ],
+                  [
+                     "and",
+                     388.91,
+                     389
+                  ],
+                  [
+                     "with",
+                     389,
+                     389.15
+                  ],
+                  [
+                     "dementia",
+                     389.15,
+                     389.61
+                  ],
+                  [
+                     "patients",
+                     389.61,
+                     390.36
+                  ],
+                  [
+                     "been",
+                     390.66,
+                     390.77
+                  ],
+                  [
+                     "around",
+                     390.77,
+                     391.07
+                  ],
+                  [
+                     "for",
+                     391.07,
+                     391.23
+                  ],
+                  [
+                     "awhile",
+                     391.23,
+                     391.81
+                  ],
+                  [
+                     "and",
+                     392.21,
+                     392.38
+                  ],
+                  [
+                     "I",
+                     392.38,
+                     392.43
+                  ],
+                  [
+                     "remember",
+                     392.43,
+                     393.05
+                  ],
+                  [
+                     "years",
+                     393.34,
+                     393.79
+                  ],
+                  [
+                     "ago",
+                     393.79,
+                     394.03
+                  ],
+                  [
+                     "being",
+                     394.03,
+                     394.22
+                  ],
+                  [
+                     "at",
+                     394.22,
+                     394.31
+                  ],
+                  [
+                     "a",
+                     394.31,
+                     394.37
+                  ],
+                  [
+                     "party",
+                     394.37,
+                     395.12
+                  ],
+                  [
+                     "and",
+                     395.6,
+                     395.76
+                  ],
+                  [
+                     "telling",
+                     395.76,
+                     396.16
+                  ],
+                  [
+                     "someone",
+                     396.16,
+                     396.44
+                  ],
+                  [
+                     "about",
+                     396.44,
+                     396.68
+                  ],
+                  [
+                     "this",
+                     396.68,
+                     396.84
+                  ],
+                  [
+                     "robot",
+                     396.84,
+                     397.42
+                  ]
+               ],
+               "confidence": 0.882,
+               "word_confidence": [
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "is",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "part",
+                     0.644
+                  ],
+                  [
+                     "baby",
+                     0.697
+                  ],
+                  [
+                     "seal",
+                     0.456
+                  ],
+                  [
+                     "robot",
+                     1
+                  ],
+                  [
+                     "is",
+                     0.282
+                  ],
+                  [
+                     "used",
+                     0.879
+                  ],
+                  [
+                     "in",
+                     0.976
+                  ],
+                  [
+                     "nursing",
+                     0.996
+                  ],
+                  [
+                     "homes",
+                     0.803
+                  ],
+                  [
+                     "and",
+                     0.222
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "dementia",
+                     1
+                  ],
+                  [
+                     "patients",
+                     0.907
+                  ],
+                  [
+                     "been",
+                     0.458
+                  ],
+                  [
+                     "around",
+                     0.975
+                  ],
+                  [
+                     "for",
+                     0.969
+                  ],
+                  [
+                     "awhile",
+                     0.51
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "remember",
+                     1
+                  ],
+                  [
+                     "years",
+                     1
+                  ],
+                  [
+                     "ago",
+                     1
+                  ],
+                  [
+                     "being",
+                     1
+                  ],
+                  [
+                     "at",
+                     0.84
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "party",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.663
+                  ],
+                  [
+                     "telling",
+                     1
+                  ],
+                  [
+                     "someone",
+                     1
+                  ],
+                  [
+                     "about",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "robot",
+                     0.947
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and her response was ",
+               "timestamps": [
+                  [
+                     "and",
+                     398.26,
+                     398.36
+                  ],
+                  [
+                     "her",
+                     398.36,
+                     398.52
+                  ],
+                  [
+                     "response",
+                     398.52,
+                     399.04
+                  ],
+                  [
+                     "was",
+                     399.04,
+                     399.57
+                  ]
+               ],
+               "confidence": 0.967,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.582
+                  ],
+                  [
+                     "her",
+                     1
+                  ],
+                  [
+                     "response",
+                     1
+                  ],
+                  [
+                     "was",
+                     0.997
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "oh my gosh ",
+               "timestamps": [
+                  [
+                     "oh",
+                     400.33,
+                     400.44
+                  ],
+                  [
+                     "my",
+                     400.44,
+                     400.61
+                  ],
+                  [
+                     "gosh",
+                     400.61,
+                     401.34
+                  ]
+               ],
+               "confidence": 0.856,
+               "word_confidence": [
+                  [
+                     "oh",
+                     0.591
+                  ],
+                  [
+                     "my",
+                     0.776
+                  ],
+                  [
+                     "gosh",
+                     0.915
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "that's horrible ",
+               "timestamps": [
+                  [
+                     "that's",
+                     402.49,
+                     402.75
+                  ],
+                  [
+                     "horrible",
+                     402.75,
+                     403.49
+                  ]
+               ],
+               "confidence": 0.997,
+               "word_confidence": [
+                  [
+                     "that's",
+                     1
+                  ],
+                  [
+                     "horrible",
+                     0.997
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "I can't believe we're giving people robots instead of human care ",
+               "timestamps": [
+                  [
+                     "I",
+                     405.01,
+                     405.13
+                  ],
+                  [
+                     "can't",
+                     405.13,
+                     405.44
+                  ],
+                  [
+                     "believe",
+                     405.44,
+                     405.76
+                  ],
+                  [
+                     "we're",
+                     405.76,
+                     405.86
+                  ],
+                  [
+                     "giving",
+                     405.86,
+                     406.14
+                  ],
+                  [
+                     "people",
+                     406.14,
+                     406.47
+                  ],
+                  [
+                     "robots",
+                     406.47,
+                     407.08
+                  ],
+                  [
+                     "instead",
+                     407.08,
+                     407.44
+                  ],
+                  [
+                     "of",
+                     407.44,
+                     407.52
+                  ],
+                  [
+                     "human",
+                     407.52,
+                     407.86
+                  ],
+                  [
+                     "care",
+                     407.86,
+                     408.47
+                  ]
+               ],
+               "confidence": 0.92,
+               "word_confidence": [
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "can't",
+                     1
+                  ],
+                  [
+                     "believe",
+                     1
+                  ],
+                  [
+                     "we're",
+                     0.801
+                  ],
+                  [
+                     "giving",
+                     1
+                  ],
+                  [
+                     "people",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.961
+                  ],
+                  [
+                     "instead",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "human",
+                     1
+                  ],
+                  [
+                     "care",
+                     0.615
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and this is a really common response and I think it's absolutely correct because that would be terrible ",
+               "timestamps": [
+                  [
+                     "and",
+                     410.53,
+                     410.68
+                  ],
+                  [
+                     "this",
+                     410.68,
+                     410.81
+                  ],
+                  [
+                     "is",
+                     410.81,
+                     410.92
+                  ],
+                  [
+                     "a",
+                     410.92,
+                     411
+                  ],
+                  [
+                     "really",
+                     411,
+                     411.35
+                  ],
+                  [
+                     "common",
+                     411.35,
+                     411.66
+                  ],
+                  [
+                     "response",
+                     411.66,
+                     412.36
+                  ],
+                  [
+                     "and",
+                     412.39,
+                     412.67
+                  ],
+                  [
+                     "I",
+                     412.7,
+                     412.79
+                  ],
+                  [
+                     "think",
+                     412.79,
+                     413
+                  ],
+                  [
+                     "it's",
+                     413,
+                     413.16
+                  ],
+                  [
+                     "absolutely",
+                     413.24,
+                     414.02
+                  ],
+                  [
+                     "correct",
+                     414.02,
+                     414.72
+                  ],
+                  [
+                     "because",
+                     414.92,
+                     415.28
+                  ],
+                  [
+                     "that",
+                     415.28,
+                     415.55
+                  ],
+                  [
+                     "would",
+                     415.55,
+                     415.85
+                  ],
+                  [
+                     "be",
+                     415.85,
+                     416.11
+                  ],
+                  [
+                     "terrible",
+                     416.11,
+                     416.97
+                  ]
+               ],
+               "confidence": 0.961,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "is",
+                     1
+                  ],
+                  [
+                     "a",
+                     0.81
+                  ],
+                  [
+                     "really",
+                     1
+                  ],
+                  [
+                     "common",
+                     1
+                  ],
+                  [
+                     "response",
+                     0.804
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "think",
+                     1
+                  ],
+                  [
+                     "it's",
+                     0.521
+                  ],
+                  [
+                     "absolutely",
+                     1
+                  ],
+                  [
+                     "correct",
+                     0.997
+                  ],
+                  [
+                     "because",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "would",
+                     1
+                  ],
+                  [
+                     "be",
+                     0.99
+                  ],
+                  [
+                     "terrible",
+                     0.997
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "but in this case it's not with his robot replaces with his robot replaces is animal fair ",
+               "timestamps": [
+                  [
+                     "but",
+                     417.81,
+                     417.93
+                  ],
+                  [
+                     "in",
+                     417.93,
+                     418.04
+                  ],
+                  [
+                     "this",
+                     418.04,
+                     418.22
+                  ],
+                  [
+                     "case",
+                     418.22,
+                     418.44
+                  ],
+                  [
+                     "it's",
+                     418.44,
+                     418.58
+                  ],
+                  [
+                     "not",
+                     418.58,
+                     418.81
+                  ],
+                  [
+                     "with",
+                     418.81,
+                     418.9
+                  ],
+                  [
+                     "his",
+                     418.9,
+                     419.04
+                  ],
+                  [
+                     "robot",
+                     419.04,
+                     419.4
+                  ],
+                  [
+                     "replaces",
+                     419.4,
+                     420.22
+                  ],
+                  [
+                     "with",
+                     420.74,
+                     420.98
+                  ],
+                  [
+                     "his",
+                     420.98,
+                     421.13
+                  ],
+                  [
+                     "robot",
+                     421.13,
+                     421.54
+                  ],
+                  [
+                     "replaces",
+                     421.54,
+                     422.2
+                  ],
+                  [
+                     "is",
+                     422.23,
+                     422.47
+                  ],
+                  [
+                     "animal",
+                     422.5,
+                     422.9
+                  ],
+                  [
+                     "fair",
+                     422.9,
+                     423.23
+                  ]
+               ],
+               "confidence": 0.873,
+               "word_confidence": [
+                  [
+                     "but",
+                     1
+                  ],
+                  [
+                     "in",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "case",
+                     1
+                  ],
+                  [
+                     "it's",
+                     0.849
+                  ],
+                  [
+                     "not",
+                     0.997
+                  ],
+                  [
+                     "with",
+                     0.614
+                  ],
+                  [
+                     "his",
+                     0.206
+                  ],
+                  [
+                     "robot",
+                     1
+                  ],
+                  [
+                     "replaces",
+                     0.822
+                  ],
+                  [
+                     "with",
+                     0.68
+                  ],
+                  [
+                     "his",
+                     0.354
+                  ],
+                  [
+                     "robot",
+                     0.928
+                  ],
+                  [
+                     "replaces",
+                     1
+                  ],
+                  [
+                     "is",
+                     0.923
+                  ],
+                  [
+                     "animal",
+                     0.973
+                  ],
+                  [
+                     "fair",
+                     0.793
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "in contexts where we can't use real animals but we can use robots because people will consistently treat them like more like more like an animal in a device ",
+               "timestamps": [
+                  [
+                     "in",
+                     424.07,
+                     424.13
+                  ],
+                  [
+                     "contexts",
+                     424.13,
+                     424.74
+                  ],
+                  [
+                     "where",
+                     424.74,
+                     424.88
+                  ],
+                  [
+                     "we",
+                     424.88,
+                     425
+                  ],
+                  [
+                     "can't",
+                     425,
+                     425.47
+                  ],
+                  [
+                     "use",
+                     425.47,
+                     425.79
+                  ],
+                  [
+                     "real",
+                     425.79,
+                     426.03
+                  ],
+                  [
+                     "animals",
+                     426.03,
+                     426.84
+                  ],
+                  [
+                     "but",
+                     427.14,
+                     427.3
+                  ],
+                  [
+                     "we",
+                     427.3,
+                     427.42
+                  ],
+                  [
+                     "can",
+                     427.42,
+                     427.75
+                  ],
+                  [
+                     "use",
+                     427.75,
+                     427.93
+                  ],
+                  [
+                     "robots",
+                     427.93,
+                     428.35
+                  ],
+                  [
+                     "because",
+                     428.35,
+                     428.63
+                  ],
+                  [
+                     "people",
+                     428.63,
+                     428.91
+                  ],
+                  [
+                     "will",
+                     428.91,
+                     429.02
+                  ],
+                  [
+                     "consistently",
+                     429.02,
+                     429.93
+                  ],
+                  [
+                     "treat",
+                     429.93,
+                     430.3
+                  ],
+                  [
+                     "them",
+                     430.3,
+                     430.61
+                  ],
+                  [
+                     "like",
+                     430.64,
+                     430.85
+                  ],
+                  [
+                     "more",
+                     430.85,
+                     431.36
+                  ],
+                  [
+                     "like",
+                     431.68,
+                     431.82
+                  ],
+                  [
+                     "more",
+                     431.82,
+                     432.05
+                  ],
+                  [
+                     "like",
+                     432.05,
+                     432.2
+                  ],
+                  [
+                     "an",
+                     432.2,
+                     432.28
+                  ],
+                  [
+                     "animal",
+                     432.31,
+                     432.87
+                  ],
+                  [
+                     "in",
+                     432.91,
+                     433.02
+                  ],
+                  [
+                     "a",
+                     433.02,
+                     433.09
+                  ],
+                  [
+                     "device",
+                     433.09,
+                     433.65
+                  ]
+               ],
+               "confidence": 0.803,
+               "word_confidence": [
+                  [
+                     "in",
+                     0.438
+                  ],
+                  [
+                     "contexts",
+                     0.371
+                  ],
+                  [
+                     "where",
+                     0.33
+                  ],
+                  [
+                     "we",
+                     0.569
+                  ],
+                  [
+                     "can't",
+                     0.798
+                  ],
+                  [
+                     "use",
+                     1
+                  ],
+                  [
+                     "real",
+                     1
+                  ],
+                  [
+                     "animals",
+                     1
+                  ],
+                  [
+                     "but",
+                     0.754
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "can",
+                     0.676
+                  ],
+                  [
+                     "use",
+                     0.964
+                  ],
+                  [
+                     "robots",
+                     0.822
+                  ],
+                  [
+                     "because",
+                     0.965
+                  ],
+                  [
+                     "people",
+                     1
+                  ],
+                  [
+                     "will",
+                     0.547
+                  ],
+                  [
+                     "consistently",
+                     1
+                  ],
+                  [
+                     "treat",
+                     1
+                  ],
+                  [
+                     "them",
+                     1
+                  ],
+                  [
+                     "like",
+                     1
+                  ],
+                  [
+                     "more",
+                     1
+                  ],
+                  [
+                     "like",
+                     0.199
+                  ],
+                  [
+                     "more",
+                     0.974
+                  ],
+                  [
+                     "like",
+                     1
+                  ],
+                  [
+                     "an",
+                     0.523
+                  ],
+                  [
+                     "animal",
+                     0.986
+                  ],
+                  [
+                     "in",
+                     0.143
+                  ],
+                  [
+                     "a",
+                     0.128
+                  ],
+                  [
+                     "device",
+                     0.145
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "technology in this emotional connection to robots can also help us anticipate challenges as these devices move into more intimate areas of people's lives ",
+               "timestamps": [
+                  [
+                     "technology",
+                     435.5,
+                     436.11
+                  ],
+                  [
+                     "in",
+                     436.11,
+                     436.18
+                  ],
+                  [
+                     "this",
+                     436.18,
+                     436.34
+                  ],
+                  [
+                     "emotional",
+                     436.34,
+                     436.74
+                  ],
+                  [
+                     "connection",
+                     436.74,
+                     437.18
+                  ],
+                  [
+                     "to",
+                     437.18,
+                     437.26
+                  ],
+                  [
+                     "robots",
+                     437.26,
+                     437.56
+                  ],
+                  [
+                     "can",
+                     437.56,
+                     437.72
+                  ],
+                  [
+                     "also",
+                     437.72,
+                     438
+                  ],
+                  [
+                     "help",
+                     438,
+                     438.24
+                  ],
+                  [
+                     "us",
+                     438.24,
+                     438.36
+                  ],
+                  [
+                     "anticipate",
+                     438.36,
+                     438.91
+                  ],
+                  [
+                     "challenges",
+                     438.91,
+                     439.83
+                  ],
+                  [
+                     "as",
+                     439.86,
+                     440.12
+                  ],
+                  [
+                     "these",
+                     440.12,
+                     440.27
+                  ],
+                  [
+                     "devices",
+                     440.27,
+                     440.84
+                  ],
+                  [
+                     "move",
+                     440.84,
+                     441.2
+                  ],
+                  [
+                     "into",
+                     441.2,
+                     441.42
+                  ],
+                  [
+                     "more",
+                     441.42,
+                     441.56
+                  ],
+                  [
+                     "intimate",
+                     441.56,
+                     441.98
+                  ],
+                  [
+                     "areas",
+                     441.98,
+                     442.32
+                  ],
+                  [
+                     "of",
+                     442.32,
+                     442.42
+                  ],
+                  [
+                     "people's",
+                     442.42,
+                     442.77
+                  ],
+                  [
+                     "lives",
+                     442.77,
+                     443.36
+                  ]
+               ],
+               "confidence": 0.851,
+               "word_confidence": [
+                  [
+                     "technology",
+                     0.703
+                  ],
+                  [
+                     "in",
+                     0.48
+                  ],
+                  [
+                     "this",
+                     0.686
+                  ],
+                  [
+                     "emotional",
+                     1
+                  ],
+                  [
+                     "connection",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.544
+                  ],
+                  [
+                     "robots",
+                     0.179
+                  ],
+                  [
+                     "can",
+                     1
+                  ],
+                  [
+                     "also",
+                     1
+                  ],
+                  [
+                     "help",
+                     1
+                  ],
+                  [
+                     "us",
+                     1
+                  ],
+                  [
+                     "anticipate",
+                     1
+                  ],
+                  [
+                     "challenges",
+                     1
+                  ],
+                  [
+                     "as",
+                     0.79
+                  ],
+                  [
+                     "these",
+                     1
+                  ],
+                  [
+                     "devices",
+                     0.998
+                  ],
+                  [
+                     "move",
+                     0.463
+                  ],
+                  [
+                     "into",
+                     0.478
+                  ],
+                  [
+                     "more",
+                     0.932
+                  ],
+                  [
+                     "intimate",
+                     0.738
+                  ],
+                  [
+                     "areas",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "people's",
+                     0.861
+                  ],
+                  [
+                     "lives",
+                     0.855
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "for example is it okay if your child's teddy bear robot records private conversations is it okay if your sex robot have compelling in app purchases ",
+               "timestamps": [
+                  [
+                     "for",
+                     444.08,
+                     444.23
+                  ],
+                  [
+                     "example",
+                     444.23,
+                     444.75
+                  ],
+                  [
+                     "is",
+                     444.75,
+                     444.96
+                  ],
+                  [
+                     "it",
+                     444.96,
+                     445.06
+                  ],
+                  [
+                     "okay",
+                     445.06,
+                     445.47
+                  ],
+                  [
+                     "if",
+                     445.47,
+                     445.61
+                  ],
+                  [
+                     "your",
+                     445.61,
+                     445.71
+                  ],
+                  [
+                     "child's",
+                     445.71,
+                     446.36
+                  ],
+                  [
+                     "teddy",
+                     446.68,
+                     446.98
+                  ],
+                  [
+                     "bear",
+                     446.98,
+                     447.19
+                  ],
+                  [
+                     "robot",
+                     447.19,
+                     447.53
+                  ],
+                  [
+                     "records",
+                     447.53,
+                     447.85
+                  ],
+                  [
+                     "private",
+                     447.85,
+                     448.18
+                  ],
+                  [
+                     "conversations",
+                     448.18,
+                     449.11
+                  ],
+                  [
+                     "is",
+                     449.76,
+                     449.87
+                  ],
+                  [
+                     "it",
+                     449.87,
+                     449.97
+                  ],
+                  [
+                     "okay",
+                     449.97,
+                     450.28
+                  ],
+                  [
+                     "if",
+                     450.28,
+                     450.4
+                  ],
+                  [
+                     "your",
+                     450.4,
+                     450.53
+                  ],
+                  [
+                     "sex",
+                     450.53,
+                     451.01
+                  ],
+                  [
+                     "robot",
+                     451.01,
+                     451.39
+                  ],
+                  [
+                     "have",
+                     451.42,
+                     451.63
+                  ],
+                  [
+                     "compelling",
+                     451.63,
+                     452.3
+                  ],
+                  [
+                     "in",
+                     452.33,
+                     452.51
+                  ],
+                  [
+                     "app",
+                     452.51,
+                     452.8
+                  ],
+                  [
+                     "purchases",
+                     452.8,
+                     453.6
+                  ]
+               ],
+               "confidence": 0.918,
+               "word_confidence": [
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "example",
+                     1
+                  ],
+                  [
+                     "is",
+                     0.92
+                  ],
+                  [
+                     "it",
+                     0.935
+                  ],
+                  [
+                     "okay",
+                     1
+                  ],
+                  [
+                     "if",
+                     0.845
+                  ],
+                  [
+                     "your",
+                     0.985
+                  ],
+                  [
+                     "child's",
+                     0.897
+                  ],
+                  [
+                     "teddy",
+                     1
+                  ],
+                  [
+                     "bear",
+                     1
+                  ],
+                  [
+                     "robot",
+                     1
+                  ],
+                  [
+                     "records",
+                     0.792
+                  ],
+                  [
+                     "private",
+                     1
+                  ],
+                  [
+                     "conversations",
+                     0.794
+                  ],
+                  [
+                     "is",
+                     0.719
+                  ],
+                  [
+                     "it",
+                     0.883
+                  ],
+                  [
+                     "okay",
+                     1
+                  ],
+                  [
+                     "if",
+                     0.731
+                  ],
+                  [
+                     "your",
+                     0.992
+                  ],
+                  [
+                     "sex",
+                     1
+                  ],
+                  [
+                     "robot",
+                     0.645
+                  ],
+                  [
+                     "have",
+                     0.568
+                  ],
+                  [
+                     "compelling",
+                     0.99
+                  ],
+                  [
+                     "in",
+                     1
+                  ],
+                  [
+                     "app",
+                     0.945
+                  ],
+                  [
+                     "purchases",
+                     0.998
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "because of rope plus capitalism equals questions around consumer protection and privacy ",
+               "timestamps": [
+                  [
+                     "because",
+                     455.28,
+                     455.63
+                  ],
+                  [
+                     "of",
+                     455.63,
+                     455.74
+                  ],
+                  [
+                     "rope",
+                     455.74,
+                     456.02
+                  ],
+                  [
+                     "plus",
+                     456.32,
+                     456.62
+                  ],
+                  [
+                     "capitalism",
+                     456.62,
+                     457.77
+                  ],
+                  [
+                     "equals",
+                     457.8,
+                     458.16
+                  ],
+                  [
+                     "questions",
+                     458.16,
+                     458.89
+                  ],
+                  [
+                     "around",
+                     458.92,
+                     459.48
+                  ],
+                  [
+                     "consumer",
+                     459.72,
+                     460.17
+                  ],
+                  [
+                     "protection",
+                     460.17,
+                     460.77
+                  ],
+                  [
+                     "and",
+                     460.77,
+                     460.9
+                  ],
+                  [
+                     "privacy",
+                     460.9,
+                     461.52
+                  ]
+               ],
+               "confidence": 0.896,
+               "word_confidence": [
+                  [
+                     "because",
+                     0.994
+                  ],
+                  [
+                     "of",
+                     0.424
+                  ],
+                  [
+                     "rope",
+                     0.257
+                  ],
+                  [
+                     "plus",
+                     0.502
+                  ],
+                  [
+                     "capitalism",
+                     1
+                  ],
+                  [
+                     "equals",
+                     0.767
+                  ],
+                  [
+                     "questions",
+                     0.952
+                  ],
+                  [
+                     "around",
+                     0.997
+                  ],
+                  [
+                     "consumer",
+                     1
+                  ],
+                  [
+                     "protection",
+                     0.999
+                  ],
+                  [
+                     "and",
+                     0.671
+                  ],
+                  [
+                     "privacy",
+                     0.997
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and those aren't the only reasons that our behavior around these machines could matter ",
+               "timestamps": [
+                  [
+                     "and",
+                     462.55,
+                     462.7
+                  ],
+                  [
+                     "those",
+                     462.7,
+                     462.86
+                  ],
+                  [
+                     "aren't",
+                     462.86,
+                     463.11
+                  ],
+                  [
+                     "the",
+                     463.11,
+                     463.25
+                  ],
+                  [
+                     "only",
+                     463.25,
+                     463.51
+                  ],
+                  [
+                     "reasons",
+                     463.51,
+                     463.93
+                  ],
+                  [
+                     "that",
+                     463.93,
+                     464.06
+                  ],
+                  [
+                     "our",
+                     464.06,
+                     464.15
+                  ],
+                  [
+                     "behavior",
+                     464.15,
+                     464.78
+                  ],
+                  [
+                     "around",
+                     464.78,
+                     465.03
+                  ],
+                  [
+                     "these",
+                     465.03,
+                     465.19
+                  ],
+                  [
+                     "machines",
+                     465.19,
+                     465.62
+                  ],
+                  [
+                     "could",
+                     465.62,
+                     465.82
+                  ],
+                  [
+                     "matter",
+                     465.82,
+                     466.25
+                  ]
+               ],
+               "confidence": 0.957,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "those",
+                     0.741
+                  ],
+                  [
+                     "aren't",
+                     0.827
+                  ],
+                  [
+                     "the",
+                     0.988
+                  ],
+                  [
+                     "only",
+                     1
+                  ],
+                  [
+                     "reasons",
+                     0.971
+                  ],
+                  [
+                     "that",
+                     0.817
+                  ],
+                  [
+                     "our",
+                     0.931
+                  ],
+                  [
+                     "behavior",
+                     0.994
+                  ],
+                  [
+                     "around",
+                     0.941
+                  ],
+                  [
+                     "these",
+                     1
+                  ],
+                  [
+                     "machines",
+                     1
+                  ],
+                  [
+                     "could",
+                     1
+                  ],
+                  [
+                     "matter",
+                     0.976
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "a few years after that first initial experience I had with this baby dinosaur robot ",
+               "timestamps": [
+                  [
+                     "a",
+                     468.73,
+                     468.82
+                  ],
+                  [
+                     "few",
+                     468.82,
+                     469.05
+                  ],
+                  [
+                     "years",
+                     469.05,
+                     469.31
+                  ],
+                  [
+                     "after",
+                     469.31,
+                     470.03
+                  ],
+                  [
+                     "that",
+                     470.13,
+                     470.34
+                  ],
+                  [
+                     "first",
+                     470.34,
+                     470.7
+                  ],
+                  [
+                     "initial",
+                     470.7,
+                     471.07
+                  ],
+                  [
+                     "experience",
+                     471.07,
+                     471.69
+                  ],
+                  [
+                     "I",
+                     471.69,
+                     471.77
+                  ],
+                  [
+                     "had",
+                     471.77,
+                     472.06
+                  ],
+                  [
+                     "with",
+                     472.06,
+                     472.19
+                  ],
+                  [
+                     "this",
+                     472.19,
+                     472.37
+                  ],
+                  [
+                     "baby",
+                     472.37,
+                     472.66
+                  ],
+                  [
+                     "dinosaur",
+                     472.66,
+                     473.07
+                  ],
+                  [
+                     "robot",
+                     473.07,
+                     473.59
+                  ]
+               ],
+               "confidence": 0.969,
+               "word_confidence": [
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "few",
+                     1
+                  ],
+                  [
+                     "years",
+                     1
+                  ],
+                  [
+                     "after",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "first",
+                     1
+                  ],
+                  [
+                     "initial",
+                     1
+                  ],
+                  [
+                     "experience",
+                     1
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "had",
+                     1
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "baby",
+                     0.949
+                  ],
+                  [
+                     "dinosaur",
+                     0.811
+                  ],
+                  [
+                     "robot",
+                     0.894
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "I did a workshop with my friend harness gossip and we took five of these baby dinosaur robots and we gave them the five teams of people and we have them name them and play with them and interact with them for about an hour ",
+               "timestamps": [
+                  [
+                     "I",
+                     474.43,
+                     474.47
+                  ],
+                  [
+                     "did",
+                     474.47,
+                     474.64
+                  ],
+                  [
+                     "a",
+                     474.64,
+                     474.69
+                  ],
+                  [
+                     "workshop",
+                     474.69,
+                     475.14
+                  ],
+                  [
+                     "with",
+                     475.14,
+                     475.28
+                  ],
+                  [
+                     "my",
+                     475.28,
+                     475.37
+                  ],
+                  [
+                     "friend",
+                     475.37,
+                     475.68
+                  ],
+                  [
+                     "harness",
+                     475.68,
+                     476.01
+                  ],
+                  [
+                     "gossip",
+                     476.01,
+                     476.48
+                  ],
+                  [
+                     "and",
+                     476.88,
+                     477.25
+                  ],
+                  [
+                     "we",
+                     477.54,
+                     477.68
+                  ],
+                  [
+                     "took",
+                     477.68,
+                     477.86
+                  ],
+                  [
+                     "five",
+                     477.86,
+                     478.24
+                  ],
+                  [
+                     "of",
+                     478.24,
+                     478.35
+                  ],
+                  [
+                     "these",
+                     478.35,
+                     478.63
+                  ],
+                  [
+                     "baby",
+                     478.63,
+                     478.89
+                  ],
+                  [
+                     "dinosaur",
+                     478.89,
+                     479.31
+                  ],
+                  [
+                     "robots",
+                     479.31,
+                     479.75
+                  ],
+                  [
+                     "and",
+                     479.75,
+                     479.9
+                  ],
+                  [
+                     "we",
+                     479.9,
+                     479.99
+                  ],
+                  [
+                     "gave",
+                     479.99,
+                     480.19
+                  ],
+                  [
+                     "them",
+                     480.19,
+                     480.31
+                  ],
+                  [
+                     "the",
+                     480.31,
+                     480.4
+                  ],
+                  [
+                     "five",
+                     480.4,
+                     480.74
+                  ],
+                  [
+                     "teams",
+                     480.74,
+                     481.07
+                  ],
+                  [
+                     "of",
+                     481.07,
+                     481.16
+                  ],
+                  [
+                     "people",
+                     481.16,
+                     481.71
+                  ],
+                  [
+                     "and",
+                     482.28,
+                     482.39
+                  ],
+                  [
+                     "we",
+                     482.39,
+                     482.47
+                  ],
+                  [
+                     "have",
+                     482.47,
+                     482.68
+                  ],
+                  [
+                     "them",
+                     482.68,
+                     482.81
+                  ],
+                  [
+                     "name",
+                     482.81,
+                     483.18
+                  ],
+                  [
+                     "them",
+                     483.18,
+                     483.65
+                  ],
+                  [
+                     "and",
+                     483.98,
+                     484.15
+                  ],
+                  [
+                     "play",
+                     484.15,
+                     484.42
+                  ],
+                  [
+                     "with",
+                     484.42,
+                     484.59
+                  ],
+                  [
+                     "them",
+                     484.59,
+                     485.1
+                  ],
+                  [
+                     "and",
+                     485.13,
+                     485.27
+                  ],
+                  [
+                     "interact",
+                     485.27,
+                     485.78
+                  ],
+                  [
+                     "with",
+                     485.78,
+                     485.91
+                  ],
+                  [
+                     "them",
+                     485.91,
+                     486.26
+                  ],
+                  [
+                     "for",
+                     486.26,
+                     486.7
+                  ],
+                  [
+                     "about",
+                     486.82,
+                     487.15
+                  ],
+                  [
+                     "an",
+                     487.15,
+                     487.26
+                  ],
+                  [
+                     "hour",
+                     487.26,
+                     487.71
+                  ]
+               ],
+               "confidence": 0.897,
+               "word_confidence": [
+                  [
+                     "I",
+                     0.967
+                  ],
+                  [
+                     "did",
+                     0.852
+                  ],
+                  [
+                     "a",
+                     0.685
+                  ],
+                  [
+                     "workshop",
+                     0.993
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "my",
+                     1
+                  ],
+                  [
+                     "friend",
+                     0.883
+                  ],
+                  [
+                     "harness",
+                     0.147
+                  ],
+                  [
+                     "gossip",
+                     0.199
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "took",
+                     1
+                  ],
+                  [
+                     "five",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "these",
+                     0.997
+                  ],
+                  [
+                     "baby",
+                     0.57
+                  ],
+                  [
+                     "dinosaur",
+                     1
+                  ],
+                  [
+                     "robots",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "gave",
+                     0.682
+                  ],
+                  [
+                     "them",
+                     0.871
+                  ],
+                  [
+                     "the",
+                     0.342
+                  ],
+                  [
+                     "five",
+                     1
+                  ],
+                  [
+                     "teams",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "people",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.78
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "have",
+                     0.628
+                  ],
+                  [
+                     "them",
+                     0.577
+                  ],
+                  [
+                     "name",
+                     0.94
+                  ],
+                  [
+                     "them",
+                     0.991
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "play",
+                     1
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "them",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "interact",
+                     1
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "them",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "about",
+                     1
+                  ],
+                  [
+                     "an",
+                     1
+                  ],
+                  [
+                     "hour",
+                     0.982
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and then we unveiled a hammer and hatchet and we told them to torture and kill the robots ",
+               "timestamps": [
+                  [
+                     "and",
+                     488.69,
+                     488.89
+                  ],
+                  [
+                     "then",
+                     488.89,
+                     489.05
+                  ],
+                  [
+                     "we",
+                     489.05,
+                     489.16
+                  ],
+                  [
+                     "unveiled",
+                     489.16,
+                     489.69
+                  ],
+                  [
+                     "a",
+                     489.72,
+                     489.81
+                  ],
+                  [
+                     "hammer",
+                     489.81,
+                     490.19
+                  ],
+                  [
+                     "and",
+                     490.19,
+                     490.32
+                  ],
+                  [
+                     "hatchet",
+                     490.32,
+                     490.9
+                  ],
+                  [
+                     "and",
+                     490.93,
+                     491.04
+                  ],
+                  [
+                     "we",
+                     491.04,
+                     491.14
+                  ],
+                  [
+                     "told",
+                     491.14,
+                     491.38
+                  ],
+                  [
+                     "them",
+                     491.38,
+                     491.49
+                  ],
+                  [
+                     "to",
+                     491.49,
+                     491.59
+                  ],
+                  [
+                     "torture",
+                     491.59,
+                     492.01
+                  ],
+                  [
+                     "and",
+                     492.01,
+                     492.12
+                  ],
+                  [
+                     "kill",
+                     492.12,
+                     492.41
+                  ],
+                  [
+                     "the",
+                     492.41,
+                     492.51
+                  ],
+                  [
+                     "robots",
+                     492.51,
+                     493.17
+                  ]
+               ],
+               "confidence": 0.906,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "then",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "unveiled",
+                     1
+                  ],
+                  [
+                     "a",
+                     0.903
+                  ],
+                  [
+                     "hammer",
+                     0.985
+                  ],
+                  [
+                     "and",
+                     0.88
+                  ],
+                  [
+                     "hatchet",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "told",
+                     1
+                  ],
+                  [
+                     "them",
+                     0.704
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "torture",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "kill",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.467
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and this turned out to be a little more dramatic than we expected it to be because none of the participants would even so much a strike these baby dinosaur robots so we had to improvise a little and at some point he said okay ",
+               "timestamps": [
+                  [
+                     "and",
+                     496.84,
+                     497.07
+                  ],
+                  [
+                     "this",
+                     497.17,
+                     497.4
+                  ],
+                  [
+                     "turned",
+                     497.4,
+                     497.64
+                  ],
+                  [
+                     "out",
+                     497.64,
+                     497.78
+                  ],
+                  [
+                     "to",
+                     497.78,
+                     497.91
+                  ],
+                  [
+                     "be",
+                     497.91,
+                     498.02
+                  ],
+                  [
+                     "a",
+                     498.02,
+                     498.09
+                  ],
+                  [
+                     "little",
+                     498.09,
+                     498.28
+                  ],
+                  [
+                     "more",
+                     498.28,
+                     498.44
+                  ],
+                  [
+                     "dramatic",
+                     498.44,
+                     498.97
+                  ],
+                  [
+                     "than",
+                     498.97,
+                     499.12
+                  ],
+                  [
+                     "we",
+                     499.12,
+                     499.22
+                  ],
+                  [
+                     "expected",
+                     499.22,
+                     499.9
+                  ],
+                  [
+                     "it",
+                     499.9,
+                     500
+                  ],
+                  [
+                     "to",
+                     500,
+                     500.11
+                  ],
+                  [
+                     "be",
+                     500.11,
+                     500.29
+                  ],
+                  [
+                     "because",
+                     500.29,
+                     500.57
+                  ],
+                  [
+                     "none",
+                     500.57,
+                     500.89
+                  ],
+                  [
+                     "of",
+                     500.89,
+                     501
+                  ],
+                  [
+                     "the",
+                     501,
+                     501.09
+                  ],
+                  [
+                     "participants",
+                     501.09,
+                     501.84
+                  ],
+                  [
+                     "would",
+                     501.84,
+                     502.09
+                  ],
+                  [
+                     "even",
+                     502.44,
+                     502.7
+                  ],
+                  [
+                     "so",
+                     502.7,
+                     502.83
+                  ],
+                  [
+                     "much",
+                     502.83,
+                     502.99
+                  ],
+                  [
+                     "a",
+                     502.99,
+                     503.07
+                  ],
+                  [
+                     "strike",
+                     503.07,
+                     503.54
+                  ],
+                  [
+                     "these",
+                     503.54,
+                     503.76
+                  ],
+                  [
+                     "baby",
+                     503.76,
+                     503.96
+                  ],
+                  [
+                     "dinosaur",
+                     503.96,
+                     504.33
+                  ],
+                  [
+                     "robots",
+                     504.33,
+                     504.76
+                  ],
+                  [
+                     "so",
+                     504.76,
+                     505.12
+                  ],
+                  [
+                     "we",
+                     505.36,
+                     505.54
+                  ],
+                  [
+                     "had",
+                     505.54,
+                     505.64
+                  ],
+                  [
+                     "to",
+                     505.64,
+                     505.72
+                  ],
+                  [
+                     "improvise",
+                     505.72,
+                     506.2
+                  ],
+                  [
+                     "a",
+                     506.2,
+                     506.26
+                  ],
+                  [
+                     "little",
+                     506.26,
+                     506.71
+                  ],
+                  [
+                     "and",
+                     507.35,
+                     507.75
+                  ],
+                  [
+                     "at",
+                     507.79,
+                     507.98
+                  ],
+                  [
+                     "some",
+                     507.98,
+                     508.13
+                  ],
+                  [
+                     "point",
+                     508.13,
+                     508.32
+                  ],
+                  [
+                     "he",
+                     508.32,
+                     508.4
+                  ],
+                  [
+                     "said",
+                     508.4,
+                     508.71
+                  ],
+                  [
+                     "okay",
+                     508.71,
+                     509.34
+                  ]
+               ],
+               "confidence": 0.92,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.614
+                  ],
+                  [
+                     "this",
+                     0.966
+                  ],
+                  [
+                     "turned",
+                     1
+                  ],
+                  [
+                     "out",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "be",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "little",
+                     1
+                  ],
+                  [
+                     "more",
+                     1
+                  ],
+                  [
+                     "dramatic",
+                     1
+                  ],
+                  [
+                     "than",
+                     1
+                  ],
+                  [
+                     "we",
+                     0.614
+                  ],
+                  [
+                     "expected",
+                     0.993
+                  ],
+                  [
+                     "it",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "be",
+                     1
+                  ],
+                  [
+                     "because",
+                     1
+                  ],
+                  [
+                     "none",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "participants",
+                     1
+                  ],
+                  [
+                     "would",
+                     0.562
+                  ],
+                  [
+                     "even",
+                     1
+                  ],
+                  [
+                     "so",
+                     1
+                  ],
+                  [
+                     "much",
+                     1
+                  ],
+                  [
+                     "a",
+                     0.507
+                  ],
+                  [
+                     "strike",
+                     0.964
+                  ],
+                  [
+                     "these",
+                     0.982
+                  ],
+                  [
+                     "baby",
+                     0.396
+                  ],
+                  [
+                     "dinosaur",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.688
+                  ],
+                  [
+                     "so",
+                     0.97
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "had",
+                     0.734
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "improvise",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "little",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.451
+                  ],
+                  [
+                     "at",
+                     1
+                  ],
+                  [
+                     "some",
+                     1
+                  ],
+                  [
+                     "point",
+                     0.98
+                  ],
+                  [
+                     "he",
+                     0.406
+                  ],
+                  [
+                     "said",
+                     0.996
+                  ],
+                  [
+                     "okay",
+                     0.981
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "you can save your team's robot if you destroy another team's robot ",
+               "timestamps": [
+                  [
+                     "you",
+                     510.06,
+                     510.33
+                  ],
+                  [
+                     "can",
+                     510.33,
+                     510.49
+                  ],
+                  [
+                     "save",
+                     510.49,
+                     510.8
+                  ],
+                  [
+                     "your",
+                     510.8,
+                     511.13
+                  ],
+                  [
+                     "team's",
+                     511.13,
+                     511.59
+                  ],
+                  [
+                     "robot",
+                     511.59,
+                     512.08
+                  ],
+                  [
+                     "if",
+                     512.11,
+                     512.3
+                  ],
+                  [
+                     "you",
+                     512.3,
+                     512.44
+                  ],
+                  [
+                     "destroy",
+                     512.44,
+                     513.01
+                  ],
+                  [
+                     "another",
+                     513.04,
+                     513.6
+                  ],
+                  [
+                     "team's",
+                     513.6,
+                     514.01
+                  ],
+                  [
+                     "robot",
+                     514.01,
+                     514.56
+                  ]
+               ],
+               "confidence": 0.815,
+               "word_confidence": [
+                  [
+                     "you",
+                     1
+                  ],
+                  [
+                     "can",
+                     0.783
+                  ],
+                  [
+                     "save",
+                     0.979
+                  ],
+                  [
+                     "your",
+                     1
+                  ],
+                  [
+                     "team's",
+                     0.686
+                  ],
+                  [
+                     "robot",
+                     0.917
+                  ],
+                  [
+                     "if",
+                     1
+                  ],
+                  [
+                     "you",
+                     1
+                  ],
+                  [
+                     "destroy",
+                     0.97
+                  ],
+                  [
+                     "another",
+                     0.894
+                  ],
+                  [
+                     "team's",
+                     0.624
+                  ],
+                  [
+                     "robot",
+                     0.335
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and even that didn't work they couldn't do it so finally we said we're going to destroy all of the robots unless someone takes a hatchet to one of them ",
+               "timestamps": [
+                  [
+                     "and",
+                     516.82,
+                     516.99
+                  ],
+                  [
+                     "even",
+                     516.99,
+                     517.18
+                  ],
+                  [
+                     "that",
+                     517.18,
+                     517.33
+                  ],
+                  [
+                     "didn't",
+                     517.33,
+                     517.58
+                  ],
+                  [
+                     "work",
+                     517.58,
+                     517.82
+                  ],
+                  [
+                     "they",
+                     517.82,
+                     517.93
+                  ],
+                  [
+                     "couldn't",
+                     517.93,
+                     518.22
+                  ],
+                  [
+                     "do",
+                     518.22,
+                     518.33
+                  ],
+                  [
+                     "it",
+                     518.33,
+                     518.53
+                  ],
+                  [
+                     "so",
+                     518.64,
+                     518.82
+                  ],
+                  [
+                     "finally",
+                     518.82,
+                     519.24
+                  ],
+                  [
+                     "we",
+                     519.24,
+                     519.33
+                  ],
+                  [
+                     "said",
+                     519.33,
+                     519.75
+                  ],
+                  [
+                     "we're",
+                     519.99,
+                     520.22
+                  ],
+                  [
+                     "going",
+                     520.22,
+                     520.34
+                  ],
+                  [
+                     "to",
+                     520.34,
+                     520.4
+                  ],
+                  [
+                     "destroy",
+                     520.4,
+                     520.88
+                  ],
+                  [
+                     "all",
+                     520.91,
+                     521.17
+                  ],
+                  [
+                     "of",
+                     521.17,
+                     521.27
+                  ],
+                  [
+                     "the",
+                     521.27,
+                     521.37
+                  ],
+                  [
+                     "robots",
+                     521.37,
+                     521.91
+                  ],
+                  [
+                     "unless",
+                     521.94,
+                     522.22
+                  ],
+                  [
+                     "someone",
+                     522.22,
+                     522.49
+                  ],
+                  [
+                     "takes",
+                     522.49,
+                     522.69
+                  ],
+                  [
+                     "a",
+                     522.69,
+                     522.76
+                  ],
+                  [
+                     "hatchet",
+                     522.76,
+                     523.23
+                  ],
+                  [
+                     "to",
+                     523.23,
+                     523.35
+                  ],
+                  [
+                     "one",
+                     523.35,
+                     523.55
+                  ],
+                  [
+                     "of",
+                     523.55,
+                     523.68
+                  ],
+                  [
+                     "them",
+                     523.68,
+                     524.01
+                  ]
+               ],
+               "confidence": 0.908,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.84
+                  ],
+                  [
+                     "even",
+                     0.975
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "didn't",
+                     1
+                  ],
+                  [
+                     "work",
+                     1
+                  ],
+                  [
+                     "they",
+                     0.721
+                  ],
+                  [
+                     "couldn't",
+                     0.985
+                  ],
+                  [
+                     "do",
+                     1
+                  ],
+                  [
+                     "it",
+                     0.989
+                  ],
+                  [
+                     "so",
+                     1
+                  ],
+                  [
+                     "finally",
+                     1
+                  ],
+                  [
+                     "we",
+                     0.304
+                  ],
+                  [
+                     "said",
+                     1
+                  ],
+                  [
+                     "we're",
+                     1
+                  ],
+                  [
+                     "going",
+                     0.471
+                  ],
+                  [
+                     "to",
+                     0.471
+                  ],
+                  [
+                     "destroy",
+                     0.886
+                  ],
+                  [
+                     "all",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.78
+                  ],
+                  [
+                     "unless",
+                     1
+                  ],
+                  [
+                     "someone",
+                     1
+                  ],
+                  [
+                     "takes",
+                     0.821
+                  ],
+                  [
+                     "a",
+                     0.572
+                  ],
+                  [
+                     "hatchet",
+                     0.67
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "one",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "them",
+                     0.992
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and this guy stood up and he took the hatchet ",
+               "timestamps": [
+                  [
+                     "and",
+                     525.56,
+                     525.78
+                  ],
+                  [
+                     "this",
+                     525.78,
+                     525.96
+                  ],
+                  [
+                     "guy",
+                     525.96,
+                     526.2
+                  ],
+                  [
+                     "stood",
+                     526.2,
+                     526.48
+                  ],
+                  [
+                     "up",
+                     526.48,
+                     526.75
+                  ],
+                  [
+                     "and",
+                     526.78,
+                     527.06
+                  ],
+                  [
+                     "he",
+                     527.06,
+                     527.28
+                  ],
+                  [
+                     "took",
+                     527.28,
+                     527.61
+                  ],
+                  [
+                     "the",
+                     527.61,
+                     527.71
+                  ],
+                  [
+                     "hatchet",
+                     527.71,
+                     528.33
+                  ]
+               ],
+               "confidence": 0.859,
+               "word_confidence": [
+                  [
+                     "and",
+                     0.301
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "guy",
+                     0.803
+                  ],
+                  [
+                     "stood",
+                     0.859
+                  ],
+                  [
+                     "up",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "he",
+                     1
+                  ],
+                  [
+                     "took",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "hatchet",
+                     0.765
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and the whole room winced as he brought the hatchet down on the robots neck and there was this half joking half serious moment of silence in the room for this fallen robot ",
+               "timestamps": [
+                  [
+                     "and",
+                     529.18,
+                     529.37
+                  ],
+                  [
+                     "the",
+                     529.37,
+                     529.44
+                  ],
+                  [
+                     "whole",
+                     529.44,
+                     529.7
+                  ],
+                  [
+                     "room",
+                     529.7,
+                     530.06
+                  ],
+                  [
+                     "winced",
+                     530.06,
+                     530.56
+                  ],
+                  [
+                     "as",
+                     530.56,
+                     530.66
+                  ],
+                  [
+                     "he",
+                     530.66,
+                     530.76
+                  ],
+                  [
+                     "brought",
+                     530.76,
+                     531
+                  ],
+                  [
+                     "the",
+                     531,
+                     531.08
+                  ],
+                  [
+                     "hatchet",
+                     531.08,
+                     531.47
+                  ],
+                  [
+                     "down",
+                     531.47,
+                     531.73
+                  ],
+                  [
+                     "on",
+                     531.73,
+                     531.82
+                  ],
+                  [
+                     "the",
+                     531.82,
+                     531.93
+                  ],
+                  [
+                     "robots",
+                     531.93,
+                     532.4
+                  ],
+                  [
+                     "neck",
+                     532.4,
+                     533.02
+                  ],
+                  [
+                     "and",
+                     533.68,
+                     534.06
+                  ],
+                  [
+                     "there",
+                     534.09,
+                     534.33
+                  ],
+                  [
+                     "was",
+                     534.33,
+                     534.5
+                  ],
+                  [
+                     "this",
+                     534.5,
+                     534.65
+                  ],
+                  [
+                     "half",
+                     534.65,
+                     535.11
+                  ],
+                  [
+                     "joking",
+                     535.11,
+                     535.83
+                  ],
+                  [
+                     "half",
+                     536,
+                     536.65
+                  ],
+                  [
+                     "serious",
+                     536.68,
+                     537.4
+                  ],
+                  [
+                     "moment",
+                     537.4,
+                     537.8
+                  ],
+                  [
+                     "of",
+                     537.8,
+                     537.87
+                  ],
+                  [
+                     "silence",
+                     537.87,
+                     538.54
+                  ],
+                  [
+                     "in",
+                     538.54,
+                     538.79
+                  ],
+                  [
+                     "the",
+                     538.79,
+                     538.89
+                  ],
+                  [
+                     "room",
+                     538.89,
+                     539.52
+                  ],
+                  [
+                     "for",
+                     540.02,
+                     540.26
+                  ],
+                  [
+                     "this",
+                     540.26,
+                     540.45
+                  ],
+                  [
+                     "fallen",
+                     540.45,
+                     540.96
+                  ],
+                  [
+                     "robot",
+                     540.96,
+                     541.57
+                  ]
+               ],
+               "confidence": 0.849,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "the",
+                     0.932
+                  ],
+                  [
+                     "whole",
+                     1
+                  ],
+                  [
+                     "room",
+                     0.927
+                  ],
+                  [
+                     "winced",
+                     0.866
+                  ],
+                  [
+                     "as",
+                     1
+                  ],
+                  [
+                     "he",
+                     0.936
+                  ],
+                  [
+                     "brought",
+                     1
+                  ],
+                  [
+                     "the",
+                     0.967
+                  ],
+                  [
+                     "hatchet",
+                     0.421
+                  ],
+                  [
+                     "down",
+                     1
+                  ],
+                  [
+                     "on",
+                     0.536
+                  ],
+                  [
+                     "the",
+                     0.962
+                  ],
+                  [
+                     "robots",
+                     0.521
+                  ],
+                  [
+                     "neck",
+                     0.369
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "there",
+                     1
+                  ],
+                  [
+                     "was",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "half",
+                     1
+                  ],
+                  [
+                     "joking",
+                     0.997
+                  ],
+                  [
+                     "half",
+                     1
+                  ],
+                  [
+                     "serious",
+                     0.563
+                  ],
+                  [
+                     "moment",
+                     0.836
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "silence",
+                     1
+                  ],
+                  [
+                     "in",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "room",
+                     0.999
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "fallen",
+                     0.6
+                  ],
+                  [
+                     "robot",
+                     0.876
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "so that was a really interesting experience no it wasn't a controlled study obviously but it did lead to some later research that I did it on my T. with plush non Dian Cynthia Brazil where we had people come into the lab and smash these hex bugs that move around in a really life like way like insects so instead of choosing something cute the people are drawn to which was something more basic and what we found was that high embassy people would hesitate more to hit the hex Bucks ",
+               "timestamps": [
+                  [
+                     "so",
+                     543.2,
+                     543.53
+                  ],
+                  [
+                     "that",
+                     543.63,
+                     543.83
+                  ],
+                  [
+                     "was",
+                     543.83,
+                     544.03
+                  ],
+                  [
+                     "a",
+                     544.03,
+                     544.12
+                  ],
+                  [
+                     "really",
+                     544.12,
+                     544.52
+                  ],
+                  [
+                     "interesting",
+                     544.55,
+                     545.36
+                  ],
+                  [
+                     "experience",
+                     545.36,
+                     546.52
+                  ],
+                  [
+                     "no",
+                     546.9,
+                     547.08
+                  ],
+                  [
+                     "it",
+                     547.08,
+                     547.25
+                  ],
+                  [
+                     "wasn't",
+                     547.25,
+                     547.53
+                  ],
+                  [
+                     "a",
+                     547.53,
+                     547.58
+                  ],
+                  [
+                     "controlled",
+                     547.58,
+                     548.25
+                  ],
+                  [
+                     "study",
+                     548.25,
+                     548.7
+                  ],
+                  [
+                     "obviously",
+                     548.7,
+                     549.33
+                  ],
+                  [
+                     "but",
+                     549.33,
+                     549.56
+                  ],
+                  [
+                     "it",
+                     549.56,
+                     549.7
+                  ],
+                  [
+                     "did",
+                     549.7,
+                     549.92
+                  ],
+                  [
+                     "lead",
+                     549.92,
+                     550.13
+                  ],
+                  [
+                     "to",
+                     550.13,
+                     550.21
+                  ],
+                  [
+                     "some",
+                     550.21,
+                     550.41
+                  ],
+                  [
+                     "later",
+                     550.41,
+                     550.7
+                  ],
+                  [
+                     "research",
+                     550.7,
+                     551.16
+                  ],
+                  [
+                     "that",
+                     551.16,
+                     551.33
+                  ],
+                  [
+                     "I",
+                     551.33,
+                     551.4
+                  ],
+                  [
+                     "did",
+                     551.4,
+                     551.68
+                  ],
+                  [
+                     "it",
+                     551.68,
+                     551.78
+                  ],
+                  [
+                     "on",
+                     551.78,
+                     551.88
+                  ],
+                  [
+                     "my",
+                     551.88,
+                     551.98
+                  ],
+                  [
+                     "T.",
+                     551.98,
+                     552.25
+                  ],
+                  [
+                     "with",
+                     552.25,
+                     552.42
+                  ],
+                  [
+                     "plush",
+                     552.42,
+                     552.82
+                  ],
+                  [
+                     "non",
+                     552.82,
+                     553.06
+                  ],
+                  [
+                     "Dian",
+                     553.06,
+                     553.25
+                  ],
+                  [
+                     "Cynthia",
+                     553.25,
+                     553.62
+                  ],
+                  [
+                     "Brazil",
+                     553.62,
+                     554.24
+                  ],
+                  [
+                     "where",
+                     554.41,
+                     554.82
+                  ],
+                  [
+                     "we",
+                     554.82,
+                     554.95
+                  ],
+                  [
+                     "had",
+                     554.95,
+                     555.1
+                  ],
+                  [
+                     "people",
+                     555.1,
+                     555.32
+                  ],
+                  [
+                     "come",
+                     555.32,
+                     555.5
+                  ],
+                  [
+                     "into",
+                     555.5,
+                     555.7
+                  ],
+                  [
+                     "the",
+                     555.7,
+                     555.8
+                  ],
+                  [
+                     "lab",
+                     555.8,
+                     556.3
+                  ],
+                  [
+                     "and",
+                     556.64,
+                     556.88
+                  ],
+                  [
+                     "smash",
+                     556.88,
+                     557.21
+                  ],
+                  [
+                     "these",
+                     557.21,
+                     557.42
+                  ],
+                  [
+                     "hex",
+                     557.42,
+                     557.83
+                  ],
+                  [
+                     "bugs",
+                     557.83,
+                     558.19
+                  ],
+                  [
+                     "that",
+                     558.19,
+                     558.31
+                  ],
+                  [
+                     "move",
+                     558.31,
+                     558.61
+                  ],
+                  [
+                     "around",
+                     558.61,
+                     559.1
+                  ],
+                  [
+                     "in",
+                     559.1,
+                     559.21
+                  ],
+                  [
+                     "a",
+                     559.21,
+                     559.27
+                  ],
+                  [
+                     "really",
+                     559.27,
+                     559.49
+                  ],
+                  [
+                     "life",
+                     559.49,
+                     559.74
+                  ],
+                  [
+                     "like",
+                     559.74,
+                     559.91
+                  ],
+                  [
+                     "way",
+                     559.91,
+                     560.08
+                  ],
+                  [
+                     "like",
+                     560.08,
+                     560.29
+                  ],
+                  [
+                     "insects",
+                     560.29,
+                     561.16
+                  ],
+                  [
+                     "so",
+                     561.31,
+                     561.47
+                  ],
+                  [
+                     "instead",
+                     561.47,
+                     561.7
+                  ],
+                  [
+                     "of",
+                     561.7,
+                     561.79
+                  ],
+                  [
+                     "choosing",
+                     561.79,
+                     562.08
+                  ],
+                  [
+                     "something",
+                     562.08,
+                     562.34
+                  ],
+                  [
+                     "cute",
+                     562.34,
+                     562.74
+                  ],
+                  [
+                     "the",
+                     562.74,
+                     562.83
+                  ],
+                  [
+                     "people",
+                     562.83,
+                     563.37
+                  ],
+                  [
+                     "are",
+                     563.72,
+                     563.85
+                  ],
+                  [
+                     "drawn",
+                     563.85,
+                     564.22
+                  ],
+                  [
+                     "to",
+                     564.22,
+                     564.44
+                  ],
+                  [
+                     "which",
+                     564.44,
+                     564.64
+                  ],
+                  [
+                     "was",
+                     564.64,
+                     564.77
+                  ],
+                  [
+                     "something",
+                     564.77,
+                     565.04
+                  ],
+                  [
+                     "more",
+                     565.04,
+                     565.23
+                  ],
+                  [
+                     "basic",
+                     565.23,
+                     566.06
+                  ],
+                  [
+                     "and",
+                     566.57,
+                     566.97
+                  ],
+                  [
+                     "what",
+                     567.21,
+                     567.4
+                  ],
+                  [
+                     "we",
+                     567.4,
+                     567.52
+                  ],
+                  [
+                     "found",
+                     567.52,
+                     568.12
+                  ],
+                  [
+                     "was",
+                     568.15,
+                     568.53
+                  ],
+                  [
+                     "that",
+                     568.53,
+                     568.77
+                  ],
+                  [
+                     "high",
+                     568.8,
+                     569.15
+                  ],
+                  [
+                     "embassy",
+                     569.15,
+                     569.65
+                  ],
+                  [
+                     "people",
+                     569.65,
+                     570.08
+                  ],
+                  [
+                     "would",
+                     570.08,
+                     570.25
+                  ],
+                  [
+                     "hesitate",
+                     570.25,
+                     570.78
+                  ],
+                  [
+                     "more",
+                     570.78,
+                     570.99
+                  ],
+                  [
+                     "to",
+                     570.99,
+                     571.07
+                  ],
+                  [
+                     "hit",
+                     571.07,
+                     571.26
+                  ],
+                  [
+                     "the",
+                     571.26,
+                     571.35
+                  ],
+                  [
+                     "hex",
+                     571.35,
+                     571.68
+                  ],
+                  [
+                     "Bucks",
+                     571.68,
+                     572.16
+                  ]
+               ],
+               "confidence": 0.843,
+               "word_confidence": [
+                  [
+                     "so",
+                     0.503
+                  ],
+                  [
+                     "that",
+                     0.89
+                  ],
+                  [
+                     "was",
+                     1
+                  ],
+                  [
+                     "a",
+                     0.774
+                  ],
+                  [
+                     "really",
+                     0.955
+                  ],
+                  [
+                     "interesting",
+                     1
+                  ],
+                  [
+                     "experience",
+                     0.997
+                  ],
+                  [
+                     "no",
+                     0.685
+                  ],
+                  [
+                     "it",
+                     1
+                  ],
+                  [
+                     "wasn't",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "controlled",
+                     1
+                  ],
+                  [
+                     "study",
+                     1
+                  ],
+                  [
+                     "obviously",
+                     1
+                  ],
+                  [
+                     "but",
+                     1
+                  ],
+                  [
+                     "it",
+                     1
+                  ],
+                  [
+                     "did",
+                     0.821
+                  ],
+                  [
+                     "lead",
+                     0.974
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "some",
+                     1
+                  ],
+                  [
+                     "later",
+                     0.81
+                  ],
+                  [
+                     "research",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "I",
+                     1
+                  ],
+                  [
+                     "did",
+                     0.993
+                  ],
+                  [
+                     "it",
+                     0.484
+                  ],
+                  [
+                     "on",
+                     0.194
+                  ],
+                  [
+                     "my",
+                     0.608
+                  ],
+                  [
+                     "T.",
+                     0.935
+                  ],
+                  [
+                     "with",
+                     0.968
+                  ],
+                  [
+                     "plush",
+                     0.255
+                  ],
+                  [
+                     "non",
+                     0.468
+                  ],
+                  [
+                     "Dian",
+                     0.332
+                  ],
+                  [
+                     "Cynthia",
+                     0.186
+                  ],
+                  [
+                     "Brazil",
+                     0.548
+                  ],
+                  [
+                     "where",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "had",
+                     0.641
+                  ],
+                  [
+                     "people",
+                     1
+                  ],
+                  [
+                     "come",
+                     0.799
+                  ],
+                  [
+                     "into",
+                     0.361
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "lab",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "smash",
+                     0.592
+                  ],
+                  [
+                     "these",
+                     0.914
+                  ],
+                  [
+                     "hex",
+                     0.657
+                  ],
+                  [
+                     "bugs",
+                     0.996
+                  ],
+                  [
+                     "that",
+                     0.577
+                  ],
+                  [
+                     "move",
+                     0.549
+                  ],
+                  [
+                     "around",
+                     1
+                  ],
+                  [
+                     "in",
+                     0.59
+                  ],
+                  [
+                     "a",
+                     0.505
+                  ],
+                  [
+                     "really",
+                     1
+                  ],
+                  [
+                     "life",
+                     0.76
+                  ],
+                  [
+                     "like",
+                     0.792
+                  ],
+                  [
+                     "way",
+                     0.809
+                  ],
+                  [
+                     "like",
+                     0.985
+                  ],
+                  [
+                     "insects",
+                     0.798
+                  ],
+                  [
+                     "so",
+                     1
+                  ],
+                  [
+                     "instead",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "choosing",
+                     1
+                  ],
+                  [
+                     "something",
+                     0.515
+                  ],
+                  [
+                     "cute",
+                     0.487
+                  ],
+                  [
+                     "the",
+                     0.381
+                  ],
+                  [
+                     "people",
+                     0.98
+                  ],
+                  [
+                     "are",
+                     1
+                  ],
+                  [
+                     "drawn",
+                     0.94
+                  ],
+                  [
+                     "to",
+                     0.848
+                  ],
+                  [
+                     "which",
+                     0.523
+                  ],
+                  [
+                     "was",
+                     0.261
+                  ],
+                  [
+                     "something",
+                     1
+                  ],
+                  [
+                     "more",
+                     1
+                  ],
+                  [
+                     "basic",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "what",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "found",
+                     1
+                  ],
+                  [
+                     "was",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "high",
+                     0.986
+                  ],
+                  [
+                     "embassy",
+                     0.288
+                  ],
+                  [
+                     "people",
+                     1
+                  ],
+                  [
+                     "would",
+                     0.756
+                  ],
+                  [
+                     "hesitate",
+                     1
+                  ],
+                  [
+                     "more",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.872
+                  ],
+                  [
+                     "hit",
+                     0.819
+                  ],
+                  [
+                     "the",
+                     0.92
+                  ],
+                  [
+                     "hex",
+                     0.868
+                  ],
+                  [
+                     "Bucks",
+                     0.478
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "I was just a little study but it's part of a larger body of research that is starting to indicate that there may be a connection between people's tendencies for empathy and their behavior around robots ",
+               "timestamps": [
+                  [
+                     "I",
+                     573.58,
+                     573.66
+                  ],
+                  [
+                     "was",
+                     573.66,
+                     573.92
+                  ],
+                  [
+                     "just",
+                     573.92,
+                     574.1
+                  ],
+                  [
+                     "a",
+                     574.1,
+                     574.16
+                  ],
+                  [
+                     "little",
+                     574.16,
+                     574.39
+                  ],
+                  [
+                     "study",
+                     574.39,
+                     574.89
+                  ],
+                  [
+                     "but",
+                     574.89,
+                     575.27
+                  ],
+                  [
+                     "it's",
+                     575.51,
+                     575.71
+                  ],
+                  [
+                     "part",
+                     575.71,
+                     575.97
+                  ],
+                  [
+                     "of",
+                     575.97,
+                     576.04
+                  ],
+                  [
+                     "a",
+                     576.04,
+                     576.13
+                  ],
+                  [
+                     "larger",
+                     576.13,
+                     576.48
+                  ],
+                  [
+                     "body",
+                     576.48,
+                     576.75
+                  ],
+                  [
+                     "of",
+                     576.75,
+                     576.86
+                  ],
+                  [
+                     "research",
+                     576.86,
+                     577.48
+                  ],
+                  [
+                     "that",
+                     577.48,
+                     577.89
+                  ],
+                  [
+                     "is",
+                     577.99,
+                     578.21
+                  ],
+                  [
+                     "starting",
+                     578.21,
+                     578.58
+                  ],
+                  [
+                     "to",
+                     578.58,
+                     578.73
+                  ],
+                  [
+                     "indicate",
+                     578.73,
+                     579.19
+                  ],
+                  [
+                     "that",
+                     579.19,
+                     579.3
+                  ],
+                  [
+                     "there",
+                     579.3,
+                     579.4
+                  ],
+                  [
+                     "may",
+                     579.4,
+                     579.6
+                  ],
+                  [
+                     "be",
+                     579.6,
+                     579.82
+                  ],
+                  [
+                     "a",
+                     579.82,
+                     579.93
+                  ],
+                  [
+                     "connection",
+                     579.93,
+                     580.52
+                  ],
+                  [
+                     "between",
+                     580.52,
+                     580.85
+                  ],
+                  [
+                     "people's",
+                     580.85,
+                     581.27
+                  ],
+                  [
+                     "tendencies",
+                     581.27,
+                     581.78
+                  ],
+                  [
+                     "for",
+                     581.78,
+                     581.9
+                  ],
+                  [
+                     "empathy",
+                     581.9,
+                     582.62
+                  ],
+                  [
+                     "and",
+                     582.89,
+                     583.04
+                  ],
+                  [
+                     "their",
+                     583.04,
+                     583.15
+                  ],
+                  [
+                     "behavior",
+                     583.15,
+                     583.83
+                  ],
+                  [
+                     "around",
+                     583.83,
+                     584.18
+                  ],
+                  [
+                     "robots",
+                     584.18,
+                     584.86
+                  ]
+               ],
+               "confidence": 0.884,
+               "word_confidence": [
+                  [
+                     "I",
+                     0.189
+                  ],
+                  [
+                     "was",
+                     0.155
+                  ],
+                  [
+                     "just",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "little",
+                     0.981
+                  ],
+                  [
+                     "study",
+                     0.383
+                  ],
+                  [
+                     "but",
+                     1
+                  ],
+                  [
+                     "it's",
+                     1
+                  ],
+                  [
+                     "part",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "larger",
+                     0.614
+                  ],
+                  [
+                     "body",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "research",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "is",
+                     0.761
+                  ],
+                  [
+                     "starting",
+                     0.994
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "indicate",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "there",
+                     1
+                  ],
+                  [
+                     "may",
+                     1
+                  ],
+                  [
+                     "be",
+                     1
+                  ],
+                  [
+                     "a",
+                     0.896
+                  ],
+                  [
+                     "connection",
+                     1
+                  ],
+                  [
+                     "between",
+                     1
+                  ],
+                  [
+                     "people's",
+                     0.948
+                  ],
+                  [
+                     "tendencies",
+                     0.749
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "empathy",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "their",
+                     0.852
+                  ],
+                  [
+                     "behavior",
+                     0.996
+                  ],
+                  [
+                     "around",
+                     0.994
+                  ],
+                  [
+                     "robots",
+                     0.6
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "but my question for the coming era of human robot interaction is not do we empathize with robots ",
+               "timestamps": [
+                  [
+                     "but",
+                     585.7,
+                     585.84
+                  ],
+                  [
+                     "my",
+                     585.84,
+                     586.08
+                  ],
+                  [
+                     "question",
+                     586.08,
+                     586.83
+                  ],
+                  [
+                     "for",
+                     586.86,
+                     587
+                  ],
+                  [
+                     "the",
+                     587,
+                     587.09
+                  ],
+                  [
+                     "coming",
+                     587.09,
+                     587.5
+                  ],
+                  [
+                     "era",
+                     587.5,
+                     587.95
+                  ],
+                  [
+                     "of",
+                     587.95,
+                     588.07
+                  ],
+                  [
+                     "human",
+                     588.07,
+                     588.37
+                  ],
+                  [
+                     "robot",
+                     588.37,
+                     588.68
+                  ],
+                  [
+                     "interaction",
+                     588.68,
+                     589.36
+                  ],
+                  [
+                     "is",
+                     589.36,
+                     589.53
+                  ],
+                  [
+                     "not",
+                     589.53,
+                     589.99
+                  ],
+                  [
+                     "do",
+                     590.45,
+                     590.57
+                  ],
+                  [
+                     "we",
+                     590.57,
+                     590.73
+                  ],
+                  [
+                     "empathize",
+                     590.73,
+                     591.4
+                  ],
+                  [
+                     "with",
+                     591.4,
+                     591.58
+                  ],
+                  [
+                     "robots",
+                     591.58,
+                     592.32
+                  ]
+               ],
+               "confidence": 0.952,
+               "word_confidence": [
+                  [
+                     "but",
+                     0.67
+                  ],
+                  [
+                     "my",
+                     0.963
+                  ],
+                  [
+                     "question",
+                     0.818
+                  ],
+                  [
+                     "for",
+                     0.858
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "coming",
+                     1
+                  ],
+                  [
+                     "era",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "human",
+                     1
+                  ],
+                  [
+                     "robot",
+                     1
+                  ],
+                  [
+                     "interaction",
+                     0.988
+                  ],
+                  [
+                     "is",
+                     0.796
+                  ],
+                  [
+                     "not",
+                     1
+                  ],
+                  [
+                     "do",
+                     0.726
+                  ],
+                  [
+                     "we",
+                     0.974
+                  ],
+                  [
+                     "empathize",
+                     1
+                  ],
+                  [
+                     "with",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.999
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "it's Karen robots change people's empathy ",
+               "timestamps": [
+                  [
+                     "it's",
+                     593.19,
+                     593.4
+                  ],
+                  [
+                     "Karen",
+                     593.4,
+                     593.77
+                  ],
+                  [
+                     "robots",
+                     593.77,
+                     594.32
+                  ],
+                  [
+                     "change",
+                     594.35,
+                     594.98
+                  ],
+                  [
+                     "people's",
+                     594.98,
+                     595.37
+                  ],
+                  [
+                     "empathy",
+                     595.37,
+                     595.99
+                  ]
+               ],
+               "confidence": 0.749,
+               "word_confidence": [
+                  [
+                     "it's",
+                     0.949
+                  ],
+                  [
+                     "Karen",
+                     0.322
+                  ],
+                  [
+                     "robots",
+                     0.503
+                  ],
+                  [
+                     "change",
+                     0.826
+                  ],
+                  [
+                     "people's",
+                     0.978
+                  ],
+                  [
+                     "empathy",
+                     0.931
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "is there reason to for example prevent your child from kicking a robotic doc ",
+               "timestamps": [
+                  [
+                     "is",
+                     597.46,
+                     597.67
+                  ],
+                  [
+                     "there",
+                     597.67,
+                     597.85
+                  ],
+                  [
+                     "reason",
+                     597.85,
+                     598.25
+                  ],
+                  [
+                     "to",
+                     598.25,
+                     598.46
+                  ],
+                  [
+                     "for",
+                     598.46,
+                     598.65
+                  ],
+                  [
+                     "example",
+                     598.65,
+                     599.48
+                  ],
+                  [
+                     "prevent",
+                     599.77,
+                     600.12
+                  ],
+                  [
+                     "your",
+                     600.12,
+                     600.23
+                  ],
+                  [
+                     "child",
+                     600.23,
+                     600.69
+                  ],
+                  [
+                     "from",
+                     600.69,
+                     600.83
+                  ],
+                  [
+                     "kicking",
+                     600.83,
+                     601.22
+                  ],
+                  [
+                     "a",
+                     601.22,
+                     601.29
+                  ],
+                  [
+                     "robotic",
+                     601.29,
+                     601.69
+                  ],
+                  [
+                     "doc",
+                     601.69,
+                     602.07
+                  ]
+               ],
+               "confidence": 0.898,
+               "word_confidence": [
+                  [
+                     "is",
+                     0.831
+                  ],
+                  [
+                     "there",
+                     0.862
+                  ],
+                  [
+                     "reason",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.951
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "example",
+                     1
+                  ],
+                  [
+                     "prevent",
+                     1
+                  ],
+                  [
+                     "your",
+                     1
+                  ],
+                  [
+                     "child",
+                     1
+                  ],
+                  [
+                     "from",
+                     1
+                  ],
+                  [
+                     "kicking",
+                     0.748
+                  ],
+                  [
+                     "a",
+                     0.784
+                  ],
+                  [
+                     "robotic",
+                     1
+                  ],
+                  [
+                     "doc",
+                     0.329
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "not just out of respect for property but because the child might be more likely to kick a real doc ",
+               "timestamps": [
+                  [
+                     "not",
+                     603.19,
+                     603.51
+                  ],
+                  [
+                     "just",
+                     603.54,
+                     603.96
+                  ],
+                  [
+                     "out",
+                     603.96,
+                     604.05
+                  ],
+                  [
+                     "of",
+                     604.05,
+                     604.14
+                  ],
+                  [
+                     "respect",
+                     604.14,
+                     604.64
+                  ],
+                  [
+                     "for",
+                     604.64,
+                     604.77
+                  ],
+                  [
+                     "property",
+                     604.77,
+                     605.55
+                  ],
+                  [
+                     "but",
+                     606.13,
+                     606.28
+                  ],
+                  [
+                     "because",
+                     606.28,
+                     606.8
+                  ],
+                  [
+                     "the",
+                     606.8,
+                     606.92
+                  ],
+                  [
+                     "child",
+                     606.92,
+                     607.24
+                  ],
+                  [
+                     "might",
+                     607.24,
+                     607.36
+                  ],
+                  [
+                     "be",
+                     607.36,
+                     607.45
+                  ],
+                  [
+                     "more",
+                     607.45,
+                     607.63
+                  ],
+                  [
+                     "likely",
+                     607.63,
+                     607.96
+                  ],
+                  [
+                     "to",
+                     607.96,
+                     608.06
+                  ],
+                  [
+                     "kick",
+                     608.06,
+                     608.25
+                  ],
+                  [
+                     "a",
+                     608.25,
+                     608.33
+                  ],
+                  [
+                     "real",
+                     608.33,
+                     608.54
+                  ],
+                  [
+                     "doc",
+                     608.54,
+                     609
+                  ]
+               ],
+               "confidence": 0.885,
+               "word_confidence": [
+                  [
+                     "not",
+                     1
+                  ],
+                  [
+                     "just",
+                     1
+                  ],
+                  [
+                     "out",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "respect",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "property",
+                     1
+                  ],
+                  [
+                     "but",
+                     0.479
+                  ],
+                  [
+                     "because",
+                     1
+                  ],
+                  [
+                     "the",
+                     0.88
+                  ],
+                  [
+                     "child",
+                     0.696
+                  ],
+                  [
+                     "might",
+                     0.54
+                  ],
+                  [
+                     "be",
+                     1
+                  ],
+                  [
+                     "more",
+                     1
+                  ],
+                  [
+                     "likely",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.992
+                  ],
+                  [
+                     "kick",
+                     0.358
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "real",
+                     1
+                  ],
+                  [
+                     "doc",
+                     0.504
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and again it's not just kids ",
+               "timestamps": [
+                  [
+                     "and",
+                     610.48,
+                     610.65
+                  ],
+                  [
+                     "again",
+                     610.65,
+                     610.95
+                  ],
+                  [
+                     "it's",
+                     610.95,
+                     611.14
+                  ],
+                  [
+                     "not",
+                     611.14,
+                     611.47
+                  ],
+                  [
+                     "just",
+                     611.47,
+                     611.72
+                  ],
+                  [
+                     "kids",
+                     611.72,
+                     612.32
+                  ]
+               ],
+               "confidence": 0.995,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "again",
+                     1
+                  ],
+                  [
+                     "it's",
+                     1
+                  ],
+                  [
+                     "not",
+                     1
+                  ],
+                  [
+                     "just",
+                     0.974
+                  ],
+                  [
+                     "kids",
+                     0.997
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "this is the violent video games question but it's on a completely new level because of this visceral physicality that we respond more intensely to into images on a screen ",
+               "timestamps": [
+                  [
+                     "this",
+                     613.53,
+                     613.74
+                  ],
+                  [
+                     "is",
+                     613.74,
+                     613.93
+                  ],
+                  [
+                     "the",
+                     613.93,
+                     614.35
+                  ],
+                  [
+                     "violent",
+                     614.4,
+                     615.02
+                  ],
+                  [
+                     "video",
+                     615.05,
+                     615.38
+                  ],
+                  [
+                     "games",
+                     615.38,
+                     615.67
+                  ],
+                  [
+                     "question",
+                     615.67,
+                     616.12
+                  ],
+                  [
+                     "but",
+                     616.12,
+                     616.27
+                  ],
+                  [
+                     "it's",
+                     616.27,
+                     616.37
+                  ],
+                  [
+                     "on",
+                     616.37,
+                     616.47
+                  ],
+                  [
+                     "a",
+                     616.47,
+                     616.52
+                  ],
+                  [
+                     "completely",
+                     616.52,
+                     617.13
+                  ],
+                  [
+                     "new",
+                     617.13,
+                     617.26
+                  ],
+                  [
+                     "level",
+                     617.26,
+                     617.6
+                  ],
+                  [
+                     "because",
+                     617.6,
+                     617.82
+                  ],
+                  [
+                     "of",
+                     617.82,
+                     617.93
+                  ],
+                  [
+                     "this",
+                     617.93,
+                     618.1
+                  ],
+                  [
+                     "visceral",
+                     618.1,
+                     618.81
+                  ],
+                  [
+                     "physicality",
+                     618.81,
+                     619.73
+                  ],
+                  [
+                     "that",
+                     619.73,
+                     619.9
+                  ],
+                  [
+                     "we",
+                     619.9,
+                     620.04
+                  ],
+                  [
+                     "respond",
+                     620.04,
+                     620.7
+                  ],
+                  [
+                     "more",
+                     620.7,
+                     621.05
+                  ],
+                  [
+                     "intensely",
+                     621.05,
+                     621.72
+                  ],
+                  [
+                     "to",
+                     621.72,
+                     622.2
+                  ],
+                  [
+                     "into",
+                     622.44,
+                     622.67
+                  ],
+                  [
+                     "images",
+                     622.67,
+                     623.12
+                  ],
+                  [
+                     "on",
+                     623.12,
+                     623.22
+                  ],
+                  [
+                     "a",
+                     623.22,
+                     623.29
+                  ],
+                  [
+                     "screen",
+                     623.29,
+                     623.92
+                  ]
+               ],
+               "confidence": 0.933,
+               "word_confidence": [
+                  [
+                     "this",
+                     1
+                  ],
+                  [
+                     "is",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "violent",
+                     1
+                  ],
+                  [
+                     "video",
+                     0.635
+                  ],
+                  [
+                     "games",
+                     0.635
+                  ],
+                  [
+                     "question",
+                     0.707
+                  ],
+                  [
+                     "but",
+                     0.948
+                  ],
+                  [
+                     "it's",
+                     0.992
+                  ],
+                  [
+                     "on",
+                     0.8
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "completely",
+                     0.992
+                  ],
+                  [
+                     "new",
+                     1
+                  ],
+                  [
+                     "level",
+                     1
+                  ],
+                  [
+                     "because",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "this",
+                     0.997
+                  ],
+                  [
+                     "visceral",
+                     0.974
+                  ],
+                  [
+                     "physicality",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "we",
+                     0.891
+                  ],
+                  [
+                     "respond",
+                     0.993
+                  ],
+                  [
+                     "more",
+                     0.987
+                  ],
+                  [
+                     "intensely",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.978
+                  ],
+                  [
+                     "into",
+                     0.327
+                  ],
+                  [
+                     "images",
+                     0.956
+                  ],
+                  [
+                     "on",
+                     0.982
+                  ],
+                  [
+                     "a",
+                     0.82
+                  ],
+                  [
+                     "screen",
+                     0.939
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "when we behave violently towards robots specifically robots that are designed to mimic life is that healthy outlet for violent behavior ",
+               "timestamps": [
+                  [
+                     "when",
+                     625.62,
+                     625.84
+                  ],
+                  [
+                     "we",
+                     625.84,
+                     625.95
+                  ],
+                  [
+                     "behave",
+                     625.95,
+                     626.27
+                  ],
+                  [
+                     "violently",
+                     626.27,
+                     626.88
+                  ],
+                  [
+                     "towards",
+                     626.88,
+                     627.4
+                  ],
+                  [
+                     "robots",
+                     627.4,
+                     628.07
+                  ],
+                  [
+                     "specifically",
+                     628.1,
+                     628.82
+                  ],
+                  [
+                     "robots",
+                     628.82,
+                     629.2
+                  ],
+                  [
+                     "that",
+                     629.2,
+                     629.35
+                  ],
+                  [
+                     "are",
+                     629.35,
+                     629.43
+                  ],
+                  [
+                     "designed",
+                     629.43,
+                     629.94
+                  ],
+                  [
+                     "to",
+                     629.94,
+                     630.07
+                  ],
+                  [
+                     "mimic",
+                     630.07,
+                     630.39
+                  ],
+                  [
+                     "life",
+                     630.39,
+                     630.94
+                  ],
+                  [
+                     "is",
+                     631.37,
+                     631.55
+                  ],
+                  [
+                     "that",
+                     631.55,
+                     631.88
+                  ],
+                  [
+                     "healthy",
+                     632.54,
+                     633
+                  ],
+                  [
+                     "outlet",
+                     633,
+                     633.48
+                  ],
+                  [
+                     "for",
+                     633.48,
+                     633.62
+                  ],
+                  [
+                     "violent",
+                     633.62,
+                     633.95
+                  ],
+                  [
+                     "behavior",
+                     633.95,
+                     634.53
+                  ]
+               ],
+               "confidence": 0.96,
+               "word_confidence": [
+                  [
+                     "when",
+                     1
+                  ],
+                  [
+                     "we",
+                     0.553
+                  ],
+                  [
+                     "behave",
+                     0.84
+                  ],
+                  [
+                     "violently",
+                     1
+                  ],
+                  [
+                     "towards",
+                     1
+                  ],
+                  [
+                     "robots",
+                     0.997
+                  ],
+                  [
+                     "specifically",
+                     0.993
+                  ],
+                  [
+                     "robots",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "are",
+                     1
+                  ],
+                  [
+                     "designed",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "mimic",
+                     0.821
+                  ],
+                  [
+                     "life",
+                     0.987
+                  ],
+                  [
+                     "is",
+                     1
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "healthy",
+                     0.917
+                  ],
+                  [
+                     "outlet",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "violent",
+                     0.714
+                  ],
+                  [
+                     "behavior",
+                     0.99
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "or is that training or cruelty muscles ",
+               "timestamps": [
+                  [
+                     "or",
+                     635.37,
+                     635.46
+                  ],
+                  [
+                     "is",
+                     635.46,
+                     635.59
+                  ],
+                  [
+                     "that",
+                     635.59,
+                     635.83
+                  ],
+                  [
+                     "training",
+                     635.92,
+                     636.38
+                  ],
+                  [
+                     "or",
+                     636.38,
+                     636.51
+                  ],
+                  [
+                     "cruelty",
+                     636.51,
+                     637
+                  ],
+                  [
+                     "muscles",
+                     637,
+                     637.7
+                  ]
+               ],
+               "confidence": 0.766,
+               "word_confidence": [
+                  [
+                     "or",
+                     0.566
+                  ],
+                  [
+                     "is",
+                     0.948
+                  ],
+                  [
+                     "that",
+                     1
+                  ],
+                  [
+                     "training",
+                     1
+                  ],
+                  [
+                     "or",
+                     0.415
+                  ],
+                  [
+                     "cruelty",
+                     0.24
+                  ],
+                  [
+                     "muscles",
+                     0.956
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "we don't know ",
+               "timestamps": [
+                  [
+                     "we",
+                     639.48,
+                     639.64
+                  ],
+                  [
+                     "don't",
+                     639.64,
+                     639.84
+                  ],
+                  [
+                     "know",
+                     639.84,
+                     640.14
+                  ]
+               ],
+               "confidence": 0.88,
+               "word_confidence": [
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "don't",
+                     1
+                  ],
+                  [
+                     "know",
+                     0.735
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "but the answer this question has the potential to impact human behavior has the potential to impact social norms it has the potential to inspire rules around what we can and can't do with certain robots similar to our animal cruelty laws ",
+               "timestamps": [
+                  [
+                     "but",
+                     642.59,
+                     642.73
+                  ],
+                  [
+                     "the",
+                     642.73,
+                     642.86
+                  ],
+                  [
+                     "answer",
+                     642.86,
+                     643.26
+                  ],
+                  [
+                     "this",
+                     643.26,
+                     643.47
+                  ],
+                  [
+                     "question",
+                     643.47,
+                     644.08
+                  ],
+                  [
+                     "has",
+                     644.08,
+                     644.32
+                  ],
+                  [
+                     "the",
+                     644.32,
+                     644.41
+                  ],
+                  [
+                     "potential",
+                     644.41,
+                     644.89
+                  ],
+                  [
+                     "to",
+                     644.89,
+                     644.99
+                  ],
+                  [
+                     "impact",
+                     644.99,
+                     645.44
+                  ],
+                  [
+                     "human",
+                     645.44,
+                     645.71
+                  ],
+                  [
+                     "behavior",
+                     645.71,
+                     646.44
+                  ],
+                  [
+                     "has",
+                     646.56,
+                     646.88
+                  ],
+                  [
+                     "the",
+                     646.88,
+                     646.98
+                  ],
+                  [
+                     "potential",
+                     646.98,
+                     647.42
+                  ],
+                  [
+                     "to",
+                     647.42,
+                     647.52
+                  ],
+                  [
+                     "impact",
+                     647.52,
+                     647.92
+                  ],
+                  [
+                     "social",
+                     647.92,
+                     648.3
+                  ],
+                  [
+                     "norms",
+                     648.3,
+                     648.93
+                  ],
+                  [
+                     "it",
+                     649.34,
+                     649.48
+                  ],
+                  [
+                     "has",
+                     649.48,
+                     649.66
+                  ],
+                  [
+                     "the",
+                     649.66,
+                     649.76
+                  ],
+                  [
+                     "potential",
+                     649.76,
+                     650.22
+                  ],
+                  [
+                     "to",
+                     650.22,
+                     650.35
+                  ],
+                  [
+                     "inspire",
+                     650.35,
+                     650.83
+                  ],
+                  [
+                     "rules",
+                     650.83,
+                     651.4
+                  ],
+                  [
+                     "around",
+                     651.4,
+                     651.78
+                  ],
+                  [
+                     "what",
+                     651.78,
+                     651.92
+                  ],
+                  [
+                     "we",
+                     651.92,
+                     652.19
+                  ],
+                  [
+                     "can",
+                     652.3,
+                     652.63
+                  ],
+                  [
+                     "and",
+                     652.63,
+                     652.74
+                  ],
+                  [
+                     "can't",
+                     652.74,
+                     653.03
+                  ],
+                  [
+                     "do",
+                     653.03,
+                     653.19
+                  ],
+                  [
+                     "with",
+                     653.19,
+                     653.34
+                  ],
+                  [
+                     "certain",
+                     653.34,
+                     653.59
+                  ],
+                  [
+                     "robots",
+                     653.59,
+                     654.21
+                  ],
+                  [
+                     "similar",
+                     654.24,
+                     654.67
+                  ],
+                  [
+                     "to",
+                     654.67,
+                     654.77
+                  ],
+                  [
+                     "our",
+                     654.77,
+                     654.94
+                  ],
+                  [
+                     "animal",
+                     654.97,
+                     655.31
+                  ],
+                  [
+                     "cruelty",
+                     655.31,
+                     655.71
+                  ],
+                  [
+                     "laws",
+                     655.71,
+                     656.25
+                  ]
+               ],
+               "confidence": 0.94,
+               "word_confidence": [
+                  [
+                     "but",
+                     0.839
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "answer",
+                     1
+                  ],
+                  [
+                     "this",
+                     0.741
+                  ],
+                  [
+                     "question",
+                     1
+                  ],
+                  [
+                     "has",
+                     0.649
+                  ],
+                  [
+                     "the",
+                     0.857
+                  ],
+                  [
+                     "potential",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "impact",
+                     1
+                  ],
+                  [
+                     "human",
+                     1
+                  ],
+                  [
+                     "behavior",
+                     0.999
+                  ],
+                  [
+                     "has",
+                     0.817
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "potential",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.789
+                  ],
+                  [
+                     "impact",
+                     0.822
+                  ],
+                  [
+                     "social",
+                     0.979
+                  ],
+                  [
+                     "norms",
+                     1
+                  ],
+                  [
+                     "it",
+                     0.957
+                  ],
+                  [
+                     "has",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "potential",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "inspire",
+                     1
+                  ],
+                  [
+                     "rules",
+                     0.993
+                  ],
+                  [
+                     "around",
+                     0.98
+                  ],
+                  [
+                     "what",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "can",
+                     1
+                  ],
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "can't",
+                     1
+                  ],
+                  [
+                     "do",
+                     1
+                  ],
+                  [
+                     "with",
+                     0.574
+                  ],
+                  [
+                     "certain",
+                     1
+                  ],
+                  [
+                     "robots",
+                     1
+                  ],
+                  [
+                     "similar",
+                     1
+                  ],
+                  [
+                     "to",
+                     0.857
+                  ],
+                  [
+                     "our",
+                     0.34
+                  ],
+                  [
+                     "animal",
+                     1
+                  ],
+                  [
+                     "cruelty",
+                     0.999
+                  ],
+                  [
+                     "laws",
+                     0.559
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "because even if robots can't feel our behavior towards them might matter for us ",
+               "timestamps": [
+                  [
+                     "because",
+                     657.2,
+                     657.51
+                  ],
+                  [
+                     "even",
+                     657.51,
+                     657.86
+                  ],
+                  [
+                     "if",
+                     657.86,
+                     657.99
+                  ],
+                  [
+                     "robots",
+                     657.99,
+                     658.4
+                  ],
+                  [
+                     "can't",
+                     658.4,
+                     658.71
+                  ],
+                  [
+                     "feel",
+                     658.71,
+                     659.38
+                  ],
+                  [
+                     "our",
+                     660.1,
+                     660.27
+                  ],
+                  [
+                     "behavior",
+                     660.27,
+                     660.85
+                  ],
+                  [
+                     "towards",
+                     660.85,
+                     661.19
+                  ],
+                  [
+                     "them",
+                     661.19,
+                     661.35
+                  ],
+                  [
+                     "might",
+                     661.35,
+                     661.64
+                  ],
+                  [
+                     "matter",
+                     661.64,
+                     662.23
+                  ],
+                  [
+                     "for",
+                     662.38,
+                     662.6
+                  ],
+                  [
+                     "us",
+                     662.6,
+                     663.12
+                  ]
+               ],
+               "confidence": 0.947,
+               "word_confidence": [
+                  [
+                     "because",
+                     1
+                  ],
+                  [
+                     "even",
+                     1
+                  ],
+                  [
+                     "if",
+                     1
+                  ],
+                  [
+                     "robots",
+                     1
+                  ],
+                  [
+                     "can't",
+                     0.989
+                  ],
+                  [
+                     "feel",
+                     0.929
+                  ],
+                  [
+                     "our",
+                     0.68
+                  ],
+                  [
+                     "behavior",
+                     1
+                  ],
+                  [
+                     "towards",
+                     0.96
+                  ],
+                  [
+                     "them",
+                     0.359
+                  ],
+                  [
+                     "might",
+                     0.858
+                  ],
+                  [
+                     "matter",
+                     1
+                  ],
+                  [
+                     "for",
+                     1
+                  ],
+                  [
+                     "us",
+                     0.996
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "and regardless of whether we end up changing our rules ",
+               "timestamps": [
+                  [
+                     "and",
+                     664.89,
+                     665.06
+                  ],
+                  [
+                     "regardless",
+                     665.06,
+                     665.57
+                  ],
+                  [
+                     "of",
+                     665.57,
+                     665.68
+                  ],
+                  [
+                     "whether",
+                     665.68,
+                     665.91
+                  ],
+                  [
+                     "we",
+                     665.91,
+                     666.04
+                  ],
+                  [
+                     "end",
+                     666.04,
+                     666.2
+                  ],
+                  [
+                     "up",
+                     666.2,
+                     666.29
+                  ],
+                  [
+                     "changing",
+                     666.29,
+                     666.84
+                  ],
+                  [
+                     "our",
+                     666.84,
+                     666.97
+                  ],
+                  [
+                     "rules",
+                     666.97,
+                     667.62
+                  ]
+               ],
+               "confidence": 0.925,
+               "word_confidence": [
+                  [
+                     "and",
+                     1
+                  ],
+                  [
+                     "regardless",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "whether",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "end",
+                     0.978
+                  ],
+                  [
+                     "up",
+                     0.656
+                  ],
+                  [
+                     "changing",
+                     0.991
+                  ],
+                  [
+                     "our",
+                     0.627
+                  ],
+                  [
+                     "rules",
+                     0.822
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "robots might be able to help us come to a new understanding of ourselves ",
+               "timestamps": [
+                  [
+                     "robots",
+                     668.88,
+                     669.32
+                  ],
+                  [
+                     "might",
+                     669.32,
+                     669.57
+                  ],
+                  [
+                     "be",
+                     669.57,
+                     669.7
+                  ],
+                  [
+                     "able",
+                     669.7,
+                     669.93
+                  ],
+                  [
+                     "to",
+                     669.93,
+                     670.03
+                  ],
+                  [
+                     "help",
+                     670.03,
+                     670.24
+                  ],
+                  [
+                     "us",
+                     670.24,
+                     670.36
+                  ],
+                  [
+                     "come",
+                     670.36,
+                     670.57
+                  ],
+                  [
+                     "to",
+                     670.57,
+                     670.72
+                  ],
+                  [
+                     "a",
+                     670.72,
+                     670.79
+                  ],
+                  [
+                     "new",
+                     670.79,
+                     670.98
+                  ],
+                  [
+                     "understanding",
+                     670.98,
+                     671.57
+                  ],
+                  [
+                     "of",
+                     671.57,
+                     671.66
+                  ],
+                  [
+                     "ourselves",
+                     671.66,
+                     672.44
+                  ]
+               ],
+               "confidence": 0.825,
+               "word_confidence": [
+                  [
+                     "robots",
+                     0.771
+                  ],
+                  [
+                     "might",
+                     0.76
+                  ],
+                  [
+                     "be",
+                     1
+                  ],
+                  [
+                     "able",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "help",
+                     0.986
+                  ],
+                  [
+                     "us",
+                     0.711
+                  ],
+                  [
+                     "come",
+                     0.992
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "new",
+                     1
+                  ],
+                  [
+                     "understanding",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "ourselves",
+                     0.458
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "most of what I've learned over the past ten years have not been about technology at all ",
+               "timestamps": [
+                  [
+                     "most",
+                     674.22,
+                     674.48
+                  ],
+                  [
+                     "of",
+                     674.48,
+                     674.54
+                  ],
+                  [
+                     "what",
+                     674.54,
+                     674.66
+                  ],
+                  [
+                     "I've",
+                     674.66,
+                     674.76
+                  ],
+                  [
+                     "learned",
+                     674.76,
+                     675.05
+                  ],
+                  [
+                     "over",
+                     675.05,
+                     675.16
+                  ],
+                  [
+                     "the",
+                     675.16,
+                     675.23
+                  ],
+                  [
+                     "past",
+                     675.23,
+                     675.53
+                  ],
+                  [
+                     "ten",
+                     675.53,
+                     675.69
+                  ],
+                  [
+                     "years",
+                     675.69,
+                     676.29
+                  ],
+                  [
+                     "have",
+                     676.44,
+                     676.62
+                  ],
+                  [
+                     "not",
+                     676.62,
+                     676.86
+                  ],
+                  [
+                     "been",
+                     676.86,
+                     676.97
+                  ],
+                  [
+                     "about",
+                     676.97,
+                     677.2
+                  ],
+                  [
+                     "technology",
+                     677.2,
+                     677.72
+                  ],
+                  [
+                     "at",
+                     677.72,
+                     677.8
+                  ],
+                  [
+                     "all",
+                     677.8,
+                     678.12
+                  ]
+               ],
+               "confidence": 0.943,
+               "word_confidence": [
+                  [
+                     "most",
+                     0.903
+                  ],
+                  [
+                     "of",
+                     0.78
+                  ],
+                  [
+                     "what",
+                     0.815
+                  ],
+                  [
+                     "I've",
+                     0.815
+                  ],
+                  [
+                     "learned",
+                     1
+                  ],
+                  [
+                     "over",
+                     1
+                  ],
+                  [
+                     "the",
+                     1
+                  ],
+                  [
+                     "past",
+                     1
+                  ],
+                  [
+                     "ten",
+                     1
+                  ],
+                  [
+                     "years",
+                     0.998
+                  ],
+                  [
+                     "have",
+                     0.46
+                  ],
+                  [
+                     "not",
+                     0.989
+                  ],
+                  [
+                     "been",
+                     1
+                  ],
+                  [
+                     "about",
+                     1
+                  ],
+                  [
+                     "technology",
+                     1
+                  ],
+                  [
+                     "at",
+                     0.613
+                  ],
+                  [
+                     "all",
+                     0.992
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "it's been about human psychology and empathy and how we relate to others ",
+               "timestamps": [
+                  [
+                     "it's",
+                     678.96,
+                     679.06
+                  ],
+                  [
+                     "been",
+                     679.06,
+                     679.2
+                  ],
+                  [
+                     "about",
+                     679.2,
+                     679.45
+                  ],
+                  [
+                     "human",
+                     679.45,
+                     679.75
+                  ],
+                  [
+                     "psychology",
+                     679.75,
+                     680.69
+                  ],
+                  [
+                     "and",
+                     681.38,
+                     681.58
+                  ],
+                  [
+                     "empathy",
+                     681.58,
+                     682.26
+                  ],
+                  [
+                     "and",
+                     682.29,
+                     682.44
+                  ],
+                  [
+                     "how",
+                     682.44,
+                     682.65
+                  ],
+                  [
+                     "we",
+                     682.65,
+                     682.78
+                  ],
+                  [
+                     "relate",
+                     682.78,
+                     683.12
+                  ],
+                  [
+                     "to",
+                     683.12,
+                     683.23
+                  ],
+                  [
+                     "others",
+                     683.23,
+                     683.82
+                  ]
+               ],
+               "confidence": 0.978,
+               "word_confidence": [
+                  [
+                     "it's",
+                     1
+                  ],
+                  [
+                     "been",
+                     1
+                  ],
+                  [
+                     "about",
+                     1
+                  ],
+                  [
+                     "human",
+                     1
+                  ],
+                  [
+                     "psychology",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.732
+                  ],
+                  [
+                     "empathy",
+                     1
+                  ],
+                  [
+                     "and",
+                     0.759
+                  ],
+                  [
+                     "how",
+                     1
+                  ],
+                  [
+                     "we",
+                     1
+                  ],
+                  [
+                     "relate",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "others",
+                     0.995
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "because when a child is kind to a room by a ",
+               "timestamps": [
+                  [
+                     "because",
+                     685.48,
+                     685.82
+                  ],
+                  [
+                     "when",
+                     685.82,
+                     685.97
+                  ],
+                  [
+                     "a",
+                     685.97,
+                     686.02
+                  ],
+                  [
+                     "child",
+                     686.02,
+                     686.47
+                  ],
+                  [
+                     "is",
+                     686.47,
+                     686.59
+                  ],
+                  [
+                     "kind",
+                     686.59,
+                     686.98
+                  ],
+                  [
+                     "to",
+                     686.98,
+                     687.11
+                  ],
+                  [
+                     "a",
+                     687.11,
+                     687.21
+                  ],
+                  [
+                     "room",
+                     687.21,
+                     687.47
+                  ],
+                  [
+                     "by",
+                     687.47,
+                     687.58
+                  ],
+                  [
+                     "a",
+                     687.58,
+                     687.78
+                  ]
+               ],
+               "confidence": 0.855,
+               "word_confidence": [
+                  [
+                     "because",
+                     1
+                  ],
+                  [
+                     "when",
+                     0.951
+                  ],
+                  [
+                     "a",
+                     0.748
+                  ],
+                  [
+                     "child",
+                     0.999
+                  ],
+                  [
+                     "is",
+                     0.962
+                  ],
+                  [
+                     "kind",
+                     0.9
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "a",
+                     0.235
+                  ],
+                  [
+                     "room",
+                     0.967
+                  ],
+                  [
+                     "by",
+                     0.388
+                  ],
+                  [
+                     "a",
+                     0.413
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "when a soldier tries to save a robot on the battlefield ",
+               "timestamps": [
+                  [
+                     "when",
+                     689.23,
+                     689.4
+                  ],
+                  [
+                     "a",
+                     689.4,
+                     689.48
+                  ],
+                  [
+                     "soldier",
+                     689.48,
+                     689.95
+                  ],
+                  [
+                     "tries",
+                     689.95,
+                     690.33
+                  ],
+                  [
+                     "to",
+                     690.33,
+                     690.44
+                  ],
+                  [
+                     "save",
+                     690.44,
+                     690.77
+                  ],
+                  [
+                     "a",
+                     690.77,
+                     690.85
+                  ],
+                  [
+                     "robot",
+                     690.85,
+                     691.21
+                  ],
+                  [
+                     "on",
+                     691.21,
+                     691.34
+                  ],
+                  [
+                     "the",
+                     691.34,
+                     691.43
+                  ],
+                  [
+                     "battlefield",
+                     691.43,
+                     692.22
+                  ]
+               ],
+               "confidence": 0.698,
+               "word_confidence": [
+                  [
+                     "when",
+                     0.578
+                  ],
+                  [
+                     "a",
+                     0.445
+                  ],
+                  [
+                     "soldier",
+                     0.924
+                  ],
+                  [
+                     "tries",
+                     0.593
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "save",
+                     0.832
+                  ],
+                  [
+                     "a",
+                     0.74
+                  ],
+                  [
+                     "robot",
+                     0.847
+                  ],
+                  [
+                     "on",
+                     1
+                  ],
+                  [
+                     "the",
+                     0.99
+                  ],
+                  [
+                     "battlefield",
+                     0.411
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "or when a group of people refuses to harm a robotic baby dinosaur ",
+               "timestamps": [
+                  [
+                     "or",
+                     693.26,
+                     693.42
+                  ],
+                  [
+                     "when",
+                     693.42,
+                     693.55
+                  ],
+                  [
+                     "a",
+                     693.55,
+                     693.61
+                  ],
+                  [
+                     "group",
+                     693.61,
+                     693.82
+                  ],
+                  [
+                     "of",
+                     693.82,
+                     693.94
+                  ],
+                  [
+                     "people",
+                     693.94,
+                     694.32
+                  ],
+                  [
+                     "refuses",
+                     694.32,
+                     694.87
+                  ],
+                  [
+                     "to",
+                     694.87,
+                     694.98
+                  ],
+                  [
+                     "harm",
+                     694.98,
+                     695.43
+                  ],
+                  [
+                     "a",
+                     695.43,
+                     695.51
+                  ],
+                  [
+                     "robotic",
+                     695.51,
+                     695.9
+                  ],
+                  [
+                     "baby",
+                     695.9,
+                     696.13
+                  ],
+                  [
+                     "dinosaur",
+                     696.13,
+                     696.88
+                  ]
+               ],
+               "confidence": 0.919,
+               "word_confidence": [
+                  [
+                     "or",
+                     0.419
+                  ],
+                  [
+                     "when",
+                     1
+                  ],
+                  [
+                     "a",
+                     1
+                  ],
+                  [
+                     "group",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "people",
+                     1
+                  ],
+                  [
+                     "refuses",
+                     1
+                  ],
+                  [
+                     "to",
+                     1
+                  ],
+                  [
+                     "harm",
+                     0.894
+                  ],
+                  [
+                     "a",
+                     0.654
+                  ],
+                  [
+                     "robotic",
+                     1
+                  ],
+                  [
+                     "baby",
+                     0.51
+                  ],
+                  [
+                     "dinosaur",
+                     0.985
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "those robots arches motors in years and algorithms ",
+               "timestamps": [
+                  [
+                     "those",
+                     698.21,
+                     698.43
+                  ],
+                  [
+                     "robots",
+                     698.43,
+                     698.83
+                  ],
+                  [
+                     "arches",
+                     698.83,
+                     699.4
+                  ],
+                  [
+                     "motors",
+                     699.44,
+                     699.91
+                  ],
+                  [
+                     "in",
+                     699.91,
+                     700.01
+                  ],
+                  [
+                     "years",
+                     700.01,
+                     700.34
+                  ],
+                  [
+                     "and",
+                     700.34,
+                     700.45
+                  ],
+                  [
+                     "algorithms",
+                     700.45,
+                     701.39
+                  ]
+               ],
+               "confidence": 0.774,
+               "word_confidence": [
+                  [
+                     "those",
+                     0.844
+                  ],
+                  [
+                     "robots",
+                     0.951
+                  ],
+                  [
+                     "arches",
+                     0.396
+                  ],
+                  [
+                     "motors",
+                     1
+                  ],
+                  [
+                     "in",
+                     0.506
+                  ],
+                  [
+                     "years",
+                     0.362
+                  ],
+                  [
+                     "and",
+                     0.553
+                  ],
+                  [
+                     "algorithms",
+                     0.998
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "their reflections of our own humanity ",
+               "timestamps": [
+                  [
+                     "their",
+                     702.48,
+                     702.65
+                  ],
+                  [
+                     "reflections",
+                     702.65,
+                     703.24
+                  ],
+                  [
+                     "of",
+                     703.24,
+                     703.33
+                  ],
+                  [
+                     "our",
+                     703.33,
+                     703.44
+                  ],
+                  [
+                     "own",
+                     703.44,
+                     703.62
+                  ],
+                  [
+                     "humanity",
+                     703.62,
+                     704.32
+                  ]
+               ],
+               "confidence": 0.974,
+               "word_confidence": [
+                  [
+                     "their",
+                     0.726
+                  ],
+                  [
+                     "reflections",
+                     1
+                  ],
+                  [
+                     "of",
+                     1
+                  ],
+                  [
+                     "our",
+                     1
+                  ],
+                  [
+                     "own",
+                     1
+                  ],
+                  [
+                     "humanity",
+                     0.998
+                  ]
+               ]
+            }]
+         },
+         {
+            "final": true,
+            "alternatives": [{
+               "transcript": "thank you ",
+               "timestamps": [
+                  [
+                     "thank",
+                     705.5,
+                     705.77
+                  ],
+                  [
+                     "you",
+                     705.77,
+                     705.94
+                  ]
+               ],
+               "confidence": 0.998,
+               "word_confidence": [
+                  [
+                     "thank",
+                     1
+                  ],
+                  [
+                     "you",
+                     0.995
+                  ]
+               ]
+            }]
+         }
+      ]
+   }],
+   "status": "completed"
+}

--- a/src/lib/Util/adapters/ibm/sample/ibmToDraft.sample.js
+++ b/src/lib/Util/adapters/ibm/sample/ibmToDraft.sample.js
@@ -1,0 +1,31307 @@
+const draftTranscriptExample = [
+  {
+    "text": "There is a day about ten years ago when I asked a friend to hold a baby dinosaur robot upside down.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 13.04,
+      "words": [
+        {
+          "start": 13.04,
+          "confidence": 0.902,
+          "end": 13.23,
+          "word": "there",
+          "punct": "There",
+          "index": 0
+        },
+        {
+          "start": 13.23,
+          "confidence": 0.52,
+          "end": 13.36,
+          "word": "is",
+          "punct": "is",
+          "index": 1
+        },
+        {
+          "start": 13.36,
+          "confidence": 0.819,
+          "end": 13.42,
+          "word": "a",
+          "punct": "a",
+          "index": 2
+        },
+        {
+          "start": 13.42,
+          "confidence": 0.948,
+          "end": 13.84,
+          "word": "day",
+          "punct": "day",
+          "index": 3
+        },
+        {
+          "start": 13.84,
+          "confidence": 0.976,
+          "end": 14.13,
+          "word": "about",
+          "punct": "about",
+          "index": 4
+        },
+        {
+          "start": 14.13,
+          "confidence": 1,
+          "end": 14.35,
+          "word": "ten",
+          "punct": "ten",
+          "index": 5
+        },
+        {
+          "start": 14.35,
+          "confidence": 1,
+          "end": 14.59,
+          "word": "years",
+          "punct": "years",
+          "index": 6
+        },
+        {
+          "start": 14.59,
+          "confidence": 1,
+          "end": 15.16,
+          "word": "ago",
+          "punct": "ago",
+          "index": 7
+        },
+        {
+          "start": 15.46,
+          "confidence": 1,
+          "end": 15.72,
+          "word": "when",
+          "punct": "when",
+          "index": 8
+        },
+        {
+          "start": 15.72,
+          "confidence": 1,
+          "end": 15.78,
+          "word": "I",
+          "punct": "I",
+          "index": 9
+        },
+        {
+          "start": 15.78,
+          "confidence": 0.818,
+          "end": 16.19,
+          "word": "asked",
+          "punct": "asked",
+          "index": 10
+        },
+        {
+          "start": 16.19,
+          "confidence": 1,
+          "end": 16.27,
+          "word": "a",
+          "punct": "a",
+          "index": 11
+        },
+        {
+          "start": 16.27,
+          "confidence": 1,
+          "end": 16.64,
+          "word": "friend",
+          "punct": "friend",
+          "index": 12
+        },
+        {
+          "start": 16.64,
+          "confidence": 1,
+          "end": 16.72,
+          "word": "to",
+          "punct": "to",
+          "index": 13
+        },
+        {
+          "start": 16.72,
+          "confidence": 1,
+          "end": 17.2,
+          "word": "hold",
+          "punct": "hold",
+          "index": 14
+        },
+        {
+          "start": 17.23,
+          "confidence": 0.643,
+          "end": 17.31,
+          "word": "a",
+          "punct": "a",
+          "index": 15
+        },
+        {
+          "start": 17.31,
+          "confidence": 1,
+          "end": 17.62,
+          "word": "baby",
+          "punct": "baby",
+          "index": 16
+        },
+        {
+          "start": 17.62,
+          "confidence": 0.981,
+          "end": 18.12,
+          "word": "dinosaur",
+          "punct": "dinosaur",
+          "index": 17
+        },
+        {
+          "start": 18.12,
+          "confidence": 0.861,
+          "end": 18.6,
+          "word": "robot",
+          "punct": "robot",
+          "index": 18
+        },
+        {
+          "start": 18.72,
+          "confidence": 0.832,
+          "end": 19.16,
+          "word": "upside",
+          "punct": "upside",
+          "index": 19
+        },
+        {
+          "start": 19.16,
+          "confidence": 0.992,
+          "end": 19.52,
+          "word": "down",
+          "punct": "down.",
+          "index": 20
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 13.04,
+        "end": 13.23,
+        "confidence": 0.902,
+        "text": "There",
+        "offset": 0,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 13.23,
+        "end": 13.36,
+        "confidence": 0.52,
+        "text": "is",
+        "offset": 6,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 13.36,
+        "end": 13.42,
+        "confidence": 0.819,
+        "text": "a",
+        "offset": 9,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 13.42,
+        "end": 13.84,
+        "confidence": 0.948,
+        "text": "day",
+        "offset": 11,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 13.84,
+        "end": 14.13,
+        "confidence": 0.976,
+        "text": "about",
+        "offset": 15,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 14.13,
+        "end": 14.35,
+        "confidence": 1,
+        "text": "ten",
+        "offset": 21,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 14.35,
+        "end": 14.59,
+        "confidence": 1,
+        "text": "years",
+        "offset": 25,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 14.59,
+        "end": 15.16,
+        "confidence": 1,
+        "text": "ago",
+        "offset": 31,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 15.46,
+        "end": 15.72,
+        "confidence": 1,
+        "text": "when",
+        "offset": 35,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 15.72,
+        "end": 15.78,
+        "confidence": 1,
+        "text": "I",
+        "offset": 40,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 15.78,
+        "end": 16.19,
+        "confidence": 0.818,
+        "text": "asked",
+        "offset": 42,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 16.19,
+        "end": 16.27,
+        "confidence": 1,
+        "text": "a",
+        "offset": 48,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 16.27,
+        "end": 16.64,
+        "confidence": 1,
+        "text": "friend",
+        "offset": 50,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 16.64,
+        "end": 16.72,
+        "confidence": 1,
+        "text": "to",
+        "offset": 57,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 16.72,
+        "end": 17.2,
+        "confidence": 1,
+        "text": "hold",
+        "offset": 60,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 17.23,
+        "end": 17.31,
+        "confidence": 0.643,
+        "text": "a",
+        "offset": 65,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 17.31,
+        "end": 17.62,
+        "confidence": 1,
+        "text": "baby",
+        "offset": 67,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 17.62,
+        "end": 18.12,
+        "confidence": 0.981,
+        "text": "dinosaur",
+        "offset": 72,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 18.12,
+        "end": 18.6,
+        "confidence": 0.861,
+        "text": "robot",
+        "offset": 81,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 18.72,
+        "end": 19.16,
+        "confidence": 0.832,
+        "text": "upside",
+        "offset": 87,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 19.16,
+        "end": 19.52,
+        "confidence": 0.992,
+        "text": "down.",
+        "offset": 94,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Use this toy call the pleroma that I had ordered and I was really excited about it because I've always loved robots and this one has really cool technical features it had motors and touch sensors and it had an infrared camera and one of the things that had with a tilt sensor so we knew what direction it was the thing and when you held it upside down would start to crack.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 21.86,
+      "words": [
+        {
+          "start": 21.86,
+          "confidence": 0.164,
+          "end": 22.07,
+          "word": "use",
+          "punct": "Use",
+          "index": 0
+        },
+        {
+          "start": 22.07,
+          "confidence": 0.929,
+          "end": 22.22,
+          "word": "this",
+          "punct": "this",
+          "index": 1
+        },
+        {
+          "start": 22.22,
+          "confidence": 0.945,
+          "end": 22.68,
+          "word": "toy",
+          "punct": "toy",
+          "index": 2
+        },
+        {
+          "start": 22.68,
+          "confidence": 0.497,
+          "end": 22.86,
+          "word": "call",
+          "punct": "call",
+          "index": 3
+        },
+        {
+          "start": 22.86,
+          "confidence": 0.836,
+          "end": 22.94,
+          "word": "the",
+          "punct": "the",
+          "index": 4
+        },
+        {
+          "start": 22.94,
+          "confidence": 0.172,
+          "end": 23.77,
+          "word": "pleroma",
+          "punct": "pleroma",
+          "index": 5
+        },
+        {
+          "start": 24.2,
+          "confidence": 1,
+          "end": 24.57,
+          "word": "that",
+          "punct": "that",
+          "index": 6
+        },
+        {
+          "start": 24.61,
+          "confidence": 0.867,
+          "end": 24.71,
+          "word": "I",
+          "punct": "I",
+          "index": 7
+        },
+        {
+          "start": 24.71,
+          "confidence": 0.867,
+          "end": 24.84,
+          "word": "had",
+          "punct": "had",
+          "index": 8
+        },
+        {
+          "start": 24.84,
+          "confidence": 1,
+          "end": 25.32,
+          "word": "ordered",
+          "punct": "ordered",
+          "index": 9
+        },
+        {
+          "start": 25.32,
+          "confidence": 1,
+          "end": 25.43,
+          "word": "and",
+          "punct": "and",
+          "index": 10
+        },
+        {
+          "start": 25.43,
+          "confidence": 1,
+          "end": 25.48,
+          "word": "I",
+          "punct": "I",
+          "index": 11
+        },
+        {
+          "start": 25.48,
+          "confidence": 1,
+          "end": 25.62,
+          "word": "was",
+          "punct": "was",
+          "index": 12
+        },
+        {
+          "start": 25.62,
+          "confidence": 1,
+          "end": 25.86,
+          "word": "really",
+          "punct": "really",
+          "index": 13
+        },
+        {
+          "start": 25.86,
+          "confidence": 1,
+          "end": 26.48,
+          "word": "excited",
+          "punct": "excited",
+          "index": 14
+        },
+        {
+          "start": 26.48,
+          "confidence": 1,
+          "end": 26.82,
+          "word": "about",
+          "punct": "about",
+          "index": 15
+        },
+        {
+          "start": 26.82,
+          "confidence": 0.982,
+          "end": 27.03,
+          "word": "it",
+          "punct": "it",
+          "index": 16
+        },
+        {
+          "start": 27.03,
+          "confidence": 0.997,
+          "end": 27.77,
+          "word": "because",
+          "punct": "because",
+          "index": 17
+        },
+        {
+          "start": 28.42,
+          "confidence": 0.941,
+          "end": 28.57,
+          "word": "I've",
+          "punct": "I've",
+          "index": 18
+        },
+        {
+          "start": 28.57,
+          "confidence": 1,
+          "end": 28.76,
+          "word": "always",
+          "punct": "always",
+          "index": 19
+        },
+        {
+          "start": 28.76,
+          "confidence": 0.99,
+          "end": 29,
+          "word": "loved",
+          "punct": "loved",
+          "index": 20
+        },
+        {
+          "start": 29,
+          "confidence": 0.876,
+          "end": 29.55,
+          "word": "robots",
+          "punct": "robots",
+          "index": 21
+        },
+        {
+          "start": 29.75,
+          "confidence": 1,
+          "end": 29.88,
+          "word": "and",
+          "punct": "and",
+          "index": 22
+        },
+        {
+          "start": 29.88,
+          "confidence": 1,
+          "end": 30.02,
+          "word": "this",
+          "punct": "this",
+          "index": 23
+        },
+        {
+          "start": 30.02,
+          "confidence": 1,
+          "end": 30.18,
+          "word": "one",
+          "punct": "one",
+          "index": 24
+        },
+        {
+          "start": 30.18,
+          "confidence": 0.988,
+          "end": 30.42,
+          "word": "has",
+          "punct": "has",
+          "index": 25
+        },
+        {
+          "start": 30.42,
+          "confidence": 0.948,
+          "end": 30.76,
+          "word": "really",
+          "punct": "really",
+          "index": 26
+        },
+        {
+          "start": 30.76,
+          "confidence": 0.677,
+          "end": 30.92,
+          "word": "cool",
+          "punct": "cool",
+          "index": 27
+        },
+        {
+          "start": 30.92,
+          "confidence": 0.989,
+          "end": 31.33,
+          "word": "technical",
+          "punct": "technical",
+          "index": 28
+        },
+        {
+          "start": 31.33,
+          "confidence": 0.79,
+          "end": 31.79,
+          "word": "features",
+          "punct": "features",
+          "index": 29
+        },
+        {
+          "start": 31.79,
+          "confidence": 0.63,
+          "end": 31.92,
+          "word": "it",
+          "punct": "it",
+          "index": 30
+        },
+        {
+          "start": 31.92,
+          "confidence": 0.905,
+          "end": 32.1,
+          "word": "had",
+          "punct": "had",
+          "index": 31
+        },
+        {
+          "start": 32.1,
+          "confidence": 0.931,
+          "end": 32.73,
+          "word": "motors",
+          "punct": "motors",
+          "index": 32
+        },
+        {
+          "start": 32.73,
+          "confidence": 1,
+          "end": 32.89,
+          "word": "and",
+          "punct": "and",
+          "index": 33
+        },
+        {
+          "start": 32.89,
+          "confidence": 1,
+          "end": 33.16,
+          "word": "touch",
+          "punct": "touch",
+          "index": 34
+        },
+        {
+          "start": 33.16,
+          "confidence": 1,
+          "end": 33.87,
+          "word": "sensors",
+          "punct": "sensors",
+          "index": 35
+        },
+        {
+          "start": 34.2,
+          "confidence": 0.84,
+          "end": 34.39,
+          "word": "and",
+          "punct": "and",
+          "index": 36
+        },
+        {
+          "start": 34.39,
+          "confidence": 0.379,
+          "end": 34.49,
+          "word": "it",
+          "punct": "it",
+          "index": 37
+        },
+        {
+          "start": 34.49,
+          "confidence": 0.919,
+          "end": 34.7,
+          "word": "had",
+          "punct": "had",
+          "index": 38
+        },
+        {
+          "start": 34.7,
+          "confidence": 0.959,
+          "end": 34.79,
+          "word": "an",
+          "punct": "an",
+          "index": 39
+        },
+        {
+          "start": 34.79,
+          "confidence": 0.748,
+          "end": 35.3,
+          "word": "infrared",
+          "punct": "infrared",
+          "index": 40
+        },
+        {
+          "start": 35.3,
+          "confidence": 1,
+          "end": 35.97,
+          "word": "camera",
+          "punct": "camera",
+          "index": 41
+        },
+        {
+          "start": 36.49,
+          "confidence": 1,
+          "end": 36.65,
+          "word": "and",
+          "punct": "and",
+          "index": 42
+        },
+        {
+          "start": 36.65,
+          "confidence": 1,
+          "end": 36.78,
+          "word": "one",
+          "punct": "one",
+          "index": 43
+        },
+        {
+          "start": 36.78,
+          "confidence": 1,
+          "end": 36.86,
+          "word": "of",
+          "punct": "of",
+          "index": 44
+        },
+        {
+          "start": 36.86,
+          "confidence": 1,
+          "end": 36.96,
+          "word": "the",
+          "punct": "the",
+          "index": 45
+        },
+        {
+          "start": 36.96,
+          "confidence": 1,
+          "end": 37.21,
+          "word": "things",
+          "punct": "things",
+          "index": 46
+        },
+        {
+          "start": 37.21,
+          "confidence": 0.717,
+          "end": 37.32,
+          "word": "that",
+          "punct": "that",
+          "index": 47
+        },
+        {
+          "start": 37.32,
+          "confidence": 0.837,
+          "end": 37.51,
+          "word": "had",
+          "punct": "had",
+          "index": 48
+        },
+        {
+          "start": 37.51,
+          "confidence": 0.563,
+          "end": 37.67,
+          "word": "with",
+          "punct": "with",
+          "index": 49
+        },
+        {
+          "start": 37.67,
+          "confidence": 0.298,
+          "end": 37.78,
+          "word": "a",
+          "punct": "a",
+          "index": 50
+        },
+        {
+          "start": 37.95,
+          "confidence": 0.482,
+          "end": 38.37,
+          "word": "tilt",
+          "punct": "tilt",
+          "index": 51
+        },
+        {
+          "start": 38.37,
+          "confidence": 0.978,
+          "end": 38.98,
+          "word": "sensor",
+          "punct": "sensor",
+          "index": 52
+        },
+        {
+          "start": 39.25,
+          "confidence": 0.898,
+          "end": 39.46,
+          "word": "so",
+          "punct": "so",
+          "index": 53
+        },
+        {
+          "start": 39.46,
+          "confidence": 0.226,
+          "end": 39.58,
+          "word": "we",
+          "punct": "we",
+          "index": 54
+        },
+        {
+          "start": 39.61,
+          "confidence": 0.815,
+          "end": 39.81,
+          "word": "knew",
+          "punct": "knew",
+          "index": 55
+        },
+        {
+          "start": 39.81,
+          "confidence": 1,
+          "end": 39.95,
+          "word": "what",
+          "punct": "what",
+          "index": 56
+        },
+        {
+          "start": 39.95,
+          "confidence": 1,
+          "end": 40.53,
+          "word": "direction",
+          "punct": "direction",
+          "index": 57
+        },
+        {
+          "start": 40.53,
+          "confidence": 0.974,
+          "end": 40.63,
+          "word": "it",
+          "punct": "it",
+          "index": 58
+        },
+        {
+          "start": 40.63,
+          "confidence": 0.823,
+          "end": 40.89,
+          "word": "was",
+          "punct": "was",
+          "index": 59
+        },
+        {
+          "start": 40.99,
+          "confidence": 0.346,
+          "end": 41.14,
+          "word": "the",
+          "punct": "the",
+          "index": 60
+        },
+        {
+          "start": 41.14,
+          "confidence": 0.767,
+          "end": 41.54,
+          "word": "thing",
+          "punct": "thing",
+          "index": 61
+        },
+        {
+          "start": 42.01,
+          "confidence": 0.88,
+          "end": 42.22,
+          "word": "and",
+          "punct": "and",
+          "index": 62
+        },
+        {
+          "start": 42.22,
+          "confidence": 0.973,
+          "end": 42.32,
+          "word": "when",
+          "punct": "when",
+          "index": 63
+        },
+        {
+          "start": 42.32,
+          "confidence": 1,
+          "end": 42.4,
+          "word": "you",
+          "punct": "you",
+          "index": 64
+        },
+        {
+          "start": 42.4,
+          "confidence": 0.503,
+          "end": 42.61,
+          "word": "held",
+          "punct": "held",
+          "index": 65
+        },
+        {
+          "start": 42.61,
+          "confidence": 0.454,
+          "end": 42.71,
+          "word": "it",
+          "punct": "it",
+          "index": 66
+        },
+        {
+          "start": 42.71,
+          "confidence": 1,
+          "end": 43.04,
+          "word": "upside",
+          "punct": "upside",
+          "index": 67
+        },
+        {
+          "start": 43.04,
+          "confidence": 0.991,
+          "end": 43.6,
+          "word": "down",
+          "punct": "down",
+          "index": 68
+        },
+        {
+          "start": 44.24,
+          "confidence": 0.511,
+          "end": 44.43,
+          "word": "would",
+          "punct": "would",
+          "index": 69
+        },
+        {
+          "start": 44.43,
+          "confidence": 0.989,
+          "end": 44.66,
+          "word": "start",
+          "punct": "start",
+          "index": 70
+        },
+        {
+          "start": 44.66,
+          "confidence": 0.907,
+          "end": 44.74,
+          "word": "to",
+          "punct": "to",
+          "index": 71
+        },
+        {
+          "start": 44.74,
+          "confidence": 0.341,
+          "end": 45.27,
+          "word": "crack",
+          "punct": "crack.",
+          "index": 72
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 21.86,
+        "end": 22.07,
+        "confidence": 0.164,
+        "text": "Use",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 22.07,
+        "end": 22.22,
+        "confidence": 0.929,
+        "text": "this",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 22.22,
+        "end": 22.68,
+        "confidence": 0.945,
+        "text": "toy",
+        "offset": 9,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 22.68,
+        "end": 22.86,
+        "confidence": 0.497,
+        "text": "call",
+        "offset": 13,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 22.86,
+        "end": 22.94,
+        "confidence": 0.836,
+        "text": "the",
+        "offset": 18,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 22.94,
+        "end": 23.77,
+        "confidence": 0.172,
+        "text": "pleroma",
+        "offset": 22,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 24.2,
+        "end": 24.57,
+        "confidence": 1,
+        "text": "that",
+        "offset": 30,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 24.61,
+        "end": 24.71,
+        "confidence": 0.867,
+        "text": "I",
+        "offset": 35,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 24.71,
+        "end": 24.84,
+        "confidence": 0.867,
+        "text": "had",
+        "offset": 37,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 24.84,
+        "end": 25.32,
+        "confidence": 1,
+        "text": "ordered",
+        "offset": 41,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 25.32,
+        "end": 25.43,
+        "confidence": 1,
+        "text": "and",
+        "offset": 49,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 25.43,
+        "end": 25.48,
+        "confidence": 1,
+        "text": "I",
+        "offset": 53,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 25.48,
+        "end": 25.62,
+        "confidence": 1,
+        "text": "was",
+        "offset": 55,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 25.62,
+        "end": 25.86,
+        "confidence": 1,
+        "text": "really",
+        "offset": 59,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 25.86,
+        "end": 26.48,
+        "confidence": 1,
+        "text": "excited",
+        "offset": 66,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 26.48,
+        "end": 26.82,
+        "confidence": 1,
+        "text": "about",
+        "offset": 74,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 26.82,
+        "end": 27.03,
+        "confidence": 0.982,
+        "text": "it",
+        "offset": 80,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 27.03,
+        "end": 27.77,
+        "confidence": 0.997,
+        "text": "because",
+        "offset": 83,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 28.42,
+        "end": 28.57,
+        "confidence": 0.941,
+        "text": "I've",
+        "offset": 91,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 28.57,
+        "end": 28.76,
+        "confidence": 1,
+        "text": "always",
+        "offset": 96,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 28.76,
+        "end": 29,
+        "confidence": 0.99,
+        "text": "loved",
+        "offset": 103,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 29,
+        "end": 29.55,
+        "confidence": 0.876,
+        "text": "robots",
+        "offset": 109,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 29.75,
+        "end": 29.88,
+        "confidence": 1,
+        "text": "and",
+        "offset": 116,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 29.88,
+        "end": 30.02,
+        "confidence": 1,
+        "text": "this",
+        "offset": 120,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 30.02,
+        "end": 30.18,
+        "confidence": 1,
+        "text": "one",
+        "offset": 125,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 30.18,
+        "end": 30.42,
+        "confidence": 0.988,
+        "text": "has",
+        "offset": 129,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 30.42,
+        "end": 30.76,
+        "confidence": 0.948,
+        "text": "really",
+        "offset": 133,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 30.76,
+        "end": 30.92,
+        "confidence": 0.677,
+        "text": "cool",
+        "offset": 140,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 30.92,
+        "end": 31.33,
+        "confidence": 0.989,
+        "text": "technical",
+        "offset": 145,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 31.33,
+        "end": 31.79,
+        "confidence": 0.79,
+        "text": "features",
+        "offset": 155,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 31.79,
+        "end": 31.92,
+        "confidence": 0.63,
+        "text": "it",
+        "offset": 164,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 31.92,
+        "end": 32.1,
+        "confidence": 0.905,
+        "text": "had",
+        "offset": 167,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 32.1,
+        "end": 32.73,
+        "confidence": 0.931,
+        "text": "motors",
+        "offset": 171,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 32.73,
+        "end": 32.89,
+        "confidence": 1,
+        "text": "and",
+        "offset": 178,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 32.89,
+        "end": 33.16,
+        "confidence": 1,
+        "text": "touch",
+        "offset": 182,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 33.16,
+        "end": 33.87,
+        "confidence": 1,
+        "text": "sensors",
+        "offset": 188,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 34.2,
+        "end": 34.39,
+        "confidence": 0.84,
+        "text": "and",
+        "offset": 196,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 34.39,
+        "end": 34.49,
+        "confidence": 0.379,
+        "text": "it",
+        "offset": 200,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 34.49,
+        "end": 34.7,
+        "confidence": 0.919,
+        "text": "had",
+        "offset": 203,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 34.7,
+        "end": 34.79,
+        "confidence": 0.959,
+        "text": "an",
+        "offset": 207,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 34.79,
+        "end": 35.3,
+        "confidence": 0.748,
+        "text": "infrared",
+        "offset": 210,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 35.3,
+        "end": 35.97,
+        "confidence": 1,
+        "text": "camera",
+        "offset": 219,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 36.49,
+        "end": 36.65,
+        "confidence": 1,
+        "text": "and",
+        "offset": 226,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 36.65,
+        "end": 36.78,
+        "confidence": 1,
+        "text": "one",
+        "offset": 230,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 36.78,
+        "end": 36.86,
+        "confidence": 1,
+        "text": "of",
+        "offset": 234,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 36.86,
+        "end": 36.96,
+        "confidence": 1,
+        "text": "the",
+        "offset": 237,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 36.96,
+        "end": 37.21,
+        "confidence": 1,
+        "text": "things",
+        "offset": 241,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 37.21,
+        "end": 37.32,
+        "confidence": 0.717,
+        "text": "that",
+        "offset": 248,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 37.32,
+        "end": 37.51,
+        "confidence": 0.837,
+        "text": "had",
+        "offset": 253,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 37.51,
+        "end": 37.67,
+        "confidence": 0.563,
+        "text": "with",
+        "offset": 257,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 37.67,
+        "end": 37.78,
+        "confidence": 0.298,
+        "text": "a",
+        "offset": 262,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 37.95,
+        "end": 38.37,
+        "confidence": 0.482,
+        "text": "tilt",
+        "offset": 264,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 38.37,
+        "end": 38.98,
+        "confidence": 0.978,
+        "text": "sensor",
+        "offset": 269,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 39.25,
+        "end": 39.46,
+        "confidence": 0.898,
+        "text": "so",
+        "offset": 276,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 39.46,
+        "end": 39.58,
+        "confidence": 0.226,
+        "text": "we",
+        "offset": 279,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 39.61,
+        "end": 39.81,
+        "confidence": 0.815,
+        "text": "knew",
+        "offset": 282,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 39.81,
+        "end": 39.95,
+        "confidence": 1,
+        "text": "what",
+        "offset": 287,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 39.95,
+        "end": 40.53,
+        "confidence": 1,
+        "text": "direction",
+        "offset": 292,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 40.53,
+        "end": 40.63,
+        "confidence": 0.974,
+        "text": "it",
+        "offset": 302,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 40.63,
+        "end": 40.89,
+        "confidence": 0.823,
+        "text": "was",
+        "offset": 305,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 40.99,
+        "end": 41.14,
+        "confidence": 0.346,
+        "text": "the",
+        "offset": 309,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 41.14,
+        "end": 41.54,
+        "confidence": 0.767,
+        "text": "thing",
+        "offset": 313,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 42.01,
+        "end": 42.22,
+        "confidence": 0.88,
+        "text": "and",
+        "offset": 319,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 42.22,
+        "end": 42.32,
+        "confidence": 0.973,
+        "text": "when",
+        "offset": 323,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 42.32,
+        "end": 42.4,
+        "confidence": 1,
+        "text": "you",
+        "offset": 328,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 42.4,
+        "end": 42.61,
+        "confidence": 0.503,
+        "text": "held",
+        "offset": 332,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 42.61,
+        "end": 42.71,
+        "confidence": 0.454,
+        "text": "it",
+        "offset": 337,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 42.71,
+        "end": 43.04,
+        "confidence": 1,
+        "text": "upside",
+        "offset": 340,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 43.04,
+        "end": 43.6,
+        "confidence": 0.991,
+        "text": "down",
+        "offset": 347,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 44.24,
+        "end": 44.43,
+        "confidence": 0.511,
+        "text": "would",
+        "offset": 352,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 44.43,
+        "end": 44.66,
+        "confidence": 0.989,
+        "text": "start",
+        "offset": 358,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 44.66,
+        "end": 44.74,
+        "confidence": 0.907,
+        "text": "to",
+        "offset": 364,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 44.74,
+        "end": 45.27,
+        "confidence": 0.341,
+        "text": "crack.",
+        "offset": 367,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And I thought this was super cool so I'm showing off to my friend and I said to hold it up by that helps you to.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 46.52,
+      "words": [
+        {
+          "start": 46.52,
+          "confidence": 0.616,
+          "end": 46.62,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 46.62,
+          "confidence": 0.799,
+          "end": 46.67,
+          "word": "I",
+          "punct": "I",
+          "index": 1
+        },
+        {
+          "start": 46.67,
+          "confidence": 0.894,
+          "end": 46.88,
+          "word": "thought",
+          "punct": "thought",
+          "index": 2
+        },
+        {
+          "start": 46.88,
+          "confidence": 0.244,
+          "end": 47.1,
+          "word": "this",
+          "punct": "this",
+          "index": 3
+        },
+        {
+          "start": 47.13,
+          "confidence": 0.103,
+          "end": 47.26,
+          "word": "was",
+          "punct": "was",
+          "index": 4
+        },
+        {
+          "start": 47.26,
+          "confidence": 0.943,
+          "end": 47.62,
+          "word": "super",
+          "punct": "super",
+          "index": 5
+        },
+        {
+          "start": 47.62,
+          "confidence": 0.869,
+          "end": 47.98,
+          "word": "cool",
+          "punct": "cool",
+          "index": 6
+        },
+        {
+          "start": 47.98,
+          "confidence": 0.321,
+          "end": 48.15,
+          "word": "so",
+          "punct": "so",
+          "index": 7
+        },
+        {
+          "start": 48.15,
+          "confidence": 0.116,
+          "end": 48.25,
+          "word": "I'm",
+          "punct": "I'm",
+          "index": 8
+        },
+        {
+          "start": 48.25,
+          "confidence": 0.885,
+          "end": 48.66,
+          "word": "showing",
+          "punct": "showing",
+          "index": 9
+        },
+        {
+          "start": 48.66,
+          "confidence": 0.702,
+          "end": 48.81,
+          "word": "off",
+          "punct": "off",
+          "index": 10
+        },
+        {
+          "start": 48.81,
+          "confidence": 0.56,
+          "end": 48.92,
+          "word": "to",
+          "punct": "to",
+          "index": 11
+        },
+        {
+          "start": 48.92,
+          "confidence": 1,
+          "end": 49.02,
+          "word": "my",
+          "punct": "my",
+          "index": 12
+        },
+        {
+          "start": 49.02,
+          "confidence": 0.682,
+          "end": 49.57,
+          "word": "friend",
+          "punct": "friend",
+          "index": 13
+        },
+        {
+          "start": 50.01,
+          "confidence": 1,
+          "end": 50.15,
+          "word": "and",
+          "punct": "and",
+          "index": 14
+        },
+        {
+          "start": 50.15,
+          "confidence": 1,
+          "end": 50.2,
+          "word": "I",
+          "punct": "I",
+          "index": 15
+        },
+        {
+          "start": 50.2,
+          "confidence": 0.949,
+          "end": 50.38,
+          "word": "said",
+          "punct": "said",
+          "index": 16
+        },
+        {
+          "start": 50.38,
+          "confidence": 0.195,
+          "end": 50.44,
+          "word": "to",
+          "punct": "to",
+          "index": 17
+        },
+        {
+          "start": 50.44,
+          "confidence": 0.63,
+          "end": 50.81,
+          "word": "hold",
+          "punct": "hold",
+          "index": 18
+        },
+        {
+          "start": 50.81,
+          "confidence": 0.443,
+          "end": 50.88,
+          "word": "it",
+          "punct": "it",
+          "index": 19
+        },
+        {
+          "start": 50.88,
+          "confidence": 0.451,
+          "end": 50.96,
+          "word": "up",
+          "punct": "up",
+          "index": 20
+        },
+        {
+          "start": 50.96,
+          "confidence": 0.954,
+          "end": 51.05,
+          "word": "by",
+          "punct": "by",
+          "index": 21
+        },
+        {
+          "start": 51.05,
+          "confidence": 0.375,
+          "end": 51.22,
+          "word": "that",
+          "punct": "that",
+          "index": 22
+        },
+        {
+          "start": 51.22,
+          "confidence": 0.282,
+          "end": 51.57,
+          "word": "helps",
+          "punct": "helps",
+          "index": 23
+        },
+        {
+          "start": 51.57,
+          "confidence": 0.426,
+          "end": 51.71,
+          "word": "you",
+          "punct": "you",
+          "index": 24
+        },
+        {
+          "start": 51.71,
+          "confidence": 0.188,
+          "end": 52,
+          "word": "to",
+          "punct": "to.",
+          "index": 25
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 46.52,
+        "end": 46.62,
+        "confidence": 0.616,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 46.62,
+        "end": 46.67,
+        "confidence": 0.799,
+        "text": "I",
+        "offset": 4,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 46.67,
+        "end": 46.88,
+        "confidence": 0.894,
+        "text": "thought",
+        "offset": 6,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 46.88,
+        "end": 47.1,
+        "confidence": 0.244,
+        "text": "this",
+        "offset": 14,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 47.13,
+        "end": 47.26,
+        "confidence": 0.103,
+        "text": "was",
+        "offset": 19,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 47.26,
+        "end": 47.62,
+        "confidence": 0.943,
+        "text": "super",
+        "offset": 23,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 47.62,
+        "end": 47.98,
+        "confidence": 0.869,
+        "text": "cool",
+        "offset": 29,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 47.98,
+        "end": 48.15,
+        "confidence": 0.321,
+        "text": "so",
+        "offset": 34,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 48.15,
+        "end": 48.25,
+        "confidence": 0.116,
+        "text": "I'm",
+        "offset": 37,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 48.25,
+        "end": 48.66,
+        "confidence": 0.885,
+        "text": "showing",
+        "offset": 41,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 48.66,
+        "end": 48.81,
+        "confidence": 0.702,
+        "text": "off",
+        "offset": 49,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 48.81,
+        "end": 48.92,
+        "confidence": 0.56,
+        "text": "to",
+        "offset": 53,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 48.92,
+        "end": 49.02,
+        "confidence": 1,
+        "text": "my",
+        "offset": 56,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 49.02,
+        "end": 49.57,
+        "confidence": 0.682,
+        "text": "friend",
+        "offset": 59,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 50.01,
+        "end": 50.15,
+        "confidence": 1,
+        "text": "and",
+        "offset": 66,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 50.15,
+        "end": 50.2,
+        "confidence": 1,
+        "text": "I",
+        "offset": 70,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 50.2,
+        "end": 50.38,
+        "confidence": 0.949,
+        "text": "said",
+        "offset": 72,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 50.38,
+        "end": 50.44,
+        "confidence": 0.195,
+        "text": "to",
+        "offset": 77,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 50.44,
+        "end": 50.81,
+        "confidence": 0.63,
+        "text": "hold",
+        "offset": 80,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 50.81,
+        "end": 50.88,
+        "confidence": 0.443,
+        "text": "it",
+        "offset": 85,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 50.88,
+        "end": 50.96,
+        "confidence": 0.451,
+        "text": "up",
+        "offset": 88,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 50.96,
+        "end": 51.05,
+        "confidence": 0.954,
+        "text": "by",
+        "offset": 91,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 51.05,
+        "end": 51.22,
+        "confidence": 0.375,
+        "text": "that",
+        "offset": 94,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 51.22,
+        "end": 51.57,
+        "confidence": 0.282,
+        "text": "helps",
+        "offset": 99,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 51.57,
+        "end": 51.71,
+        "confidence": 0.426,
+        "text": "you",
+        "offset": 105,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 51.71,
+        "end": 52,
+        "confidence": 0.188,
+        "text": "to.",
+        "offset": 109,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "So we're watching the theatrics of this robot.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 55.24,
+      "words": [
+        {
+          "start": 55.24,
+          "confidence": 0.438,
+          "end": 55.37,
+          "word": "so",
+          "punct": "So",
+          "index": 0
+        },
+        {
+          "start": 55.37,
+          "confidence": 0.483,
+          "end": 55.49,
+          "word": "we're",
+          "punct": "we're",
+          "index": 1
+        },
+        {
+          "start": 55.49,
+          "confidence": 0.988,
+          "end": 55.91,
+          "word": "watching",
+          "punct": "watching",
+          "index": 2
+        },
+        {
+          "start": 55.91,
+          "confidence": 1,
+          "end": 56,
+          "word": "the",
+          "punct": "the",
+          "index": 3
+        },
+        {
+          "start": 56,
+          "confidence": 1,
+          "end": 56.9,
+          "word": "theatrics",
+          "punct": "theatrics",
+          "index": 4
+        },
+        {
+          "start": 56.9,
+          "confidence": 1,
+          "end": 57,
+          "word": "of",
+          "punct": "of",
+          "index": 5
+        },
+        {
+          "start": 57,
+          "confidence": 1,
+          "end": 57.2,
+          "word": "this",
+          "punct": "this",
+          "index": 6
+        },
+        {
+          "start": 57.2,
+          "confidence": 0.991,
+          "end": 57.94,
+          "word": "robot",
+          "punct": "robot.",
+          "index": 7
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 55.24,
+        "end": 55.37,
+        "confidence": 0.438,
+        "text": "So",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 55.37,
+        "end": 55.49,
+        "confidence": 0.483,
+        "text": "we're",
+        "offset": 3,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 55.49,
+        "end": 55.91,
+        "confidence": 0.988,
+        "text": "watching",
+        "offset": 9,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 55.91,
+        "end": 56,
+        "confidence": 1,
+        "text": "the",
+        "offset": 18,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 56,
+        "end": 56.9,
+        "confidence": 1,
+        "text": "theatrics",
+        "offset": 22,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 56.9,
+        "end": 57,
+        "confidence": 1,
+        "text": "of",
+        "offset": 32,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 57,
+        "end": 57.2,
+        "confidence": 1,
+        "text": "this",
+        "offset": 35,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 57.2,
+        "end": 57.94,
+        "confidence": 0.991,
+        "text": "robot.",
+        "offset": 40,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Struggle and cry out.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 58.87,
+      "words": [
+        {
+          "start": 58.87,
+          "confidence": 0.592,
+          "end": 59.83,
+          "word": "struggle",
+          "punct": "Struggle",
+          "index": 0
+        },
+        {
+          "start": 59.89,
+          "confidence": 0.872,
+          "end": 60.11,
+          "word": "and",
+          "punct": "and",
+          "index": 1
+        },
+        {
+          "start": 60.11,
+          "confidence": 0.556,
+          "end": 60.61,
+          "word": "cry",
+          "punct": "cry",
+          "index": 2
+        },
+        {
+          "start": 60.61,
+          "confidence": 0.954,
+          "end": 61.09,
+          "word": "out",
+          "punct": "out.",
+          "index": 3
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 58.87,
+        "end": 59.83,
+        "confidence": 0.592,
+        "text": "Struggle",
+        "offset": 0,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 59.89,
+        "end": 60.11,
+        "confidence": 0.872,
+        "text": "and",
+        "offset": 9,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 60.11,
+        "end": 60.61,
+        "confidence": 0.556,
+        "text": "cry",
+        "offset": 13,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 60.61,
+        "end": 61.09,
+        "confidence": 0.954,
+        "text": "out.",
+        "offset": 17,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And after a few seconds first bother me a little.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 62.74,
+      "words": [
+        {
+          "start": 62.74,
+          "confidence": 0.858,
+          "end": 63.01,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 63.24,
+          "confidence": 1,
+          "end": 63.53,
+          "word": "after",
+          "punct": "after",
+          "index": 1
+        },
+        {
+          "start": 63.53,
+          "confidence": 0.673,
+          "end": 63.56,
+          "word": "a",
+          "punct": "a",
+          "index": 2
+        },
+        {
+          "start": 63.56,
+          "confidence": 1,
+          "end": 63.73,
+          "word": "few",
+          "punct": "few",
+          "index": 3
+        },
+        {
+          "start": 63.73,
+          "confidence": 0.995,
+          "end": 64.46,
+          "word": "seconds",
+          "punct": "seconds",
+          "index": 4
+        },
+        {
+          "start": 64.93,
+          "confidence": 0.853,
+          "end": 65.31,
+          "word": "first",
+          "punct": "first",
+          "index": 5
+        },
+        {
+          "start": 65.48,
+          "confidence": 0.86,
+          "end": 65.83,
+          "word": "bother",
+          "punct": "bother",
+          "index": 6
+        },
+        {
+          "start": 65.83,
+          "confidence": 0.98,
+          "end": 65.97,
+          "word": "me",
+          "punct": "me",
+          "index": 7
+        },
+        {
+          "start": 65.97,
+          "confidence": 0.896,
+          "end": 66.04,
+          "word": "a",
+          "punct": "a",
+          "index": 8
+        },
+        {
+          "start": 66.04,
+          "confidence": 0.994,
+          "end": 66.43,
+          "word": "little",
+          "punct": "little.",
+          "index": 9
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 62.74,
+        "end": 63.01,
+        "confidence": 0.858,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 63.24,
+        "end": 63.53,
+        "confidence": 1,
+        "text": "after",
+        "offset": 4,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 63.53,
+        "end": 63.56,
+        "confidence": 0.673,
+        "text": "a",
+        "offset": 10,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 63.56,
+        "end": 63.73,
+        "confidence": 1,
+        "text": "few",
+        "offset": 12,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 63.73,
+        "end": 64.46,
+        "confidence": 0.995,
+        "text": "seconds",
+        "offset": 16,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 64.93,
+        "end": 65.31,
+        "confidence": 0.853,
+        "text": "first",
+        "offset": 24,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 65.48,
+        "end": 65.83,
+        "confidence": 0.86,
+        "text": "bother",
+        "offset": 30,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 65.83,
+        "end": 65.97,
+        "confidence": 0.98,
+        "text": "me",
+        "offset": 37,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 65.97,
+        "end": 66.04,
+        "confidence": 0.896,
+        "text": "a",
+        "offset": 40,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 66.04,
+        "end": 66.43,
+        "confidence": 0.994,
+        "text": "little.",
+        "offset": 42,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And I said okay.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 67.71,
+      "words": [
+        {
+          "start": 67.71,
+          "confidence": 1,
+          "end": 67.88,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 67.88,
+          "confidence": 1,
+          "end": 67.95,
+          "word": "I",
+          "punct": "I",
+          "index": 1
+        },
+        {
+          "start": 67.95,
+          "confidence": 1,
+          "end": 68.2,
+          "word": "said",
+          "punct": "said",
+          "index": 2
+        },
+        {
+          "start": 68.2,
+          "confidence": 0.957,
+          "end": 68.83,
+          "word": "okay",
+          "punct": "okay.",
+          "index": 3
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 67.71,
+        "end": 67.88,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 67.88,
+        "end": 67.95,
+        "confidence": 1,
+        "text": "I",
+        "offset": 4,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 67.95,
+        "end": 68.2,
+        "confidence": 1,
+        "text": "said",
+        "offset": 6,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 68.2,
+        "end": 68.83,
+        "confidence": 0.957,
+        "text": "okay.",
+        "offset": 11,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "That's enough now.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 69.96,
+      "words": [
+        {
+          "start": 69.96,
+          "confidence": 0.854,
+          "end": 70.19,
+          "word": "that's",
+          "punct": "That's",
+          "index": 0
+        },
+        {
+          "start": 70.19,
+          "confidence": 0.988,
+          "end": 70.56,
+          "word": "enough",
+          "punct": "enough",
+          "index": 1
+        },
+        {
+          "start": 70.56,
+          "confidence": 0.859,
+          "end": 71.03,
+          "word": "now",
+          "punct": "now.",
+          "index": 2
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 69.96,
+        "end": 70.19,
+        "confidence": 0.854,
+        "text": "That's",
+        "offset": 0,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 70.19,
+        "end": 70.56,
+        "confidence": 0.988,
+        "text": "enough",
+        "offset": 7,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 70.56,
+        "end": 71.03,
+        "confidence": 0.859,
+        "text": "now.",
+        "offset": 14,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Let's put him back down.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 71.92,
+      "words": [
+        {
+          "start": 71.92,
+          "confidence": 0.628,
+          "end": 72.1,
+          "word": "let's",
+          "punct": "Let's",
+          "index": 0
+        },
+        {
+          "start": 72.1,
+          "confidence": 0.682,
+          "end": 72.22,
+          "word": "put",
+          "punct": "put",
+          "index": 1
+        },
+        {
+          "start": 72.22,
+          "confidence": 0.338,
+          "end": 72.31,
+          "word": "him",
+          "punct": "him",
+          "index": 2
+        },
+        {
+          "start": 72.31,
+          "confidence": 0.921,
+          "end": 72.55,
+          "word": "back",
+          "punct": "back",
+          "index": 3
+        },
+        {
+          "start": 72.55,
+          "confidence": 0.718,
+          "end": 73.08,
+          "word": "down",
+          "punct": "down.",
+          "index": 4
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 71.92,
+        "end": 72.1,
+        "confidence": 0.628,
+        "text": "Let's",
+        "offset": 0,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 72.1,
+        "end": 72.22,
+        "confidence": 0.682,
+        "text": "put",
+        "offset": 6,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 72.22,
+        "end": 72.31,
+        "confidence": 0.338,
+        "text": "him",
+        "offset": 10,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 72.31,
+        "end": 72.55,
+        "confidence": 0.921,
+        "text": "back",
+        "offset": 14,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 72.55,
+        "end": 73.08,
+        "confidence": 0.718,
+        "text": "down.",
+        "offset": 19,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And then I packed the robot to make it stop crying.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 74.26,
+      "words": [
+        {
+          "start": 74.26,
+          "confidence": 1,
+          "end": 74.42,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 74.42,
+          "confidence": 1,
+          "end": 74.55,
+          "word": "then",
+          "punct": "then",
+          "index": 1
+        },
+        {
+          "start": 74.55,
+          "confidence": 0.969,
+          "end": 74.61,
+          "word": "I",
+          "punct": "I",
+          "index": 2
+        },
+        {
+          "start": 74.61,
+          "confidence": 0.123,
+          "end": 74.88,
+          "word": "packed",
+          "punct": "packed",
+          "index": 3
+        },
+        {
+          "start": 74.88,
+          "confidence": 1,
+          "end": 74.98,
+          "word": "the",
+          "punct": "the",
+          "index": 4
+        },
+        {
+          "start": 74.98,
+          "confidence": 0.351,
+          "end": 75.34,
+          "word": "robot",
+          "punct": "robot",
+          "index": 5
+        },
+        {
+          "start": 75.34,
+          "confidence": 0.509,
+          "end": 75.43,
+          "word": "to",
+          "punct": "to",
+          "index": 6
+        },
+        {
+          "start": 75.43,
+          "confidence": 1,
+          "end": 75.56,
+          "word": "make",
+          "punct": "make",
+          "index": 7
+        },
+        {
+          "start": 75.56,
+          "confidence": 0.874,
+          "end": 75.65,
+          "word": "it",
+          "punct": "it",
+          "index": 8
+        },
+        {
+          "start": 75.65,
+          "confidence": 0.958,
+          "end": 75.91,
+          "word": "stop",
+          "punct": "stop",
+          "index": 9
+        },
+        {
+          "start": 75.91,
+          "confidence": 0.964,
+          "end": 76.46,
+          "word": "crying",
+          "punct": "crying.",
+          "index": 10
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 74.26,
+        "end": 74.42,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 74.42,
+        "end": 74.55,
+        "confidence": 1,
+        "text": "then",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 74.55,
+        "end": 74.61,
+        "confidence": 0.969,
+        "text": "I",
+        "offset": 9,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 74.61,
+        "end": 74.88,
+        "confidence": 0.123,
+        "text": "packed",
+        "offset": 11,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 74.88,
+        "end": 74.98,
+        "confidence": 1,
+        "text": "the",
+        "offset": 18,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 74.98,
+        "end": 75.34,
+        "confidence": 0.351,
+        "text": "robot",
+        "offset": 22,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 75.34,
+        "end": 75.43,
+        "confidence": 0.509,
+        "text": "to",
+        "offset": 28,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 75.43,
+        "end": 75.56,
+        "confidence": 1,
+        "text": "make",
+        "offset": 31,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 75.56,
+        "end": 75.65,
+        "confidence": 0.874,
+        "text": "it",
+        "offset": 36,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 75.65,
+        "end": 75.91,
+        "confidence": 0.958,
+        "text": "stop",
+        "offset": 39,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 75.91,
+        "end": 76.46,
+        "confidence": 0.964,
+        "text": "crying.",
+        "offset": 44,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "I was kind of a weird experience for me.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 79.08,
+      "words": [
+        {
+          "start": 79.08,
+          "confidence": 0.22,
+          "end": 79.13,
+          "word": "I",
+          "punct": "I",
+          "index": 0
+        },
+        {
+          "start": 79.13,
+          "confidence": 0.602,
+          "end": 79.27,
+          "word": "was",
+          "punct": "was",
+          "index": 1
+        },
+        {
+          "start": 79.27,
+          "confidence": 0.998,
+          "end": 79.43,
+          "word": "kind",
+          "punct": "kind",
+          "index": 2
+        },
+        {
+          "start": 79.43,
+          "confidence": 1,
+          "end": 79.5,
+          "word": "of",
+          "punct": "of",
+          "index": 3
+        },
+        {
+          "start": 79.5,
+          "confidence": 1,
+          "end": 79.6,
+          "word": "a",
+          "punct": "a",
+          "index": 4
+        },
+        {
+          "start": 79.6,
+          "confidence": 1,
+          "end": 79.93,
+          "word": "weird",
+          "punct": "weird",
+          "index": 5
+        },
+        {
+          "start": 79.93,
+          "confidence": 1,
+          "end": 80.58,
+          "word": "experience",
+          "punct": "experience",
+          "index": 6
+        },
+        {
+          "start": 80.58,
+          "confidence": 1,
+          "end": 80.75,
+          "word": "for",
+          "punct": "for",
+          "index": 7
+        },
+        {
+          "start": 80.75,
+          "confidence": 0.992,
+          "end": 81.15,
+          "word": "me",
+          "punct": "me.",
+          "index": 8
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 79.08,
+        "end": 79.13,
+        "confidence": 0.22,
+        "text": "I",
+        "offset": 0,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 79.13,
+        "end": 79.27,
+        "confidence": 0.602,
+        "text": "was",
+        "offset": 2,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 79.27,
+        "end": 79.43,
+        "confidence": 0.998,
+        "text": "kind",
+        "offset": 6,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 79.43,
+        "end": 79.5,
+        "confidence": 1,
+        "text": "of",
+        "offset": 11,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 79.5,
+        "end": 79.6,
+        "confidence": 1,
+        "text": "a",
+        "offset": 14,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 79.6,
+        "end": 79.93,
+        "confidence": 1,
+        "text": "weird",
+        "offset": 16,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 79.93,
+        "end": 80.58,
+        "confidence": 1,
+        "text": "experience",
+        "offset": 22,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 80.58,
+        "end": 80.75,
+        "confidence": 1,
+        "text": "for",
+        "offset": 33,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 80.75,
+        "end": 81.15,
+        "confidence": 0.992,
+        "text": "me.",
+        "offset": 37,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "For one thing I wasn't the most maternal person at the time.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 82.07,
+      "words": [
+        {
+          "start": 82.07,
+          "confidence": 0.491,
+          "end": 82.16,
+          "word": "for",
+          "punct": "For",
+          "index": 0
+        },
+        {
+          "start": 82.16,
+          "confidence": 0.991,
+          "end": 82.32,
+          "word": "one",
+          "punct": "one",
+          "index": 1
+        },
+        {
+          "start": 82.32,
+          "confidence": 0.999,
+          "end": 82.68,
+          "word": "thing",
+          "punct": "thing",
+          "index": 2
+        },
+        {
+          "start": 82.96,
+          "confidence": 0.473,
+          "end": 83.05,
+          "word": "I",
+          "punct": "I",
+          "index": 3
+        },
+        {
+          "start": 83.05,
+          "confidence": 0.915,
+          "end": 83.3,
+          "word": "wasn't",
+          "punct": "wasn't",
+          "index": 4
+        },
+        {
+          "start": 83.3,
+          "confidence": 1,
+          "end": 83.37,
+          "word": "the",
+          "punct": "the",
+          "index": 5
+        },
+        {
+          "start": 83.37,
+          "confidence": 1,
+          "end": 83.68,
+          "word": "most",
+          "punct": "most",
+          "index": 6
+        },
+        {
+          "start": 83.77,
+          "confidence": 1,
+          "end": 84.39,
+          "word": "maternal",
+          "punct": "maternal",
+          "index": 7
+        },
+        {
+          "start": 84.39,
+          "confidence": 0.982,
+          "end": 84.9,
+          "word": "person",
+          "punct": "person",
+          "index": 8
+        },
+        {
+          "start": 84.9,
+          "confidence": 0.614,
+          "end": 85.05,
+          "word": "at",
+          "punct": "at",
+          "index": 9
+        },
+        {
+          "start": 85.05,
+          "confidence": 0.891,
+          "end": 85.14,
+          "word": "the",
+          "punct": "the",
+          "index": 10
+        },
+        {
+          "start": 85.14,
+          "confidence": 0.992,
+          "end": 85.79,
+          "word": "time",
+          "punct": "time.",
+          "index": 11
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 82.07,
+        "end": 82.16,
+        "confidence": 0.491,
+        "text": "For",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 82.16,
+        "end": 82.32,
+        "confidence": 0.991,
+        "text": "one",
+        "offset": 4,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 82.32,
+        "end": 82.68,
+        "confidence": 0.999,
+        "text": "thing",
+        "offset": 8,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 82.96,
+        "end": 83.05,
+        "confidence": 0.473,
+        "text": "I",
+        "offset": 14,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 83.05,
+        "end": 83.3,
+        "confidence": 0.915,
+        "text": "wasn't",
+        "offset": 16,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 83.3,
+        "end": 83.37,
+        "confidence": 1,
+        "text": "the",
+        "offset": 23,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 83.37,
+        "end": 83.68,
+        "confidence": 1,
+        "text": "most",
+        "offset": 27,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 83.77,
+        "end": 84.39,
+        "confidence": 1,
+        "text": "maternal",
+        "offset": 32,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 84.39,
+        "end": 84.9,
+        "confidence": 0.982,
+        "text": "person",
+        "offset": 41,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 84.9,
+        "end": 85.05,
+        "confidence": 0.614,
+        "text": "at",
+        "offset": 48,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 85.05,
+        "end": 85.14,
+        "confidence": 0.891,
+        "text": "the",
+        "offset": 51,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 85.14,
+        "end": 85.79,
+        "confidence": 0.992,
+        "text": "time.",
+        "offset": 55,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Although since then I've become a mother nine months ago and I've learned that babies also squirming hold them off and on.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 86.66,
+      "words": [
+        {
+          "start": 86.66,
+          "confidence": 1,
+          "end": 86.9,
+          "word": "although",
+          "punct": "Although",
+          "index": 0
+        },
+        {
+          "start": 86.9,
+          "confidence": 0.953,
+          "end": 87.15,
+          "word": "since",
+          "punct": "since",
+          "index": 1
+        },
+        {
+          "start": 87.15,
+          "confidence": 0.455,
+          "end": 87.28,
+          "word": "then",
+          "punct": "then",
+          "index": 2
+        },
+        {
+          "start": 87.28,
+          "confidence": 0.395,
+          "end": 87.37,
+          "word": "I've",
+          "punct": "I've",
+          "index": 3
+        },
+        {
+          "start": 87.37,
+          "confidence": 1,
+          "end": 87.59,
+          "word": "become",
+          "punct": "become",
+          "index": 4
+        },
+        {
+          "start": 87.59,
+          "confidence": 1,
+          "end": 87.65,
+          "word": "a",
+          "punct": "a",
+          "index": 5
+        },
+        {
+          "start": 87.65,
+          "confidence": 0.905,
+          "end": 87.96,
+          "word": "mother",
+          "punct": "mother",
+          "index": 6
+        },
+        {
+          "start": 87.96,
+          "confidence": 0.755,
+          "end": 88.26,
+          "word": "nine",
+          "punct": "nine",
+          "index": 7
+        },
+        {
+          "start": 88.26,
+          "confidence": 1,
+          "end": 88.48,
+          "word": "months",
+          "punct": "months",
+          "index": 8
+        },
+        {
+          "start": 88.48,
+          "confidence": 0.998,
+          "end": 88.91,
+          "word": "ago",
+          "punct": "ago",
+          "index": 9
+        },
+        {
+          "start": 89.41,
+          "confidence": 0.987,
+          "end": 89.54,
+          "word": "and",
+          "punct": "and",
+          "index": 10
+        },
+        {
+          "start": 89.54,
+          "confidence": 0.704,
+          "end": 89.63,
+          "word": "I've",
+          "punct": "I've",
+          "index": 11
+        },
+        {
+          "start": 89.63,
+          "confidence": 0.998,
+          "end": 89.89,
+          "word": "learned",
+          "punct": "learned",
+          "index": 12
+        },
+        {
+          "start": 89.89,
+          "confidence": 0.905,
+          "end": 90.15,
+          "word": "that",
+          "punct": "that",
+          "index": 13
+        },
+        {
+          "start": 90.18,
+          "confidence": 0.77,
+          "end": 90.48,
+          "word": "babies",
+          "punct": "babies",
+          "index": 14
+        },
+        {
+          "start": 90.48,
+          "confidence": 1,
+          "end": 90.71,
+          "word": "also",
+          "punct": "also",
+          "index": 15
+        },
+        {
+          "start": 90.71,
+          "confidence": 0.23,
+          "end": 91.23,
+          "word": "squirming",
+          "punct": "squirming",
+          "index": 16
+        },
+        {
+          "start": 91.23,
+          "confidence": 0.606,
+          "end": 91.43,
+          "word": "hold",
+          "punct": "hold",
+          "index": 17
+        },
+        {
+          "start": 91.43,
+          "confidence": 0.426,
+          "end": 91.53,
+          "word": "them",
+          "punct": "them",
+          "index": 18
+        },
+        {
+          "start": 91.53,
+          "confidence": 0.393,
+          "end": 91.73,
+          "word": "off",
+          "punct": "off",
+          "index": 19
+        },
+        {
+          "start": 91.73,
+          "confidence": 0.427,
+          "end": 91.85,
+          "word": "and",
+          "punct": "and",
+          "index": 20
+        },
+        {
+          "start": 91.85,
+          "confidence": 0.433,
+          "end": 92.19,
+          "word": "on",
+          "punct": "on.",
+          "index": 21
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 86.66,
+        "end": 86.9,
+        "confidence": 1,
+        "text": "Although",
+        "offset": 0,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 86.9,
+        "end": 87.15,
+        "confidence": 0.953,
+        "text": "since",
+        "offset": 9,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 87.15,
+        "end": 87.28,
+        "confidence": 0.455,
+        "text": "then",
+        "offset": 15,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 87.28,
+        "end": 87.37,
+        "confidence": 0.395,
+        "text": "I've",
+        "offset": 20,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 87.37,
+        "end": 87.59,
+        "confidence": 1,
+        "text": "become",
+        "offset": 25,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 87.59,
+        "end": 87.65,
+        "confidence": 1,
+        "text": "a",
+        "offset": 32,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 87.65,
+        "end": 87.96,
+        "confidence": 0.905,
+        "text": "mother",
+        "offset": 34,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 87.96,
+        "end": 88.26,
+        "confidence": 0.755,
+        "text": "nine",
+        "offset": 41,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 88.26,
+        "end": 88.48,
+        "confidence": 1,
+        "text": "months",
+        "offset": 46,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 88.48,
+        "end": 88.91,
+        "confidence": 0.998,
+        "text": "ago",
+        "offset": 53,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 89.41,
+        "end": 89.54,
+        "confidence": 0.987,
+        "text": "and",
+        "offset": 57,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 89.54,
+        "end": 89.63,
+        "confidence": 0.704,
+        "text": "I've",
+        "offset": 61,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 89.63,
+        "end": 89.89,
+        "confidence": 0.998,
+        "text": "learned",
+        "offset": 66,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 89.89,
+        "end": 90.15,
+        "confidence": 0.905,
+        "text": "that",
+        "offset": 74,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 90.18,
+        "end": 90.48,
+        "confidence": 0.77,
+        "text": "babies",
+        "offset": 79,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 90.48,
+        "end": 90.71,
+        "confidence": 1,
+        "text": "also",
+        "offset": 86,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 90.71,
+        "end": 91.23,
+        "confidence": 0.23,
+        "text": "squirming",
+        "offset": 91,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 91.23,
+        "end": 91.43,
+        "confidence": 0.606,
+        "text": "hold",
+        "offset": 101,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 91.43,
+        "end": 91.53,
+        "confidence": 0.426,
+        "text": "them",
+        "offset": 106,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 91.53,
+        "end": 91.73,
+        "confidence": 0.393,
+        "text": "off",
+        "offset": 111,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 91.73,
+        "end": 91.85,
+        "confidence": 0.427,
+        "text": "and",
+        "offset": 115,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 91.85,
+        "end": 92.19,
+        "confidence": 0.433,
+        "text": "on.",
+        "offset": 119,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "But my response this robot was also interesting because I know exactly how this machine work.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 95.01,
+      "words": [
+        {
+          "start": 95.01,
+          "confidence": 1,
+          "end": 95.26,
+          "word": "but",
+          "punct": "But",
+          "index": 0
+        },
+        {
+          "start": 95.26,
+          "confidence": 1,
+          "end": 95.43,
+          "word": "my",
+          "punct": "my",
+          "index": 1
+        },
+        {
+          "start": 95.43,
+          "confidence": 0.991,
+          "end": 95.88,
+          "word": "response",
+          "punct": "response",
+          "index": 2
+        },
+        {
+          "start": 95.88,
+          "confidence": 0.962,
+          "end": 96.09,
+          "word": "this",
+          "punct": "this",
+          "index": 3
+        },
+        {
+          "start": 96.09,
+          "confidence": 0.819,
+          "end": 96.42,
+          "word": "robot",
+          "punct": "robot",
+          "index": 4
+        },
+        {
+          "start": 96.42,
+          "confidence": 1,
+          "end": 96.56,
+          "word": "was",
+          "punct": "was",
+          "index": 5
+        },
+        {
+          "start": 96.56,
+          "confidence": 1,
+          "end": 96.84,
+          "word": "also",
+          "punct": "also",
+          "index": 6
+        },
+        {
+          "start": 96.84,
+          "confidence": 1,
+          "end": 97.25,
+          "word": "interesting",
+          "punct": "interesting",
+          "index": 7
+        },
+        {
+          "start": 97.25,
+          "confidence": 1,
+          "end": 97.7,
+          "word": "because",
+          "punct": "because",
+          "index": 8
+        },
+        {
+          "start": 97.9,
+          "confidence": 1,
+          "end": 98.01,
+          "word": "I",
+          "punct": "I",
+          "index": 9
+        },
+        {
+          "start": 98.01,
+          "confidence": 0.298,
+          "end": 98.15,
+          "word": "know",
+          "punct": "know",
+          "index": 10
+        },
+        {
+          "start": 98.15,
+          "confidence": 0.994,
+          "end": 98.88,
+          "word": "exactly",
+          "punct": "exactly",
+          "index": 11
+        },
+        {
+          "start": 98.88,
+          "confidence": 1,
+          "end": 99.14,
+          "word": "how",
+          "punct": "how",
+          "index": 12
+        },
+        {
+          "start": 99.14,
+          "confidence": 1,
+          "end": 99.38,
+          "word": "this",
+          "punct": "this",
+          "index": 13
+        },
+        {
+          "start": 99.38,
+          "confidence": 0.993,
+          "end": 99.92,
+          "word": "machine",
+          "punct": "machine",
+          "index": 14
+        },
+        {
+          "start": 99.92,
+          "confidence": 0.843,
+          "end": 100.56,
+          "word": "work",
+          "punct": "work.",
+          "index": 15
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 95.01,
+        "end": 95.26,
+        "confidence": 1,
+        "text": "But",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 95.26,
+        "end": 95.43,
+        "confidence": 1,
+        "text": "my",
+        "offset": 4,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 95.43,
+        "end": 95.88,
+        "confidence": 0.991,
+        "text": "response",
+        "offset": 7,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 95.88,
+        "end": 96.09,
+        "confidence": 0.962,
+        "text": "this",
+        "offset": 16,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 96.09,
+        "end": 96.42,
+        "confidence": 0.819,
+        "text": "robot",
+        "offset": 21,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 96.42,
+        "end": 96.56,
+        "confidence": 1,
+        "text": "was",
+        "offset": 27,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 96.56,
+        "end": 96.84,
+        "confidence": 1,
+        "text": "also",
+        "offset": 31,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 96.84,
+        "end": 97.25,
+        "confidence": 1,
+        "text": "interesting",
+        "offset": 36,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 97.25,
+        "end": 97.7,
+        "confidence": 1,
+        "text": "because",
+        "offset": 48,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 97.9,
+        "end": 98.01,
+        "confidence": 1,
+        "text": "I",
+        "offset": 56,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 98.01,
+        "end": 98.15,
+        "confidence": 0.298,
+        "text": "know",
+        "offset": 58,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 98.15,
+        "end": 98.88,
+        "confidence": 0.994,
+        "text": "exactly",
+        "offset": 63,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 98.88,
+        "end": 99.14,
+        "confidence": 1,
+        "text": "how",
+        "offset": 71,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 99.14,
+        "end": 99.38,
+        "confidence": 1,
+        "text": "this",
+        "offset": 75,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 99.38,
+        "end": 99.92,
+        "confidence": 0.993,
+        "text": "machine",
+        "offset": 80,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 99.92,
+        "end": 100.56,
+        "confidence": 0.843,
+        "text": "work.",
+        "offset": 88,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And yet I still felt compelled to be kind to it.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 101.5,
+      "words": [
+        {
+          "start": 101.5,
+          "confidence": 1,
+          "end": 101.67,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 101.67,
+          "confidence": 0.933,
+          "end": 101.85,
+          "word": "yet",
+          "punct": "yet",
+          "index": 1
+        },
+        {
+          "start": 101.85,
+          "confidence": 1,
+          "end": 101.93,
+          "word": "I",
+          "punct": "I",
+          "index": 2
+        },
+        {
+          "start": 101.93,
+          "confidence": 1,
+          "end": 102.35,
+          "word": "still",
+          "punct": "still",
+          "index": 3
+        },
+        {
+          "start": 102.35,
+          "confidence": 0.765,
+          "end": 102.64,
+          "word": "felt",
+          "punct": "felt",
+          "index": 4
+        },
+        {
+          "start": 102.64,
+          "confidence": 1,
+          "end": 103.37,
+          "word": "compelled",
+          "punct": "compelled",
+          "index": 5
+        },
+        {
+          "start": 103.37,
+          "confidence": 1,
+          "end": 103.5,
+          "word": "to",
+          "punct": "to",
+          "index": 6
+        },
+        {
+          "start": 103.5,
+          "confidence": 1,
+          "end": 103.65,
+          "word": "be",
+          "punct": "be",
+          "index": 7
+        },
+        {
+          "start": 103.65,
+          "confidence": 0.981,
+          "end": 104.38,
+          "word": "kind",
+          "punct": "kind",
+          "index": 8
+        },
+        {
+          "start": 104.43,
+          "confidence": 0.838,
+          "end": 104.57,
+          "word": "to",
+          "punct": "to",
+          "index": 9
+        },
+        {
+          "start": 104.57,
+          "confidence": 0.985,
+          "end": 104.79,
+          "word": "it",
+          "punct": "it.",
+          "index": 10
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 101.5,
+        "end": 101.67,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 101.67,
+        "end": 101.85,
+        "confidence": 0.933,
+        "text": "yet",
+        "offset": 4,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 101.85,
+        "end": 101.93,
+        "confidence": 1,
+        "text": "I",
+        "offset": 8,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 101.93,
+        "end": 102.35,
+        "confidence": 1,
+        "text": "still",
+        "offset": 10,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 102.35,
+        "end": 102.64,
+        "confidence": 0.765,
+        "text": "felt",
+        "offset": 16,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 102.64,
+        "end": 103.37,
+        "confidence": 1,
+        "text": "compelled",
+        "offset": 21,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 103.37,
+        "end": 103.5,
+        "confidence": 1,
+        "text": "to",
+        "offset": 31,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 103.5,
+        "end": 103.65,
+        "confidence": 1,
+        "text": "be",
+        "offset": 34,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 103.65,
+        "end": 104.38,
+        "confidence": 0.981,
+        "text": "kind",
+        "offset": 37,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 104.43,
+        "end": 104.57,
+        "confidence": 0.838,
+        "text": "to",
+        "offset": 42,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 104.57,
+        "end": 104.79,
+        "confidence": 0.985,
+        "text": "it.",
+        "offset": 45,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And that observation sparked the curiosity that I spent the fact the past decade pursuing.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 106.4,
+      "words": [
+        {
+          "start": 106.4,
+          "confidence": 0.879,
+          "end": 106.62,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 106.62,
+          "confidence": 0.316,
+          "end": 106.86,
+          "word": "that",
+          "punct": "that",
+          "index": 1
+        },
+        {
+          "start": 106.91,
+          "confidence": 0.581,
+          "end": 107.68,
+          "word": "observation",
+          "punct": "observation",
+          "index": 2
+        },
+        {
+          "start": 107.68,
+          "confidence": 0.537,
+          "end": 108.09,
+          "word": "sparked",
+          "punct": "sparked",
+          "index": 3
+        },
+        {
+          "start": 108.09,
+          "confidence": 0.62,
+          "end": 108.18,
+          "word": "the",
+          "punct": "the",
+          "index": 4
+        },
+        {
+          "start": 108.18,
+          "confidence": 1,
+          "end": 109.1,
+          "word": "curiosity",
+          "punct": "curiosity",
+          "index": 5
+        },
+        {
+          "start": 109.1,
+          "confidence": 1,
+          "end": 109.31,
+          "word": "that",
+          "punct": "that",
+          "index": 6
+        },
+        {
+          "start": 109.31,
+          "confidence": 0.614,
+          "end": 109.37,
+          "word": "I",
+          "punct": "I",
+          "index": 7
+        },
+        {
+          "start": 109.37,
+          "confidence": 0.732,
+          "end": 109.72,
+          "word": "spent",
+          "punct": "spent",
+          "index": 8
+        },
+        {
+          "start": 109.72,
+          "confidence": 0.905,
+          "end": 109.81,
+          "word": "the",
+          "punct": "the",
+          "index": 9
+        },
+        {
+          "start": 109.81,
+          "confidence": 0.277,
+          "end": 110.16,
+          "word": "fact",
+          "punct": "fact",
+          "index": 10
+        },
+        {
+          "start": 110.19,
+          "confidence": 0.955,
+          "end": 110.35,
+          "word": "the",
+          "punct": "the",
+          "index": 11
+        },
+        {
+          "start": 110.35,
+          "confidence": 0.984,
+          "end": 110.7,
+          "word": "past",
+          "punct": "past",
+          "index": 12
+        },
+        {
+          "start": 110.75,
+          "confidence": 0.803,
+          "end": 111.26,
+          "word": "decade",
+          "punct": "decade",
+          "index": 13
+        },
+        {
+          "start": 111.26,
+          "confidence": 0.974,
+          "end": 111.99,
+          "word": "pursuing",
+          "punct": "pursuing.",
+          "index": 14
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 106.4,
+        "end": 106.62,
+        "confidence": 0.879,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 106.62,
+        "end": 106.86,
+        "confidence": 0.316,
+        "text": "that",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 106.91,
+        "end": 107.68,
+        "confidence": 0.581,
+        "text": "observation",
+        "offset": 9,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 107.68,
+        "end": 108.09,
+        "confidence": 0.537,
+        "text": "sparked",
+        "offset": 21,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 108.09,
+        "end": 108.18,
+        "confidence": 0.62,
+        "text": "the",
+        "offset": 29,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 108.18,
+        "end": 109.1,
+        "confidence": 1,
+        "text": "curiosity",
+        "offset": 33,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 109.1,
+        "end": 109.31,
+        "confidence": 1,
+        "text": "that",
+        "offset": 43,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 109.31,
+        "end": 109.37,
+        "confidence": 0.614,
+        "text": "I",
+        "offset": 48,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 109.37,
+        "end": 109.72,
+        "confidence": 0.732,
+        "text": "spent",
+        "offset": 50,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 109.72,
+        "end": 109.81,
+        "confidence": 0.905,
+        "text": "the",
+        "offset": 56,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 109.81,
+        "end": 110.16,
+        "confidence": 0.277,
+        "text": "fact",
+        "offset": 60,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 110.19,
+        "end": 110.35,
+        "confidence": 0.955,
+        "text": "the",
+        "offset": 65,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 110.35,
+        "end": 110.7,
+        "confidence": 0.984,
+        "text": "past",
+        "offset": 69,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 110.75,
+        "end": 111.26,
+        "confidence": 0.803,
+        "text": "decade",
+        "offset": 74,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 111.26,
+        "end": 111.99,
+        "confidence": 0.974,
+        "text": "pursuing.",
+        "offset": 81,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Why did I come for this robot?",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 112.91,
+      "words": [
+        {
+          "start": 112.91,
+          "confidence": 0.95,
+          "end": 113.14,
+          "word": "why",
+          "punct": "Why",
+          "index": 0
+        },
+        {
+          "start": 113.14,
+          "confidence": 0.643,
+          "end": 113.37,
+          "word": "did",
+          "punct": "did",
+          "index": 1
+        },
+        {
+          "start": 113.37,
+          "confidence": 0.442,
+          "end": 113.42,
+          "word": "I",
+          "punct": "I",
+          "index": 2
+        },
+        {
+          "start": 113.42,
+          "confidence": 0.381,
+          "end": 113.71,
+          "word": "come",
+          "punct": "come",
+          "index": 3
+        },
+        {
+          "start": 113.71,
+          "confidence": 0.379,
+          "end": 113.87,
+          "word": "for",
+          "punct": "for",
+          "index": 4
+        },
+        {
+          "start": 113.87,
+          "confidence": 0.882,
+          "end": 114.11,
+          "word": "this",
+          "punct": "this",
+          "index": 5
+        },
+        {
+          "start": 114.11,
+          "confidence": 0.521,
+          "end": 114.61,
+          "word": "robot",
+          "punct": "robot?",
+          "index": 6
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 112.91,
+        "end": 113.14,
+        "confidence": 0.95,
+        "text": "Why",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 113.14,
+        "end": 113.37,
+        "confidence": 0.643,
+        "text": "did",
+        "offset": 4,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 113.37,
+        "end": 113.42,
+        "confidence": 0.442,
+        "text": "I",
+        "offset": 8,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 113.42,
+        "end": 113.71,
+        "confidence": 0.381,
+        "text": "come",
+        "offset": 10,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 113.71,
+        "end": 113.87,
+        "confidence": 0.379,
+        "text": "for",
+        "offset": 15,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 113.87,
+        "end": 114.11,
+        "confidence": 0.882,
+        "text": "this",
+        "offset": 19,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 114.11,
+        "end": 114.61,
+        "confidence": 0.521,
+        "text": "robot?",
+        "offset": 24,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And one of the things I discovered was that my treatment of this machine was more than just an awkward moment in my living room that in a world where were increasingly integrating robots into our lives an instance like that might actually have consequences.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 116.21,
+      "words": [
+        {
+          "start": 116.21,
+          "confidence": 0.463,
+          "end": 116.35,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 116.35,
+          "confidence": 1,
+          "end": 116.46,
+          "word": "one",
+          "punct": "one",
+          "index": 1
+        },
+        {
+          "start": 116.46,
+          "confidence": 1,
+          "end": 116.55,
+          "word": "of",
+          "punct": "of",
+          "index": 2
+        },
+        {
+          "start": 116.55,
+          "confidence": 1,
+          "end": 116.63,
+          "word": "the",
+          "punct": "the",
+          "index": 3
+        },
+        {
+          "start": 116.63,
+          "confidence": 0.985,
+          "end": 116.86,
+          "word": "things",
+          "punct": "things",
+          "index": 4
+        },
+        {
+          "start": 116.86,
+          "confidence": 0.811,
+          "end": 116.91,
+          "word": "I",
+          "punct": "I",
+          "index": 5
+        },
+        {
+          "start": 116.91,
+          "confidence": 0.999,
+          "end": 117.56,
+          "word": "discovered",
+          "punct": "discovered",
+          "index": 6
+        },
+        {
+          "start": 117.56,
+          "confidence": 0.937,
+          "end": 117.74,
+          "word": "was",
+          "punct": "was",
+          "index": 7
+        },
+        {
+          "start": 117.74,
+          "confidence": 0.999,
+          "end": 118.19,
+          "word": "that",
+          "punct": "that",
+          "index": 8
+        },
+        {
+          "start": 118.44,
+          "confidence": 1,
+          "end": 118.6,
+          "word": "my",
+          "punct": "my",
+          "index": 9
+        },
+        {
+          "start": 118.6,
+          "confidence": 1,
+          "end": 119.18,
+          "word": "treatment",
+          "punct": "treatment",
+          "index": 10
+        },
+        {
+          "start": 119.18,
+          "confidence": 1,
+          "end": 119.26,
+          "word": "of",
+          "punct": "of",
+          "index": 11
+        },
+        {
+          "start": 119.26,
+          "confidence": 1,
+          "end": 119.42,
+          "word": "this",
+          "punct": "this",
+          "index": 12
+        },
+        {
+          "start": 119.42,
+          "confidence": 0.88,
+          "end": 119.77,
+          "word": "machine",
+          "punct": "machine",
+          "index": 13
+        },
+        {
+          "start": 119.77,
+          "confidence": 0.576,
+          "end": 119.92,
+          "word": "was",
+          "punct": "was",
+          "index": 14
+        },
+        {
+          "start": 119.92,
+          "confidence": 1,
+          "end": 120.21,
+          "word": "more",
+          "punct": "more",
+          "index": 15
+        },
+        {
+          "start": 120.21,
+          "confidence": 1,
+          "end": 120.35,
+          "word": "than",
+          "punct": "than",
+          "index": 16
+        },
+        {
+          "start": 120.35,
+          "confidence": 1,
+          "end": 120.76,
+          "word": "just",
+          "punct": "just",
+          "index": 17
+        },
+        {
+          "start": 121,
+          "confidence": 1,
+          "end": 121.13,
+          "word": "an",
+          "punct": "an",
+          "index": 18
+        },
+        {
+          "start": 121.13,
+          "confidence": 1,
+          "end": 121.6,
+          "word": "awkward",
+          "punct": "awkward",
+          "index": 19
+        },
+        {
+          "start": 121.6,
+          "confidence": 0.999,
+          "end": 122.07,
+          "word": "moment",
+          "punct": "moment",
+          "index": 20
+        },
+        {
+          "start": 122.07,
+          "confidence": 0.668,
+          "end": 122.15,
+          "word": "in",
+          "punct": "in",
+          "index": 21
+        },
+        {
+          "start": 122.15,
+          "confidence": 0.99,
+          "end": 122.29,
+          "word": "my",
+          "punct": "my",
+          "index": 22
+        },
+        {
+          "start": 122.29,
+          "confidence": 1,
+          "end": 122.58,
+          "word": "living",
+          "punct": "living",
+          "index": 23
+        },
+        {
+          "start": 122.58,
+          "confidence": 1,
+          "end": 122.97,
+          "word": "room",
+          "punct": "room",
+          "index": 24
+        },
+        {
+          "start": 123.53,
+          "confidence": 1,
+          "end": 123.72,
+          "word": "that",
+          "punct": "that",
+          "index": 25
+        },
+        {
+          "start": 123.72,
+          "confidence": 1,
+          "end": 123.83,
+          "word": "in",
+          "punct": "in",
+          "index": 26
+        },
+        {
+          "start": 123.83,
+          "confidence": 1,
+          "end": 123.92,
+          "word": "a",
+          "punct": "a",
+          "index": 27
+        },
+        {
+          "start": 123.92,
+          "confidence": 1,
+          "end": 124.4,
+          "word": "world",
+          "punct": "world",
+          "index": 28
+        },
+        {
+          "start": 124.4,
+          "confidence": 0.782,
+          "end": 124.54,
+          "word": "where",
+          "punct": "where",
+          "index": 29
+        },
+        {
+          "start": 124.54,
+          "confidence": 0.464,
+          "end": 124.63,
+          "word": "were",
+          "punct": "were",
+          "index": 30
+        },
+        {
+          "start": 124.63,
+          "confidence": 1,
+          "end": 125.42,
+          "word": "increasingly",
+          "punct": "increasingly",
+          "index": 31
+        },
+        {
+          "start": 125.45,
+          "confidence": 0.61,
+          "end": 126.15,
+          "word": "integrating",
+          "punct": "integrating",
+          "index": 32
+        },
+        {
+          "start": 126.15,
+          "confidence": 1,
+          "end": 126.98,
+          "word": "robots",
+          "punct": "robots",
+          "index": 33
+        },
+        {
+          "start": 127.21,
+          "confidence": 1,
+          "end": 127.5,
+          "word": "into",
+          "punct": "into",
+          "index": 34
+        },
+        {
+          "start": 127.5,
+          "confidence": 1,
+          "end": 127.64,
+          "word": "our",
+          "punct": "our",
+          "index": 35
+        },
+        {
+          "start": 127.64,
+          "confidence": 0.998,
+          "end": 128.46,
+          "word": "lives",
+          "punct": "lives",
+          "index": 36
+        },
+        {
+          "start": 128.97,
+          "confidence": 0.667,
+          "end": 129.09,
+          "word": "an",
+          "punct": "an",
+          "index": 37
+        },
+        {
+          "start": 129.09,
+          "confidence": 0.276,
+          "end": 129.56,
+          "word": "instance",
+          "punct": "instance",
+          "index": 38
+        },
+        {
+          "start": 129.56,
+          "confidence": 0.88,
+          "end": 129.72,
+          "word": "like",
+          "punct": "like",
+          "index": 39
+        },
+        {
+          "start": 129.72,
+          "confidence": 0.973,
+          "end": 130,
+          "word": "that",
+          "punct": "that",
+          "index": 40
+        },
+        {
+          "start": 130,
+          "confidence": 1,
+          "end": 130.26,
+          "word": "might",
+          "punct": "might",
+          "index": 41
+        },
+        {
+          "start": 130.38,
+          "confidence": 1,
+          "end": 130.74,
+          "word": "actually",
+          "punct": "actually",
+          "index": 42
+        },
+        {
+          "start": 130.74,
+          "confidence": 1,
+          "end": 130.87,
+          "word": "have",
+          "punct": "have",
+          "index": 43
+        },
+        {
+          "start": 130.87,
+          "confidence": 0.997,
+          "end": 132.06,
+          "word": "consequences",
+          "punct": "consequences.",
+          "index": 44
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 116.21,
+        "end": 116.35,
+        "confidence": 0.463,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 116.35,
+        "end": 116.46,
+        "confidence": 1,
+        "text": "one",
+        "offset": 4,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 116.46,
+        "end": 116.55,
+        "confidence": 1,
+        "text": "of",
+        "offset": 8,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 116.55,
+        "end": 116.63,
+        "confidence": 1,
+        "text": "the",
+        "offset": 11,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 116.63,
+        "end": 116.86,
+        "confidence": 0.985,
+        "text": "things",
+        "offset": 15,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 116.86,
+        "end": 116.91,
+        "confidence": 0.811,
+        "text": "I",
+        "offset": 22,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 116.91,
+        "end": 117.56,
+        "confidence": 0.999,
+        "text": "discovered",
+        "offset": 24,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 117.56,
+        "end": 117.74,
+        "confidence": 0.937,
+        "text": "was",
+        "offset": 35,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 117.74,
+        "end": 118.19,
+        "confidence": 0.999,
+        "text": "that",
+        "offset": 39,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 118.44,
+        "end": 118.6,
+        "confidence": 1,
+        "text": "my",
+        "offset": 44,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 118.6,
+        "end": 119.18,
+        "confidence": 1,
+        "text": "treatment",
+        "offset": 47,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 119.18,
+        "end": 119.26,
+        "confidence": 1,
+        "text": "of",
+        "offset": 57,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 119.26,
+        "end": 119.42,
+        "confidence": 1,
+        "text": "this",
+        "offset": 60,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 119.42,
+        "end": 119.77,
+        "confidence": 0.88,
+        "text": "machine",
+        "offset": 65,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 119.77,
+        "end": 119.92,
+        "confidence": 0.576,
+        "text": "was",
+        "offset": 73,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 119.92,
+        "end": 120.21,
+        "confidence": 1,
+        "text": "more",
+        "offset": 77,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 120.21,
+        "end": 120.35,
+        "confidence": 1,
+        "text": "than",
+        "offset": 82,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 120.35,
+        "end": 120.76,
+        "confidence": 1,
+        "text": "just",
+        "offset": 87,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 121,
+        "end": 121.13,
+        "confidence": 1,
+        "text": "an",
+        "offset": 92,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 121.13,
+        "end": 121.6,
+        "confidence": 1,
+        "text": "awkward",
+        "offset": 95,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 121.6,
+        "end": 122.07,
+        "confidence": 0.999,
+        "text": "moment",
+        "offset": 103,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 122.07,
+        "end": 122.15,
+        "confidence": 0.668,
+        "text": "in",
+        "offset": 110,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 122.15,
+        "end": 122.29,
+        "confidence": 0.99,
+        "text": "my",
+        "offset": 113,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 122.29,
+        "end": 122.58,
+        "confidence": 1,
+        "text": "living",
+        "offset": 116,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 122.58,
+        "end": 122.97,
+        "confidence": 1,
+        "text": "room",
+        "offset": 123,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 123.53,
+        "end": 123.72,
+        "confidence": 1,
+        "text": "that",
+        "offset": 128,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 123.72,
+        "end": 123.83,
+        "confidence": 1,
+        "text": "in",
+        "offset": 133,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 123.83,
+        "end": 123.92,
+        "confidence": 1,
+        "text": "a",
+        "offset": 136,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 123.92,
+        "end": 124.4,
+        "confidence": 1,
+        "text": "world",
+        "offset": 138,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 124.4,
+        "end": 124.54,
+        "confidence": 0.782,
+        "text": "where",
+        "offset": 144,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 124.54,
+        "end": 124.63,
+        "confidence": 0.464,
+        "text": "were",
+        "offset": 150,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 124.63,
+        "end": 125.42,
+        "confidence": 1,
+        "text": "increasingly",
+        "offset": 155,
+        "length": 12,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 125.45,
+        "end": 126.15,
+        "confidence": 0.61,
+        "text": "integrating",
+        "offset": 168,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 126.15,
+        "end": 126.98,
+        "confidence": 1,
+        "text": "robots",
+        "offset": 180,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 127.21,
+        "end": 127.5,
+        "confidence": 1,
+        "text": "into",
+        "offset": 187,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 127.5,
+        "end": 127.64,
+        "confidence": 1,
+        "text": "our",
+        "offset": 192,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 127.64,
+        "end": 128.46,
+        "confidence": 0.998,
+        "text": "lives",
+        "offset": 196,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 128.97,
+        "end": 129.09,
+        "confidence": 0.667,
+        "text": "an",
+        "offset": 202,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 129.09,
+        "end": 129.56,
+        "confidence": 0.276,
+        "text": "instance",
+        "offset": 205,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 129.56,
+        "end": 129.72,
+        "confidence": 0.88,
+        "text": "like",
+        "offset": 214,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 129.72,
+        "end": 130,
+        "confidence": 0.973,
+        "text": "that",
+        "offset": 219,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 130,
+        "end": 130.26,
+        "confidence": 1,
+        "text": "might",
+        "offset": 224,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 130.38,
+        "end": 130.74,
+        "confidence": 1,
+        "text": "actually",
+        "offset": 230,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 130.74,
+        "end": 130.87,
+        "confidence": 1,
+        "text": "have",
+        "offset": 239,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 130.87,
+        "end": 132.06,
+        "confidence": 0.997,
+        "text": "consequences.",
+        "offset": 244,
+        "length": 13,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Because the first thing that I discovered is that it's not just me.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 133.44,
+      "words": [
+        {
+          "start": 133.44,
+          "confidence": 1,
+          "end": 133.66,
+          "word": "because",
+          "punct": "Because",
+          "index": 0
+        },
+        {
+          "start": 133.66,
+          "confidence": 1,
+          "end": 133.75,
+          "word": "the",
+          "punct": "the",
+          "index": 1
+        },
+        {
+          "start": 133.75,
+          "confidence": 1,
+          "end": 134.01,
+          "word": "first",
+          "punct": "first",
+          "index": 2
+        },
+        {
+          "start": 134.01,
+          "confidence": 1,
+          "end": 134.12,
+          "word": "thing",
+          "punct": "thing",
+          "index": 3
+        },
+        {
+          "start": 134.12,
+          "confidence": 1,
+          "end": 134.25,
+          "word": "that",
+          "punct": "that",
+          "index": 4
+        },
+        {
+          "start": 134.25,
+          "confidence": 0.876,
+          "end": 134.31,
+          "word": "I",
+          "punct": "I",
+          "index": 5
+        },
+        {
+          "start": 134.31,
+          "confidence": 0.995,
+          "end": 135.1,
+          "word": "discovered",
+          "punct": "discovered",
+          "index": 6
+        },
+        {
+          "start": 135.16,
+          "confidence": 1,
+          "end": 135.34,
+          "word": "is",
+          "punct": "is",
+          "index": 7
+        },
+        {
+          "start": 135.34,
+          "confidence": 1,
+          "end": 135.52,
+          "word": "that",
+          "punct": "that",
+          "index": 8
+        },
+        {
+          "start": 135.55,
+          "confidence": 1,
+          "end": 135.76,
+          "word": "it's",
+          "punct": "it's",
+          "index": 9
+        },
+        {
+          "start": 135.76,
+          "confidence": 1,
+          "end": 136.05,
+          "word": "not",
+          "punct": "not",
+          "index": 10
+        },
+        {
+          "start": 136.05,
+          "confidence": 1,
+          "end": 136.38,
+          "word": "just",
+          "punct": "just",
+          "index": 11
+        },
+        {
+          "start": 136.38,
+          "confidence": 0.994,
+          "end": 136.87,
+          "word": "me",
+          "punct": "me.",
+          "index": 12
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 133.44,
+        "end": 133.66,
+        "confidence": 1,
+        "text": "Because",
+        "offset": 0,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 133.66,
+        "end": 133.75,
+        "confidence": 1,
+        "text": "the",
+        "offset": 8,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 133.75,
+        "end": 134.01,
+        "confidence": 1,
+        "text": "first",
+        "offset": 12,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 134.01,
+        "end": 134.12,
+        "confidence": 1,
+        "text": "thing",
+        "offset": 18,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 134.12,
+        "end": 134.25,
+        "confidence": 1,
+        "text": "that",
+        "offset": 24,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 134.25,
+        "end": 134.31,
+        "confidence": 0.876,
+        "text": "I",
+        "offset": 29,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 134.31,
+        "end": 135.1,
+        "confidence": 0.995,
+        "text": "discovered",
+        "offset": 31,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 135.16,
+        "end": 135.34,
+        "confidence": 1,
+        "text": "is",
+        "offset": 42,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 135.34,
+        "end": 135.52,
+        "confidence": 1,
+        "text": "that",
+        "offset": 45,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 135.55,
+        "end": 135.76,
+        "confidence": 1,
+        "text": "it's",
+        "offset": 50,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 135.76,
+        "end": 136.05,
+        "confidence": 1,
+        "text": "not",
+        "offset": 55,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 136.05,
+        "end": 136.38,
+        "confidence": 1,
+        "text": "just",
+        "offset": 59,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 136.38,
+        "end": 136.87,
+        "confidence": 0.994,
+        "text": "me.",
+        "offset": 64,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "In two thousand and seven The Washington Post reported that the United States military was testing this robot that defused land mines and we worked with it was shaped like a stick insect you would walk around the mine field on its legs and every time I stepped on a mine one of the legs would blow up would continue on the other likes to blow up our minds.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 139.24,
+      "words": [
+        {
+          "start": 139.24,
+          "confidence": 1,
+          "end": 139.39,
+          "word": "in",
+          "punct": "In",
+          "index": 0
+        },
+        {
+          "start": 139.39,
+          "confidence": 1,
+          "end": 139.55,
+          "word": "two",
+          "punct": "two",
+          "index": 1
+        },
+        {
+          "start": 139.55,
+          "confidence": 1,
+          "end": 139.9,
+          "word": "thousand",
+          "punct": "thousand",
+          "index": 2
+        },
+        {
+          "start": 139.9,
+          "confidence": 0.805,
+          "end": 140.04,
+          "word": "and",
+          "punct": "and",
+          "index": 3
+        },
+        {
+          "start": 140.04,
+          "confidence": 0.995,
+          "end": 140.64,
+          "word": "seven",
+          "punct": "seven",
+          "index": 4
+        },
+        {
+          "start": 140.73,
+          "confidence": 1,
+          "end": 140.86,
+          "word": "The",
+          "punct": "The",
+          "index": 5
+        },
+        {
+          "start": 140.86,
+          "confidence": 1,
+          "end": 141.37,
+          "word": "Washington",
+          "punct": "Washington",
+          "index": 6
+        },
+        {
+          "start": 141.37,
+          "confidence": 1,
+          "end": 141.74,
+          "word": "Post",
+          "punct": "Post",
+          "index": 7
+        },
+        {
+          "start": 141.74,
+          "confidence": 1,
+          "end": 142.25,
+          "word": "reported",
+          "punct": "reported",
+          "index": 8
+        },
+        {
+          "start": 142.25,
+          "confidence": 1,
+          "end": 142.41,
+          "word": "that",
+          "punct": "that",
+          "index": 9
+        },
+        {
+          "start": 142.41,
+          "confidence": 1,
+          "end": 142.5,
+          "word": "the",
+          "punct": "the",
+          "index": 10
+        },
+        {
+          "start": 142.5,
+          "confidence": 1,
+          "end": 142.89,
+          "word": "United",
+          "punct": "United",
+          "index": 11
+        },
+        {
+          "start": 142.89,
+          "confidence": 1,
+          "end": 143.19,
+          "word": "States",
+          "punct": "States",
+          "index": 12
+        },
+        {
+          "start": 143.19,
+          "confidence": 0.997,
+          "end": 144.04,
+          "word": "military",
+          "punct": "military",
+          "index": 13
+        },
+        {
+          "start": 144.07,
+          "confidence": 0.339,
+          "end": 144.24,
+          "word": "was",
+          "punct": "was",
+          "index": 14
+        },
+        {
+          "start": 144.24,
+          "confidence": 0.989,
+          "end": 144.79,
+          "word": "testing",
+          "punct": "testing",
+          "index": 15
+        },
+        {
+          "start": 144.79,
+          "confidence": 1,
+          "end": 145.12,
+          "word": "this",
+          "punct": "this",
+          "index": 16
+        },
+        {
+          "start": 145.29,
+          "confidence": 1,
+          "end": 145.86,
+          "word": "robot",
+          "punct": "robot",
+          "index": 17
+        },
+        {
+          "start": 145.86,
+          "confidence": 0.764,
+          "end": 146,
+          "word": "that",
+          "punct": "that",
+          "index": 18
+        },
+        {
+          "start": 146,
+          "confidence": 0.325,
+          "end": 146.55,
+          "word": "defused",
+          "punct": "defused",
+          "index": 19
+        },
+        {
+          "start": 146.55,
+          "confidence": 0.86,
+          "end": 146.93,
+          "word": "land",
+          "punct": "land",
+          "index": 20
+        },
+        {
+          "start": 146.93,
+          "confidence": 0.86,
+          "end": 147.28,
+          "word": "mines",
+          "punct": "mines",
+          "index": 21
+        },
+        {
+          "start": 147.28,
+          "confidence": 0.857,
+          "end": 147.51,
+          "word": "and",
+          "punct": "and",
+          "index": 22
+        },
+        {
+          "start": 147.51,
+          "confidence": 0.681,
+          "end": 147.64,
+          "word": "we",
+          "punct": "we",
+          "index": 23
+        },
+        {
+          "start": 147.64,
+          "confidence": 0.568,
+          "end": 147.89,
+          "word": "worked",
+          "punct": "worked",
+          "index": 24
+        },
+        {
+          "start": 147.89,
+          "confidence": 0.692,
+          "end": 148.11,
+          "word": "with",
+          "punct": "with",
+          "index": 25
+        },
+        {
+          "start": 148.37,
+          "confidence": 0.087,
+          "end": 148.46,
+          "word": "it",
+          "punct": "it",
+          "index": 26
+        },
+        {
+          "start": 148.46,
+          "confidence": 0.266,
+          "end": 148.57,
+          "word": "was",
+          "punct": "was",
+          "index": 27
+        },
+        {
+          "start": 148.57,
+          "confidence": 0.691,
+          "end": 148.95,
+          "word": "shaped",
+          "punct": "shaped",
+          "index": 28
+        },
+        {
+          "start": 148.95,
+          "confidence": 1,
+          "end": 149.08,
+          "word": "like",
+          "punct": "like",
+          "index": 29
+        },
+        {
+          "start": 149.08,
+          "confidence": 1,
+          "end": 149.15,
+          "word": "a",
+          "punct": "a",
+          "index": 30
+        },
+        {
+          "start": 149.15,
+          "confidence": 0.956,
+          "end": 149.54,
+          "word": "stick",
+          "punct": "stick",
+          "index": 31
+        },
+        {
+          "start": 149.54,
+          "confidence": 0.812,
+          "end": 150.05,
+          "word": "insect",
+          "punct": "insect",
+          "index": 32
+        },
+        {
+          "start": 150.43,
+          "confidence": 0.85,
+          "end": 150.55,
+          "word": "you",
+          "punct": "you",
+          "index": 33
+        },
+        {
+          "start": 150.55,
+          "confidence": 0.988,
+          "end": 150.68,
+          "word": "would",
+          "punct": "would",
+          "index": 34
+        },
+        {
+          "start": 150.68,
+          "confidence": 1,
+          "end": 150.93,
+          "word": "walk",
+          "punct": "walk",
+          "index": 35
+        },
+        {
+          "start": 150.93,
+          "confidence": 0.998,
+          "end": 151.13,
+          "word": "around",
+          "punct": "around",
+          "index": 36
+        },
+        {
+          "start": 151.13,
+          "confidence": 0.428,
+          "end": 151.19,
+          "word": "the",
+          "punct": "the",
+          "index": 37
+        },
+        {
+          "start": 151.19,
+          "confidence": 0.659,
+          "end": 151.48,
+          "word": "mine",
+          "punct": "mine",
+          "index": 38
+        },
+        {
+          "start": 151.48,
+          "confidence": 0.664,
+          "end": 151.8,
+          "word": "field",
+          "punct": "field",
+          "index": 39
+        },
+        {
+          "start": 151.8,
+          "confidence": 0.723,
+          "end": 151.89,
+          "word": "on",
+          "punct": "on",
+          "index": 40
+        },
+        {
+          "start": 151.89,
+          "confidence": 0.996,
+          "end": 152.03,
+          "word": "its",
+          "punct": "its",
+          "index": 41
+        },
+        {
+          "start": 152.03,
+          "confidence": 1,
+          "end": 152.57,
+          "word": "legs",
+          "punct": "legs",
+          "index": 42
+        },
+        {
+          "start": 152.89,
+          "confidence": 0.74,
+          "end": 153.07,
+          "word": "and",
+          "punct": "and",
+          "index": 43
+        },
+        {
+          "start": 153.07,
+          "confidence": 0.763,
+          "end": 153.29,
+          "word": "every",
+          "punct": "every",
+          "index": 44
+        },
+        {
+          "start": 153.29,
+          "confidence": 0.748,
+          "end": 153.46,
+          "word": "time",
+          "punct": "time",
+          "index": 45
+        },
+        {
+          "start": 153.46,
+          "confidence": 0.252,
+          "end": 153.51,
+          "word": "I",
+          "punct": "I",
+          "index": 46
+        },
+        {
+          "start": 153.51,
+          "confidence": 0.789,
+          "end": 153.88,
+          "word": "stepped",
+          "punct": "stepped",
+          "index": 47
+        },
+        {
+          "start": 153.88,
+          "confidence": 0.981,
+          "end": 153.97,
+          "word": "on",
+          "punct": "on",
+          "index": 48
+        },
+        {
+          "start": 153.97,
+          "confidence": 0.913,
+          "end": 154.02,
+          "word": "a",
+          "punct": "a",
+          "index": 49
+        },
+        {
+          "start": 154.02,
+          "confidence": 0.989,
+          "end": 154.4,
+          "word": "mine",
+          "punct": "mine",
+          "index": 50
+        },
+        {
+          "start": 154.43,
+          "confidence": 0.965,
+          "end": 154.64,
+          "word": "one",
+          "punct": "one",
+          "index": 51
+        },
+        {
+          "start": 154.64,
+          "confidence": 1,
+          "end": 154.71,
+          "word": "of",
+          "punct": "of",
+          "index": 52
+        },
+        {
+          "start": 154.71,
+          "confidence": 1,
+          "end": 154.81,
+          "word": "the",
+          "punct": "the",
+          "index": 53
+        },
+        {
+          "start": 154.81,
+          "confidence": 1,
+          "end": 155.08,
+          "word": "legs",
+          "punct": "legs",
+          "index": 54
+        },
+        {
+          "start": 155.08,
+          "confidence": 0.608,
+          "end": 155.2,
+          "word": "would",
+          "punct": "would",
+          "index": 55
+        },
+        {
+          "start": 155.2,
+          "confidence": 1,
+          "end": 155.43,
+          "word": "blow",
+          "punct": "blow",
+          "index": 56
+        },
+        {
+          "start": 155.43,
+          "confidence": 0.905,
+          "end": 155.75,
+          "word": "up",
+          "punct": "up",
+          "index": 57
+        },
+        {
+          "start": 155.86,
+          "confidence": 0.632,
+          "end": 156.02,
+          "word": "would",
+          "punct": "would",
+          "index": 58
+        },
+        {
+          "start": 156.02,
+          "confidence": 1,
+          "end": 156.51,
+          "word": "continue",
+          "punct": "continue",
+          "index": 59
+        },
+        {
+          "start": 156.51,
+          "confidence": 0.664,
+          "end": 156.62,
+          "word": "on",
+          "punct": "on",
+          "index": 60
+        },
+        {
+          "start": 156.62,
+          "confidence": 0.988,
+          "end": 156.69,
+          "word": "the",
+          "punct": "the",
+          "index": 61
+        },
+        {
+          "start": 156.69,
+          "confidence": 1,
+          "end": 156.89,
+          "word": "other",
+          "punct": "other",
+          "index": 62
+        },
+        {
+          "start": 156.89,
+          "confidence": 0.396,
+          "end": 157.26,
+          "word": "likes",
+          "punct": "likes",
+          "index": 63
+        },
+        {
+          "start": 157.26,
+          "confidence": 1,
+          "end": 157.38,
+          "word": "to",
+          "punct": "to",
+          "index": 64
+        },
+        {
+          "start": 157.38,
+          "confidence": 0.413,
+          "end": 157.56,
+          "word": "blow",
+          "punct": "blow",
+          "index": 65
+        },
+        {
+          "start": 157.56,
+          "confidence": 0.374,
+          "end": 157.71,
+          "word": "up",
+          "punct": "up",
+          "index": 66
+        },
+        {
+          "start": 157.71,
+          "confidence": 0.116,
+          "end": 157.81,
+          "word": "our",
+          "punct": "our",
+          "index": 67
+        },
+        {
+          "start": 157.81,
+          "confidence": 0.678,
+          "end": 158.36,
+          "word": "minds",
+          "punct": "minds.",
+          "index": 68
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 139.24,
+        "end": 139.39,
+        "confidence": 1,
+        "text": "In",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 139.39,
+        "end": 139.55,
+        "confidence": 1,
+        "text": "two",
+        "offset": 3,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 139.55,
+        "end": 139.9,
+        "confidence": 1,
+        "text": "thousand",
+        "offset": 7,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 139.9,
+        "end": 140.04,
+        "confidence": 0.805,
+        "text": "and",
+        "offset": 16,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 140.04,
+        "end": 140.64,
+        "confidence": 0.995,
+        "text": "seven",
+        "offset": 20,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 140.73,
+        "end": 140.86,
+        "confidence": 1,
+        "text": "The",
+        "offset": 26,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 140.86,
+        "end": 141.37,
+        "confidence": 1,
+        "text": "Washington",
+        "offset": 30,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 141.37,
+        "end": 141.74,
+        "confidence": 1,
+        "text": "Post",
+        "offset": 41,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 141.74,
+        "end": 142.25,
+        "confidence": 1,
+        "text": "reported",
+        "offset": 46,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 142.25,
+        "end": 142.41,
+        "confidence": 1,
+        "text": "that",
+        "offset": 55,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 142.41,
+        "end": 142.5,
+        "confidence": 1,
+        "text": "the",
+        "offset": 60,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 142.5,
+        "end": 142.89,
+        "confidence": 1,
+        "text": "United",
+        "offset": 64,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 142.89,
+        "end": 143.19,
+        "confidence": 1,
+        "text": "States",
+        "offset": 71,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 143.19,
+        "end": 144.04,
+        "confidence": 0.997,
+        "text": "military",
+        "offset": 78,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 144.07,
+        "end": 144.24,
+        "confidence": 0.339,
+        "text": "was",
+        "offset": 87,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 144.24,
+        "end": 144.79,
+        "confidence": 0.989,
+        "text": "testing",
+        "offset": 91,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 144.79,
+        "end": 145.12,
+        "confidence": 1,
+        "text": "this",
+        "offset": 99,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 145.29,
+        "end": 145.86,
+        "confidence": 1,
+        "text": "robot",
+        "offset": 104,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 145.86,
+        "end": 146,
+        "confidence": 0.764,
+        "text": "that",
+        "offset": 110,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 146,
+        "end": 146.55,
+        "confidence": 0.325,
+        "text": "defused",
+        "offset": 115,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 146.55,
+        "end": 146.93,
+        "confidence": 0.86,
+        "text": "land",
+        "offset": 123,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 146.93,
+        "end": 147.28,
+        "confidence": 0.86,
+        "text": "mines",
+        "offset": 128,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 147.28,
+        "end": 147.51,
+        "confidence": 0.857,
+        "text": "and",
+        "offset": 134,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 147.51,
+        "end": 147.64,
+        "confidence": 0.681,
+        "text": "we",
+        "offset": 138,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 147.64,
+        "end": 147.89,
+        "confidence": 0.568,
+        "text": "worked",
+        "offset": 141,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 147.89,
+        "end": 148.11,
+        "confidence": 0.692,
+        "text": "with",
+        "offset": 148,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 148.37,
+        "end": 148.46,
+        "confidence": 0.087,
+        "text": "it",
+        "offset": 153,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 148.46,
+        "end": 148.57,
+        "confidence": 0.266,
+        "text": "was",
+        "offset": 156,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 148.57,
+        "end": 148.95,
+        "confidence": 0.691,
+        "text": "shaped",
+        "offset": 160,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 148.95,
+        "end": 149.08,
+        "confidence": 1,
+        "text": "like",
+        "offset": 167,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 149.08,
+        "end": 149.15,
+        "confidence": 1,
+        "text": "a",
+        "offset": 172,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 149.15,
+        "end": 149.54,
+        "confidence": 0.956,
+        "text": "stick",
+        "offset": 174,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 149.54,
+        "end": 150.05,
+        "confidence": 0.812,
+        "text": "insect",
+        "offset": 180,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 150.43,
+        "end": 150.55,
+        "confidence": 0.85,
+        "text": "you",
+        "offset": 187,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 150.55,
+        "end": 150.68,
+        "confidence": 0.988,
+        "text": "would",
+        "offset": 191,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 150.68,
+        "end": 150.93,
+        "confidence": 1,
+        "text": "walk",
+        "offset": 197,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 150.93,
+        "end": 151.13,
+        "confidence": 0.998,
+        "text": "around",
+        "offset": 202,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 151.13,
+        "end": 151.19,
+        "confidence": 0.428,
+        "text": "the",
+        "offset": 209,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 151.19,
+        "end": 151.48,
+        "confidence": 0.659,
+        "text": "mine",
+        "offset": 213,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 151.48,
+        "end": 151.8,
+        "confidence": 0.664,
+        "text": "field",
+        "offset": 218,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 151.8,
+        "end": 151.89,
+        "confidence": 0.723,
+        "text": "on",
+        "offset": 224,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 151.89,
+        "end": 152.03,
+        "confidence": 0.996,
+        "text": "its",
+        "offset": 227,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 152.03,
+        "end": 152.57,
+        "confidence": 1,
+        "text": "legs",
+        "offset": 231,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 152.89,
+        "end": 153.07,
+        "confidence": 0.74,
+        "text": "and",
+        "offset": 236,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 153.07,
+        "end": 153.29,
+        "confidence": 0.763,
+        "text": "every",
+        "offset": 240,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 153.29,
+        "end": 153.46,
+        "confidence": 0.748,
+        "text": "time",
+        "offset": 246,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 153.46,
+        "end": 153.51,
+        "confidence": 0.252,
+        "text": "I",
+        "offset": 251,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 153.51,
+        "end": 153.88,
+        "confidence": 0.789,
+        "text": "stepped",
+        "offset": 253,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 153.88,
+        "end": 153.97,
+        "confidence": 0.981,
+        "text": "on",
+        "offset": 261,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 153.97,
+        "end": 154.02,
+        "confidence": 0.913,
+        "text": "a",
+        "offset": 264,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 154.02,
+        "end": 154.4,
+        "confidence": 0.989,
+        "text": "mine",
+        "offset": 266,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 154.43,
+        "end": 154.64,
+        "confidence": 0.965,
+        "text": "one",
+        "offset": 271,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 154.64,
+        "end": 154.71,
+        "confidence": 1,
+        "text": "of",
+        "offset": 275,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 154.71,
+        "end": 154.81,
+        "confidence": 1,
+        "text": "the",
+        "offset": 278,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 154.81,
+        "end": 155.08,
+        "confidence": 1,
+        "text": "legs",
+        "offset": 282,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 155.08,
+        "end": 155.2,
+        "confidence": 0.608,
+        "text": "would",
+        "offset": 287,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 155.2,
+        "end": 155.43,
+        "confidence": 1,
+        "text": "blow",
+        "offset": 293,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 155.43,
+        "end": 155.75,
+        "confidence": 0.905,
+        "text": "up",
+        "offset": 298,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 155.86,
+        "end": 156.02,
+        "confidence": 0.632,
+        "text": "would",
+        "offset": 301,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 156.02,
+        "end": 156.51,
+        "confidence": 1,
+        "text": "continue",
+        "offset": 307,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 156.51,
+        "end": 156.62,
+        "confidence": 0.664,
+        "text": "on",
+        "offset": 316,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 156.62,
+        "end": 156.69,
+        "confidence": 0.988,
+        "text": "the",
+        "offset": 319,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 156.69,
+        "end": 156.89,
+        "confidence": 1,
+        "text": "other",
+        "offset": 323,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 156.89,
+        "end": 157.26,
+        "confidence": 0.396,
+        "text": "likes",
+        "offset": 329,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 157.26,
+        "end": 157.38,
+        "confidence": 1,
+        "text": "to",
+        "offset": 335,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 157.38,
+        "end": 157.56,
+        "confidence": 0.413,
+        "text": "blow",
+        "offset": 338,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 157.56,
+        "end": 157.71,
+        "confidence": 0.374,
+        "text": "up",
+        "offset": 343,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 157.71,
+        "end": 157.81,
+        "confidence": 0.116,
+        "text": "our",
+        "offset": 346,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 157.81,
+        "end": 158.36,
+        "confidence": 0.678,
+        "text": "minds.",
+        "offset": 350,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And the colonel who is in charge of this testing exercise in the calling it off.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 159.22,
+      "words": [
+        {
+          "start": 159.22,
+          "confidence": 0.689,
+          "end": 159.49,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 159.52,
+          "confidence": 1,
+          "end": 159.67,
+          "word": "the",
+          "punct": "the",
+          "index": 1
+        },
+        {
+          "start": 159.67,
+          "confidence": 1,
+          "end": 160.12,
+          "word": "colonel",
+          "punct": "colonel",
+          "index": 2
+        },
+        {
+          "start": 160.12,
+          "confidence": 0.553,
+          "end": 160.24,
+          "word": "who",
+          "punct": "who",
+          "index": 3
+        },
+        {
+          "start": 160.24,
+          "confidence": 0.411,
+          "end": 160.34,
+          "word": "is",
+          "punct": "is",
+          "index": 4
+        },
+        {
+          "start": 160.34,
+          "confidence": 1,
+          "end": 160.43,
+          "word": "in",
+          "punct": "in",
+          "index": 5
+        },
+        {
+          "start": 160.43,
+          "confidence": 1,
+          "end": 160.93,
+          "word": "charge",
+          "punct": "charge",
+          "index": 6
+        },
+        {
+          "start": 160.93,
+          "confidence": 1,
+          "end": 161.01,
+          "word": "of",
+          "punct": "of",
+          "index": 7
+        },
+        {
+          "start": 161.01,
+          "confidence": 1,
+          "end": 161.17,
+          "word": "this",
+          "punct": "this",
+          "index": 8
+        },
+        {
+          "start": 161.17,
+          "confidence": 1,
+          "end": 161.67,
+          "word": "testing",
+          "punct": "testing",
+          "index": 9
+        },
+        {
+          "start": 161.67,
+          "confidence": 0.79,
+          "end": 162.67,
+          "word": "exercise",
+          "punct": "exercise",
+          "index": 10
+        },
+        {
+          "start": 163.04,
+          "confidence": 0.324,
+          "end": 163.2,
+          "word": "in",
+          "punct": "in",
+          "index": 11
+        },
+        {
+          "start": 163.2,
+          "confidence": 0.528,
+          "end": 163.31,
+          "word": "the",
+          "punct": "the",
+          "index": 12
+        },
+        {
+          "start": 163.31,
+          "confidence": 1,
+          "end": 163.79,
+          "word": "calling",
+          "punct": "calling",
+          "index": 13
+        },
+        {
+          "start": 163.79,
+          "confidence": 1,
+          "end": 163.88,
+          "word": "it",
+          "punct": "it",
+          "index": 14
+        },
+        {
+          "start": 163.88,
+          "confidence": 0.993,
+          "end": 164.42,
+          "word": "off",
+          "punct": "off.",
+          "index": 15
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 159.22,
+        "end": 159.49,
+        "confidence": 0.689,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 159.52,
+        "end": 159.67,
+        "confidence": 1,
+        "text": "the",
+        "offset": 4,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 159.67,
+        "end": 160.12,
+        "confidence": 1,
+        "text": "colonel",
+        "offset": 8,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 160.12,
+        "end": 160.24,
+        "confidence": 0.553,
+        "text": "who",
+        "offset": 16,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 160.24,
+        "end": 160.34,
+        "confidence": 0.411,
+        "text": "is",
+        "offset": 20,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 160.34,
+        "end": 160.43,
+        "confidence": 1,
+        "text": "in",
+        "offset": 23,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 160.43,
+        "end": 160.93,
+        "confidence": 1,
+        "text": "charge",
+        "offset": 26,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 160.93,
+        "end": 161.01,
+        "confidence": 1,
+        "text": "of",
+        "offset": 33,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 161.01,
+        "end": 161.17,
+        "confidence": 1,
+        "text": "this",
+        "offset": 36,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 161.17,
+        "end": 161.67,
+        "confidence": 1,
+        "text": "testing",
+        "offset": 41,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 161.67,
+        "end": 162.67,
+        "confidence": 0.79,
+        "text": "exercise",
+        "offset": 49,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 163.04,
+        "end": 163.2,
+        "confidence": 0.324,
+        "text": "in",
+        "offset": 58,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 163.2,
+        "end": 163.31,
+        "confidence": 0.528,
+        "text": "the",
+        "offset": 61,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 163.31,
+        "end": 163.79,
+        "confidence": 1,
+        "text": "calling",
+        "offset": 65,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 163.79,
+        "end": 163.88,
+        "confidence": 1,
+        "text": "it",
+        "offset": 73,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 163.88,
+        "end": 164.42,
+        "confidence": 0.993,
+        "text": "off.",
+        "offset": 76,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Because he says it's too in humane to watch this damage of robot drag itself along the mine field.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 165.26,
+      "words": [
+        {
+          "start": 165.26,
+          "confidence": 0.541,
+          "end": 165.56,
+          "word": "because",
+          "punct": "Because",
+          "index": 0
+        },
+        {
+          "start": 165.56,
+          "confidence": 0.752,
+          "end": 165.73,
+          "word": "he",
+          "punct": "he",
+          "index": 1
+        },
+        {
+          "start": 165.73,
+          "confidence": 1,
+          "end": 166.16,
+          "word": "says",
+          "punct": "says",
+          "index": 2
+        },
+        {
+          "start": 166.19,
+          "confidence": 1,
+          "end": 166.4,
+          "word": "it's",
+          "punct": "it's",
+          "index": 3
+        },
+        {
+          "start": 166.4,
+          "confidence": 0.851,
+          "end": 166.75,
+          "word": "too",
+          "punct": "too",
+          "index": 4
+        },
+        {
+          "start": 166.75,
+          "confidence": 0.729,
+          "end": 166.96,
+          "word": "in",
+          "punct": "in",
+          "index": 5
+        },
+        {
+          "start": 166.96,
+          "confidence": 0.729,
+          "end": 167.6,
+          "word": "humane",
+          "punct": "humane",
+          "index": 6
+        },
+        {
+          "start": 167.6,
+          "confidence": 0.957,
+          "end": 167.81,
+          "word": "to",
+          "punct": "to",
+          "index": 7
+        },
+        {
+          "start": 167.81,
+          "confidence": 0.762,
+          "end": 168.3,
+          "word": "watch",
+          "punct": "watch",
+          "index": 8
+        },
+        {
+          "start": 168.3,
+          "confidence": 0.969,
+          "end": 168.56,
+          "word": "this",
+          "punct": "this",
+          "index": 9
+        },
+        {
+          "start": 168.56,
+          "confidence": 0.77,
+          "end": 169,
+          "word": "damage",
+          "punct": "damage",
+          "index": 10
+        },
+        {
+          "start": 169,
+          "confidence": 0.572,
+          "end": 169.16,
+          "word": "of",
+          "punct": "of",
+          "index": 11
+        },
+        {
+          "start": 169.16,
+          "confidence": 0.881,
+          "end": 169.61,
+          "word": "robot",
+          "punct": "robot",
+          "index": 12
+        },
+        {
+          "start": 169.61,
+          "confidence": 0.198,
+          "end": 170.04,
+          "word": "drag",
+          "punct": "drag",
+          "index": 13
+        },
+        {
+          "start": 170.04,
+          "confidence": 0.6,
+          "end": 170.44,
+          "word": "itself",
+          "punct": "itself",
+          "index": 14
+        },
+        {
+          "start": 170.44,
+          "confidence": 0.612,
+          "end": 170.93,
+          "word": "along",
+          "punct": "along",
+          "index": 15
+        },
+        {
+          "start": 171.31,
+          "confidence": 1,
+          "end": 171.42,
+          "word": "the",
+          "punct": "the",
+          "index": 16
+        },
+        {
+          "start": 171.42,
+          "confidence": 0.393,
+          "end": 171.68,
+          "word": "mine",
+          "punct": "mine",
+          "index": 17
+        },
+        {
+          "start": 171.68,
+          "confidence": 0.328,
+          "end": 172.1,
+          "word": "field",
+          "punct": "field.",
+          "index": 18
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 165.26,
+        "end": 165.56,
+        "confidence": 0.541,
+        "text": "Because",
+        "offset": 0,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 165.56,
+        "end": 165.73,
+        "confidence": 0.752,
+        "text": "he",
+        "offset": 8,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 165.73,
+        "end": 166.16,
+        "confidence": 1,
+        "text": "says",
+        "offset": 11,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 166.19,
+        "end": 166.4,
+        "confidence": 1,
+        "text": "it's",
+        "offset": 16,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 166.4,
+        "end": 166.75,
+        "confidence": 0.851,
+        "text": "too",
+        "offset": 21,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 166.75,
+        "end": 166.96,
+        "confidence": 0.729,
+        "text": "in",
+        "offset": 25,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 166.96,
+        "end": 167.6,
+        "confidence": 0.729,
+        "text": "humane",
+        "offset": 28,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 167.6,
+        "end": 167.81,
+        "confidence": 0.957,
+        "text": "to",
+        "offset": 35,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 167.81,
+        "end": 168.3,
+        "confidence": 0.762,
+        "text": "watch",
+        "offset": 38,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 168.3,
+        "end": 168.56,
+        "confidence": 0.969,
+        "text": "this",
+        "offset": 44,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 168.56,
+        "end": 169,
+        "confidence": 0.77,
+        "text": "damage",
+        "offset": 49,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 169,
+        "end": 169.16,
+        "confidence": 0.572,
+        "text": "of",
+        "offset": 56,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 169.16,
+        "end": 169.61,
+        "confidence": 0.881,
+        "text": "robot",
+        "offset": 59,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 169.61,
+        "end": 170.04,
+        "confidence": 0.198,
+        "text": "drag",
+        "offset": 65,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 170.04,
+        "end": 170.44,
+        "confidence": 0.6,
+        "text": "itself",
+        "offset": 70,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 170.44,
+        "end": 170.93,
+        "confidence": 0.612,
+        "text": "along",
+        "offset": 77,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 171.31,
+        "end": 171.42,
+        "confidence": 1,
+        "text": "the",
+        "offset": 83,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 171.42,
+        "end": 171.68,
+        "confidence": 0.393,
+        "text": "mine",
+        "offset": 87,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 171.68,
+        "end": 172.1,
+        "confidence": 0.328,
+        "text": "field.",
+        "offset": 92,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Now what would cause a hardened military officer and someone like myself.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 174.97,
+      "words": [
+        {
+          "start": 174.97,
+          "confidence": 0.382,
+          "end": 175.17,
+          "word": "now",
+          "punct": "Now",
+          "index": 0
+        },
+        {
+          "start": 175.17,
+          "confidence": 0.972,
+          "end": 175.39,
+          "word": "what",
+          "punct": "what",
+          "index": 1
+        },
+        {
+          "start": 175.39,
+          "confidence": 0.341,
+          "end": 175.54,
+          "word": "would",
+          "punct": "would",
+          "index": 2
+        },
+        {
+          "start": 175.54,
+          "confidence": 0.868,
+          "end": 176.21,
+          "word": "cause",
+          "punct": "cause",
+          "index": 3
+        },
+        {
+          "start": 176.24,
+          "confidence": 0.441,
+          "end": 176.36,
+          "word": "a",
+          "punct": "a",
+          "index": 4
+        },
+        {
+          "start": 176.36,
+          "confidence": 0.806,
+          "end": 176.94,
+          "word": "hardened",
+          "punct": "hardened",
+          "index": 5
+        },
+        {
+          "start": 176.94,
+          "confidence": 0.984,
+          "end": 177.65,
+          "word": "military",
+          "punct": "military",
+          "index": 6
+        },
+        {
+          "start": 177.65,
+          "confidence": 0.963,
+          "end": 178.5,
+          "word": "officer",
+          "punct": "officer",
+          "index": 7
+        },
+        {
+          "start": 178.83,
+          "confidence": 0.357,
+          "end": 179.09,
+          "word": "and",
+          "punct": "and",
+          "index": 8
+        },
+        {
+          "start": 179.09,
+          "confidence": 0.995,
+          "end": 179.43,
+          "word": "someone",
+          "punct": "someone",
+          "index": 9
+        },
+        {
+          "start": 179.43,
+          "confidence": 1,
+          "end": 179.59,
+          "word": "like",
+          "punct": "like",
+          "index": 10
+        },
+        {
+          "start": 179.59,
+          "confidence": 0.999,
+          "end": 180.33,
+          "word": "myself",
+          "punct": "myself.",
+          "index": 11
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 174.97,
+        "end": 175.17,
+        "confidence": 0.382,
+        "text": "Now",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 175.17,
+        "end": 175.39,
+        "confidence": 0.972,
+        "text": "what",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 175.39,
+        "end": 175.54,
+        "confidence": 0.341,
+        "text": "would",
+        "offset": 9,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 175.54,
+        "end": 176.21,
+        "confidence": 0.868,
+        "text": "cause",
+        "offset": 15,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 176.24,
+        "end": 176.36,
+        "confidence": 0.441,
+        "text": "a",
+        "offset": 21,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 176.36,
+        "end": 176.94,
+        "confidence": 0.806,
+        "text": "hardened",
+        "offset": 23,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 176.94,
+        "end": 177.65,
+        "confidence": 0.984,
+        "text": "military",
+        "offset": 32,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 177.65,
+        "end": 178.5,
+        "confidence": 0.963,
+        "text": "officer",
+        "offset": 41,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 178.83,
+        "end": 179.09,
+        "confidence": 0.357,
+        "text": "and",
+        "offset": 49,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 179.09,
+        "end": 179.43,
+        "confidence": 0.995,
+        "text": "someone",
+        "offset": 53,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 179.43,
+        "end": 179.59,
+        "confidence": 1,
+        "text": "like",
+        "offset": 61,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 179.59,
+        "end": 180.33,
+        "confidence": 0.999,
+        "text": "myself.",
+        "offset": 66,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "To have this response to robots.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 180.95,
+      "words": [
+        {
+          "start": 180.95,
+          "confidence": 1,
+          "end": 181.08,
+          "word": "to",
+          "punct": "To",
+          "index": 0
+        },
+        {
+          "start": 181.08,
+          "confidence": 1,
+          "end": 181.27,
+          "word": "have",
+          "punct": "have",
+          "index": 1
+        },
+        {
+          "start": 181.27,
+          "confidence": 1,
+          "end": 181.41,
+          "word": "this",
+          "punct": "this",
+          "index": 2
+        },
+        {
+          "start": 181.41,
+          "confidence": 1,
+          "end": 181.91,
+          "word": "response",
+          "punct": "response",
+          "index": 3
+        },
+        {
+          "start": 181.91,
+          "confidence": 0.746,
+          "end": 182.04,
+          "word": "to",
+          "punct": "to",
+          "index": 4
+        },
+        {
+          "start": 182.04,
+          "confidence": 0.995,
+          "end": 182.75,
+          "word": "robots",
+          "punct": "robots.",
+          "index": 5
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 180.95,
+        "end": 181.08,
+        "confidence": 1,
+        "text": "To",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 181.08,
+        "end": 181.27,
+        "confidence": 1,
+        "text": "have",
+        "offset": 3,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 181.27,
+        "end": 181.41,
+        "confidence": 1,
+        "text": "this",
+        "offset": 8,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 181.41,
+        "end": 181.91,
+        "confidence": 1,
+        "text": "response",
+        "offset": 13,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 181.91,
+        "end": 182.04,
+        "confidence": 0.746,
+        "text": "to",
+        "offset": 22,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 182.04,
+        "end": 182.75,
+        "confidence": 0.995,
+        "text": "robots.",
+        "offset": 25,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Well of course for prime by science fiction pop culture to really want to personify these things but it goes a little bit deeper than that.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 183.59,
+      "words": [
+        {
+          "start": 183.59,
+          "confidence": 0.516,
+          "end": 183.94,
+          "word": "well",
+          "punct": "Well",
+          "index": 0
+        },
+        {
+          "start": 184.07,
+          "confidence": 1,
+          "end": 184.2,
+          "word": "of",
+          "punct": "of",
+          "index": 1
+        },
+        {
+          "start": 184.2,
+          "confidence": 1,
+          "end": 184.47,
+          "word": "course",
+          "punct": "course",
+          "index": 2
+        },
+        {
+          "start": 184.47,
+          "confidence": 0.666,
+          "end": 184.61,
+          "word": "for",
+          "punct": "for",
+          "index": 3
+        },
+        {
+          "start": 184.61,
+          "confidence": 0.576,
+          "end": 185.16,
+          "word": "prime",
+          "punct": "prime",
+          "index": 4
+        },
+        {
+          "start": 185.16,
+          "confidence": 0.861,
+          "end": 185.3,
+          "word": "by",
+          "punct": "by",
+          "index": 5
+        },
+        {
+          "start": 185.3,
+          "confidence": 0.758,
+          "end": 185.74,
+          "word": "science",
+          "punct": "science",
+          "index": 6
+        },
+        {
+          "start": 185.74,
+          "confidence": 0.928,
+          "end": 186.07,
+          "word": "fiction",
+          "punct": "fiction",
+          "index": 7
+        },
+        {
+          "start": 186.07,
+          "confidence": 0.983,
+          "end": 186.42,
+          "word": "pop",
+          "punct": "pop",
+          "index": 8
+        },
+        {
+          "start": 186.42,
+          "confidence": 0.962,
+          "end": 186.84,
+          "word": "culture",
+          "punct": "culture",
+          "index": 9
+        },
+        {
+          "start": 186.84,
+          "confidence": 0.226,
+          "end": 186.95,
+          "word": "to",
+          "punct": "to",
+          "index": 10
+        },
+        {
+          "start": 186.95,
+          "confidence": 0.982,
+          "end": 187.18,
+          "word": "really",
+          "punct": "really",
+          "index": 11
+        },
+        {
+          "start": 187.18,
+          "confidence": 0.38,
+          "end": 187.32,
+          "word": "want",
+          "punct": "want",
+          "index": 12
+        },
+        {
+          "start": 187.32,
+          "confidence": 0.356,
+          "end": 187.38,
+          "word": "to",
+          "punct": "to",
+          "index": 13
+        },
+        {
+          "start": 187.38,
+          "confidence": 0.616,
+          "end": 188.03,
+          "word": "personify",
+          "punct": "personify",
+          "index": 14
+        },
+        {
+          "start": 188.03,
+          "confidence": 0.774,
+          "end": 188.29,
+          "word": "these",
+          "punct": "these",
+          "index": 15
+        },
+        {
+          "start": 188.29,
+          "confidence": 1,
+          "end": 188.92,
+          "word": "things",
+          "punct": "things",
+          "index": 16
+        },
+        {
+          "start": 189.47,
+          "confidence": 0.952,
+          "end": 189.72,
+          "word": "but",
+          "punct": "but",
+          "index": 17
+        },
+        {
+          "start": 189.76,
+          "confidence": 0.549,
+          "end": 189.87,
+          "word": "it",
+          "punct": "it",
+          "index": 18
+        },
+        {
+          "start": 189.87,
+          "confidence": 0.776,
+          "end": 190.05,
+          "word": "goes",
+          "punct": "goes",
+          "index": 19
+        },
+        {
+          "start": 190.05,
+          "confidence": 0.97,
+          "end": 190.12,
+          "word": "a",
+          "punct": "a",
+          "index": 20
+        },
+        {
+          "start": 190.12,
+          "confidence": 1,
+          "end": 190.33,
+          "word": "little",
+          "punct": "little",
+          "index": 21
+        },
+        {
+          "start": 190.33,
+          "confidence": 0.887,
+          "end": 190.48,
+          "word": "bit",
+          "punct": "bit",
+          "index": 22
+        },
+        {
+          "start": 190.48,
+          "confidence": 0.637,
+          "end": 190.76,
+          "word": "deeper",
+          "punct": "deeper",
+          "index": 23
+        },
+        {
+          "start": 190.76,
+          "confidence": 0.778,
+          "end": 190.92,
+          "word": "than",
+          "punct": "than",
+          "index": 24
+        },
+        {
+          "start": 190.92,
+          "confidence": 0.335,
+          "end": 191.13,
+          "word": "that",
+          "punct": "that.",
+          "index": 25
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 183.59,
+        "end": 183.94,
+        "confidence": 0.516,
+        "text": "Well",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 184.07,
+        "end": 184.2,
+        "confidence": 1,
+        "text": "of",
+        "offset": 5,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 184.2,
+        "end": 184.47,
+        "confidence": 1,
+        "text": "course",
+        "offset": 8,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 184.47,
+        "end": 184.61,
+        "confidence": 0.666,
+        "text": "for",
+        "offset": 15,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 184.61,
+        "end": 185.16,
+        "confidence": 0.576,
+        "text": "prime",
+        "offset": 19,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 185.16,
+        "end": 185.3,
+        "confidence": 0.861,
+        "text": "by",
+        "offset": 25,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 185.3,
+        "end": 185.74,
+        "confidence": 0.758,
+        "text": "science",
+        "offset": 28,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 185.74,
+        "end": 186.07,
+        "confidence": 0.928,
+        "text": "fiction",
+        "offset": 36,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 186.07,
+        "end": 186.42,
+        "confidence": 0.983,
+        "text": "pop",
+        "offset": 44,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 186.42,
+        "end": 186.84,
+        "confidence": 0.962,
+        "text": "culture",
+        "offset": 48,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 186.84,
+        "end": 186.95,
+        "confidence": 0.226,
+        "text": "to",
+        "offset": 56,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 186.95,
+        "end": 187.18,
+        "confidence": 0.982,
+        "text": "really",
+        "offset": 59,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 187.18,
+        "end": 187.32,
+        "confidence": 0.38,
+        "text": "want",
+        "offset": 66,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 187.32,
+        "end": 187.38,
+        "confidence": 0.356,
+        "text": "to",
+        "offset": 71,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 187.38,
+        "end": 188.03,
+        "confidence": 0.616,
+        "text": "personify",
+        "offset": 74,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 188.03,
+        "end": 188.29,
+        "confidence": 0.774,
+        "text": "these",
+        "offset": 84,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 188.29,
+        "end": 188.92,
+        "confidence": 1,
+        "text": "things",
+        "offset": 90,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 189.47,
+        "end": 189.72,
+        "confidence": 0.952,
+        "text": "but",
+        "offset": 97,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 189.76,
+        "end": 189.87,
+        "confidence": 0.549,
+        "text": "it",
+        "offset": 101,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 189.87,
+        "end": 190.05,
+        "confidence": 0.776,
+        "text": "goes",
+        "offset": 104,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 190.05,
+        "end": 190.12,
+        "confidence": 0.97,
+        "text": "a",
+        "offset": 109,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 190.12,
+        "end": 190.33,
+        "confidence": 1,
+        "text": "little",
+        "offset": 111,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 190.33,
+        "end": 190.48,
+        "confidence": 0.887,
+        "text": "bit",
+        "offset": 118,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 190.48,
+        "end": 190.76,
+        "confidence": 0.637,
+        "text": "deeper",
+        "offset": 122,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 190.76,
+        "end": 190.92,
+        "confidence": 0.778,
+        "text": "than",
+        "offset": 129,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 190.92,
+        "end": 191.13,
+        "confidence": 0.335,
+        "text": "that.",
+        "offset": 134,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "It turns out that we're biologically hard wired to project intent and life on to any movement in our physical space it seems a communist.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 192.24,
+      "words": [
+        {
+          "start": 192.24,
+          "confidence": 1,
+          "end": 192.37,
+          "word": "it",
+          "punct": "It",
+          "index": 0
+        },
+        {
+          "start": 192.37,
+          "confidence": 0.787,
+          "end": 192.68,
+          "word": "turns",
+          "punct": "turns",
+          "index": 1
+        },
+        {
+          "start": 192.68,
+          "confidence": 0.982,
+          "end": 192.8,
+          "word": "out",
+          "punct": "out",
+          "index": 2
+        },
+        {
+          "start": 192.8,
+          "confidence": 1,
+          "end": 192.92,
+          "word": "that",
+          "punct": "that",
+          "index": 3
+        },
+        {
+          "start": 192.92,
+          "confidence": 0.358,
+          "end": 193.06,
+          "word": "we're",
+          "punct": "we're",
+          "index": 4
+        },
+        {
+          "start": 193.06,
+          "confidence": 1,
+          "end": 193.94,
+          "word": "biologically",
+          "punct": "biologically",
+          "index": 5
+        },
+        {
+          "start": 193.94,
+          "confidence": 0.497,
+          "end": 194.47,
+          "word": "hard",
+          "punct": "hard",
+          "index": 6
+        },
+        {
+          "start": 194.47,
+          "confidence": 0.497,
+          "end": 194.93,
+          "word": "wired",
+          "punct": "wired",
+          "index": 7
+        },
+        {
+          "start": 194.93,
+          "confidence": 1,
+          "end": 195.08,
+          "word": "to",
+          "punct": "to",
+          "index": 8
+        },
+        {
+          "start": 195.08,
+          "confidence": 1,
+          "end": 195.79,
+          "word": "project",
+          "punct": "project",
+          "index": 9
+        },
+        {
+          "start": 196.1,
+          "confidence": 0.806,
+          "end": 196.85,
+          "word": "intent",
+          "punct": "intent",
+          "index": 10
+        },
+        {
+          "start": 196.88,
+          "confidence": 0.86,
+          "end": 197.19,
+          "word": "and",
+          "punct": "and",
+          "index": 11
+        },
+        {
+          "start": 197.19,
+          "confidence": 0.905,
+          "end": 197.59,
+          "word": "life",
+          "punct": "life",
+          "index": 12
+        },
+        {
+          "start": 197.59,
+          "confidence": 0.797,
+          "end": 197.79,
+          "word": "on",
+          "punct": "on",
+          "index": 13
+        },
+        {
+          "start": 197.79,
+          "confidence": 0.8,
+          "end": 198.24,
+          "word": "to",
+          "punct": "to",
+          "index": 14
+        },
+        {
+          "start": 198.57,
+          "confidence": 1,
+          "end": 198.78,
+          "word": "any",
+          "punct": "any",
+          "index": 15
+        },
+        {
+          "start": 198.78,
+          "confidence": 1,
+          "end": 199.37,
+          "word": "movement",
+          "punct": "movement",
+          "index": 16
+        },
+        {
+          "start": 199.37,
+          "confidence": 0.64,
+          "end": 199.46,
+          "word": "in",
+          "punct": "in",
+          "index": 17
+        },
+        {
+          "start": 199.46,
+          "confidence": 0.776,
+          "end": 199.57,
+          "word": "our",
+          "punct": "our",
+          "index": 18
+        },
+        {
+          "start": 199.57,
+          "confidence": 1,
+          "end": 200.11,
+          "word": "physical",
+          "punct": "physical",
+          "index": 19
+        },
+        {
+          "start": 200.11,
+          "confidence": 0.74,
+          "end": 200.5,
+          "word": "space",
+          "punct": "space",
+          "index": 20
+        },
+        {
+          "start": 200.5,
+          "confidence": 0.391,
+          "end": 200.65,
+          "word": "it",
+          "punct": "it",
+          "index": 21
+        },
+        {
+          "start": 200.65,
+          "confidence": 0.984,
+          "end": 201.13,
+          "word": "seems",
+          "punct": "seems",
+          "index": 22
+        },
+        {
+          "start": 201.13,
+          "confidence": 0.231,
+          "end": 201.2,
+          "word": "a",
+          "punct": "a",
+          "index": 23
+        },
+        {
+          "start": 201.2,
+          "confidence": 0.655,
+          "end": 201.89,
+          "word": "communist",
+          "punct": "communist.",
+          "index": 24
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 192.24,
+        "end": 192.37,
+        "confidence": 1,
+        "text": "It",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 192.37,
+        "end": 192.68,
+        "confidence": 0.787,
+        "text": "turns",
+        "offset": 3,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 192.68,
+        "end": 192.8,
+        "confidence": 0.982,
+        "text": "out",
+        "offset": 9,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 192.8,
+        "end": 192.92,
+        "confidence": 1,
+        "text": "that",
+        "offset": 13,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 192.92,
+        "end": 193.06,
+        "confidence": 0.358,
+        "text": "we're",
+        "offset": 18,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 193.06,
+        "end": 193.94,
+        "confidence": 1,
+        "text": "biologically",
+        "offset": 24,
+        "length": 12,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 193.94,
+        "end": 194.47,
+        "confidence": 0.497,
+        "text": "hard",
+        "offset": 37,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 194.47,
+        "end": 194.93,
+        "confidence": 0.497,
+        "text": "wired",
+        "offset": 42,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 194.93,
+        "end": 195.08,
+        "confidence": 1,
+        "text": "to",
+        "offset": 48,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 195.08,
+        "end": 195.79,
+        "confidence": 1,
+        "text": "project",
+        "offset": 51,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 196.1,
+        "end": 196.85,
+        "confidence": 0.806,
+        "text": "intent",
+        "offset": 59,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 196.88,
+        "end": 197.19,
+        "confidence": 0.86,
+        "text": "and",
+        "offset": 66,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 197.19,
+        "end": 197.59,
+        "confidence": 0.905,
+        "text": "life",
+        "offset": 70,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 197.59,
+        "end": 197.79,
+        "confidence": 0.797,
+        "text": "on",
+        "offset": 75,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 197.79,
+        "end": 198.24,
+        "confidence": 0.8,
+        "text": "to",
+        "offset": 78,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 198.57,
+        "end": 198.78,
+        "confidence": 1,
+        "text": "any",
+        "offset": 81,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 198.78,
+        "end": 199.37,
+        "confidence": 1,
+        "text": "movement",
+        "offset": 85,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 199.37,
+        "end": 199.46,
+        "confidence": 0.64,
+        "text": "in",
+        "offset": 94,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 199.46,
+        "end": 199.57,
+        "confidence": 0.776,
+        "text": "our",
+        "offset": 97,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 199.57,
+        "end": 200.11,
+        "confidence": 1,
+        "text": "physical",
+        "offset": 101,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 200.11,
+        "end": 200.5,
+        "confidence": 0.74,
+        "text": "space",
+        "offset": 110,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 200.5,
+        "end": 200.65,
+        "confidence": 0.391,
+        "text": "it",
+        "offset": 116,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 200.65,
+        "end": 201.13,
+        "confidence": 0.984,
+        "text": "seems",
+        "offset": 119,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 201.13,
+        "end": 201.2,
+        "confidence": 0.231,
+        "text": "a",
+        "offset": 125,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 201.2,
+        "end": 201.89,
+        "confidence": 0.655,
+        "text": "communist.",
+        "offset": 127,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Some people treat all sorts of robots like their life.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 203.2,
+      "words": [
+        {
+          "start": 203.2,
+          "confidence": 0.44,
+          "end": 203.39,
+          "word": "some",
+          "punct": "Some",
+          "index": 0
+        },
+        {
+          "start": 203.39,
+          "confidence": 0.855,
+          "end": 203.74,
+          "word": "people",
+          "punct": "people",
+          "index": 1
+        },
+        {
+          "start": 203.74,
+          "confidence": 1,
+          "end": 203.99,
+          "word": "treat",
+          "punct": "treat",
+          "index": 2
+        },
+        {
+          "start": 204.02,
+          "confidence": 0.872,
+          "end": 204.2,
+          "word": "all",
+          "punct": "all",
+          "index": 3
+        },
+        {
+          "start": 204.2,
+          "confidence": 0.38,
+          "end": 204.46,
+          "word": "sorts",
+          "punct": "sorts",
+          "index": 4
+        },
+        {
+          "start": 204.46,
+          "confidence": 0.48,
+          "end": 204.57,
+          "word": "of",
+          "punct": "of",
+          "index": 5
+        },
+        {
+          "start": 204.57,
+          "confidence": 0.766,
+          "end": 204.93,
+          "word": "robots",
+          "punct": "robots",
+          "index": 6
+        },
+        {
+          "start": 204.93,
+          "confidence": 0.841,
+          "end": 205.1,
+          "word": "like",
+          "punct": "like",
+          "index": 7
+        },
+        {
+          "start": 205.1,
+          "confidence": 0.893,
+          "end": 205.28,
+          "word": "their",
+          "punct": "their",
+          "index": 8
+        },
+        {
+          "start": 205.28,
+          "confidence": 0.365,
+          "end": 205.85,
+          "word": "life",
+          "punct": "life.",
+          "index": 9
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 203.2,
+        "end": 203.39,
+        "confidence": 0.44,
+        "text": "Some",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 203.39,
+        "end": 203.74,
+        "confidence": 0.855,
+        "text": "people",
+        "offset": 5,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 203.74,
+        "end": 203.99,
+        "confidence": 1,
+        "text": "treat",
+        "offset": 12,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 204.02,
+        "end": 204.2,
+        "confidence": 0.872,
+        "text": "all",
+        "offset": 18,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 204.2,
+        "end": 204.46,
+        "confidence": 0.38,
+        "text": "sorts",
+        "offset": 22,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 204.46,
+        "end": 204.57,
+        "confidence": 0.48,
+        "text": "of",
+        "offset": 28,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 204.57,
+        "end": 204.93,
+        "confidence": 0.766,
+        "text": "robots",
+        "offset": 31,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 204.93,
+        "end": 205.1,
+        "confidence": 0.841,
+        "text": "like",
+        "offset": 38,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 205.1,
+        "end": 205.28,
+        "confidence": 0.893,
+        "text": "their",
+        "offset": 43,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 205.28,
+        "end": 205.85,
+        "confidence": 0.365,
+        "text": "life.",
+        "offset": 49,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "These bomb disposal units get names they get medals of honor they've had funerals for them with gun salute.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 206.69,
+      "words": [
+        {
+          "start": 206.69,
+          "confidence": 0.777,
+          "end": 206.91,
+          "word": "these",
+          "punct": "These",
+          "index": 0
+        },
+        {
+          "start": 206.91,
+          "confidence": 1,
+          "end": 207.23,
+          "word": "bomb",
+          "punct": "bomb",
+          "index": 1
+        },
+        {
+          "start": 207.23,
+          "confidence": 1,
+          "end": 208,
+          "word": "disposal",
+          "punct": "disposal",
+          "index": 2
+        },
+        {
+          "start": 208.03,
+          "confidence": 0.299,
+          "end": 208.56,
+          "word": "units",
+          "punct": "units",
+          "index": 3
+        },
+        {
+          "start": 208.56,
+          "confidence": 0.47,
+          "end": 208.76,
+          "word": "get",
+          "punct": "get",
+          "index": 4
+        },
+        {
+          "start": 208.76,
+          "confidence": 0.993,
+          "end": 209.35,
+          "word": "names",
+          "punct": "names",
+          "index": 5
+        },
+        {
+          "start": 209.38,
+          "confidence": 1,
+          "end": 209.53,
+          "word": "they",
+          "punct": "they",
+          "index": 6
+        },
+        {
+          "start": 209.53,
+          "confidence": 0.764,
+          "end": 209.72,
+          "word": "get",
+          "punct": "get",
+          "index": 7
+        },
+        {
+          "start": 209.72,
+          "confidence": 0.944,
+          "end": 210.15,
+          "word": "medals",
+          "punct": "medals",
+          "index": 8
+        },
+        {
+          "start": 210.15,
+          "confidence": 1,
+          "end": 210.26,
+          "word": "of",
+          "punct": "of",
+          "index": 9
+        },
+        {
+          "start": 210.26,
+          "confidence": 0.989,
+          "end": 210.77,
+          "word": "honor",
+          "punct": "honor",
+          "index": 10
+        },
+        {
+          "start": 211.09,
+          "confidence": 0.627,
+          "end": 211.27,
+          "word": "they've",
+          "punct": "they've",
+          "index": 11
+        },
+        {
+          "start": 211.27,
+          "confidence": 0.959,
+          "end": 211.4,
+          "word": "had",
+          "punct": "had",
+          "index": 12
+        },
+        {
+          "start": 211.4,
+          "confidence": 1,
+          "end": 212.01,
+          "word": "funerals",
+          "punct": "funerals",
+          "index": 13
+        },
+        {
+          "start": 212.01,
+          "confidence": 1,
+          "end": 212.17,
+          "word": "for",
+          "punct": "for",
+          "index": 14
+        },
+        {
+          "start": 212.17,
+          "confidence": 0.613,
+          "end": 212.34,
+          "word": "them",
+          "punct": "them",
+          "index": 15
+        },
+        {
+          "start": 212.34,
+          "confidence": 0.794,
+          "end": 212.53,
+          "word": "with",
+          "punct": "with",
+          "index": 16
+        },
+        {
+          "start": 212.53,
+          "confidence": 0.912,
+          "end": 212.77,
+          "word": "gun",
+          "punct": "gun",
+          "index": 17
+        },
+        {
+          "start": 212.77,
+          "confidence": 0.728,
+          "end": 213.18,
+          "word": "salute",
+          "punct": "salute.",
+          "index": 18
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 206.69,
+        "end": 206.91,
+        "confidence": 0.777,
+        "text": "These",
+        "offset": 0,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 206.91,
+        "end": 207.23,
+        "confidence": 1,
+        "text": "bomb",
+        "offset": 6,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 207.23,
+        "end": 208,
+        "confidence": 1,
+        "text": "disposal",
+        "offset": 11,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 208.03,
+        "end": 208.56,
+        "confidence": 0.299,
+        "text": "units",
+        "offset": 20,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 208.56,
+        "end": 208.76,
+        "confidence": 0.47,
+        "text": "get",
+        "offset": 26,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 208.76,
+        "end": 209.35,
+        "confidence": 0.993,
+        "text": "names",
+        "offset": 30,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 209.38,
+        "end": 209.53,
+        "confidence": 1,
+        "text": "they",
+        "offset": 36,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 209.53,
+        "end": 209.72,
+        "confidence": 0.764,
+        "text": "get",
+        "offset": 41,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 209.72,
+        "end": 210.15,
+        "confidence": 0.944,
+        "text": "medals",
+        "offset": 45,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 210.15,
+        "end": 210.26,
+        "confidence": 1,
+        "text": "of",
+        "offset": 52,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 210.26,
+        "end": 210.77,
+        "confidence": 0.989,
+        "text": "honor",
+        "offset": 55,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 211.09,
+        "end": 211.27,
+        "confidence": 0.627,
+        "text": "they've",
+        "offset": 61,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 211.27,
+        "end": 211.4,
+        "confidence": 0.959,
+        "text": "had",
+        "offset": 69,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 211.4,
+        "end": 212.01,
+        "confidence": 1,
+        "text": "funerals",
+        "offset": 73,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 212.01,
+        "end": 212.17,
+        "confidence": 1,
+        "text": "for",
+        "offset": 82,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 212.17,
+        "end": 212.34,
+        "confidence": 0.613,
+        "text": "them",
+        "offset": 86,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 212.34,
+        "end": 212.53,
+        "confidence": 0.794,
+        "text": "with",
+        "offset": 91,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 212.53,
+        "end": 212.77,
+        "confidence": 0.912,
+        "text": "gun",
+        "offset": 96,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 212.77,
+        "end": 213.18,
+        "confidence": 0.728,
+        "text": "salute.",
+        "offset": 100,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And research shows that we do this even with very simple household robots like the rumor vacuum cleaner.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 214.35,
+      "words": [
+        {
+          "start": 214.35,
+          "confidence": 0.835,
+          "end": 214.59,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 214.95,
+          "confidence": 0.793,
+          "end": 215.37,
+          "word": "research",
+          "punct": "research",
+          "index": 1
+        },
+        {
+          "start": 215.37,
+          "confidence": 0.476,
+          "end": 215.57,
+          "word": "shows",
+          "punct": "shows",
+          "index": 2
+        },
+        {
+          "start": 215.57,
+          "confidence": 1,
+          "end": 215.66,
+          "word": "that",
+          "punct": "that",
+          "index": 3
+        },
+        {
+          "start": 215.66,
+          "confidence": 0.972,
+          "end": 215.76,
+          "word": "we",
+          "punct": "we",
+          "index": 4
+        },
+        {
+          "start": 215.76,
+          "confidence": 0.847,
+          "end": 215.86,
+          "word": "do",
+          "punct": "do",
+          "index": 5
+        },
+        {
+          "start": 215.86,
+          "confidence": 0.973,
+          "end": 216.03,
+          "word": "this",
+          "punct": "this",
+          "index": 6
+        },
+        {
+          "start": 216.03,
+          "confidence": 0.976,
+          "end": 216.31,
+          "word": "even",
+          "punct": "even",
+          "index": 7
+        },
+        {
+          "start": 216.31,
+          "confidence": 0.974,
+          "end": 216.44,
+          "word": "with",
+          "punct": "with",
+          "index": 8
+        },
+        {
+          "start": 216.44,
+          "confidence": 0.912,
+          "end": 216.78,
+          "word": "very",
+          "punct": "very",
+          "index": 9
+        },
+        {
+          "start": 216.78,
+          "confidence": 1,
+          "end": 217.16,
+          "word": "simple",
+          "punct": "simple",
+          "index": 10
+        },
+        {
+          "start": 217.16,
+          "confidence": 1,
+          "end": 217.75,
+          "word": "household",
+          "punct": "household",
+          "index": 11
+        },
+        {
+          "start": 217.75,
+          "confidence": 0.936,
+          "end": 218.25,
+          "word": "robots",
+          "punct": "robots",
+          "index": 12
+        },
+        {
+          "start": 218.25,
+          "confidence": 1,
+          "end": 218.57,
+          "word": "like",
+          "punct": "like",
+          "index": 13
+        },
+        {
+          "start": 218.83,
+          "confidence": 1,
+          "end": 218.98,
+          "word": "the",
+          "punct": "the",
+          "index": 14
+        },
+        {
+          "start": 218.98,
+          "confidence": 0.28,
+          "end": 219.4,
+          "word": "rumor",
+          "punct": "rumor",
+          "index": 15
+        },
+        {
+          "start": 219.4,
+          "confidence": 0.979,
+          "end": 219.81,
+          "word": "vacuum",
+          "punct": "vacuum",
+          "index": 16
+        },
+        {
+          "start": 219.81,
+          "confidence": 0.769,
+          "end": 220.3,
+          "word": "cleaner",
+          "punct": "cleaner.",
+          "index": 17
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 214.35,
+        "end": 214.59,
+        "confidence": 0.835,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 214.95,
+        "end": 215.37,
+        "confidence": 0.793,
+        "text": "research",
+        "offset": 4,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 215.37,
+        "end": 215.57,
+        "confidence": 0.476,
+        "text": "shows",
+        "offset": 13,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 215.57,
+        "end": 215.66,
+        "confidence": 1,
+        "text": "that",
+        "offset": 19,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 215.66,
+        "end": 215.76,
+        "confidence": 0.972,
+        "text": "we",
+        "offset": 24,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 215.76,
+        "end": 215.86,
+        "confidence": 0.847,
+        "text": "do",
+        "offset": 27,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 215.86,
+        "end": 216.03,
+        "confidence": 0.973,
+        "text": "this",
+        "offset": 30,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 216.03,
+        "end": 216.31,
+        "confidence": 0.976,
+        "text": "even",
+        "offset": 35,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 216.31,
+        "end": 216.44,
+        "confidence": 0.974,
+        "text": "with",
+        "offset": 40,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 216.44,
+        "end": 216.78,
+        "confidence": 0.912,
+        "text": "very",
+        "offset": 45,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 216.78,
+        "end": 217.16,
+        "confidence": 1,
+        "text": "simple",
+        "offset": 50,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 217.16,
+        "end": 217.75,
+        "confidence": 1,
+        "text": "household",
+        "offset": 57,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 217.75,
+        "end": 218.25,
+        "confidence": 0.936,
+        "text": "robots",
+        "offset": 67,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 218.25,
+        "end": 218.57,
+        "confidence": 1,
+        "text": "like",
+        "offset": 74,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 218.83,
+        "end": 218.98,
+        "confidence": 1,
+        "text": "the",
+        "offset": 79,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 218.98,
+        "end": 219.4,
+        "confidence": 0.28,
+        "text": "rumor",
+        "offset": 83,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 219.4,
+        "end": 219.81,
+        "confidence": 0.979,
+        "text": "vacuum",
+        "offset": 89,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 219.81,
+        "end": 220.3,
+        "confidence": 0.769,
+        "text": "cleaner.",
+        "offset": 96,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Just the desk that roams around your floor to clean it which is the fact that it's moving around on its own will cause people to name the room and feel bad for the room but when it gets stuck under the couch.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 221.68,
+      "words": [
+        {
+          "start": 221.68,
+          "confidence": 1,
+          "end": 221.9,
+          "word": "just",
+          "punct": "Just",
+          "index": 0
+        },
+        {
+          "start": 221.9,
+          "confidence": 0.416,
+          "end": 221.99,
+          "word": "the",
+          "punct": "the",
+          "index": 1
+        },
+        {
+          "start": 221.99,
+          "confidence": 0.485,
+          "end": 222.48,
+          "word": "desk",
+          "punct": "desk",
+          "index": 2
+        },
+        {
+          "start": 222.48,
+          "confidence": 0.994,
+          "end": 222.68,
+          "word": "that",
+          "punct": "that",
+          "index": 3
+        },
+        {
+          "start": 222.68,
+          "confidence": 0.398,
+          "end": 222.97,
+          "word": "roams",
+          "punct": "roams",
+          "index": 4
+        },
+        {
+          "start": 222.97,
+          "confidence": 1,
+          "end": 223.24,
+          "word": "around",
+          "punct": "around",
+          "index": 5
+        },
+        {
+          "start": 223.24,
+          "confidence": 0.762,
+          "end": 223.35,
+          "word": "your",
+          "punct": "your",
+          "index": 6
+        },
+        {
+          "start": 223.35,
+          "confidence": 0.286,
+          "end": 223.77,
+          "word": "floor",
+          "punct": "floor",
+          "index": 7
+        },
+        {
+          "start": 223.77,
+          "confidence": 0.286,
+          "end": 223.86,
+          "word": "to",
+          "punct": "to",
+          "index": 8
+        },
+        {
+          "start": 223.86,
+          "confidence": 0.883,
+          "end": 224.23,
+          "word": "clean",
+          "punct": "clean",
+          "index": 9
+        },
+        {
+          "start": 224.23,
+          "confidence": 0.924,
+          "end": 224.45,
+          "word": "it",
+          "punct": "it",
+          "index": 10
+        },
+        {
+          "start": 224.77,
+          "confidence": 0.436,
+          "end": 224.9,
+          "word": "which",
+          "punct": "which",
+          "index": 11
+        },
+        {
+          "start": 224.9,
+          "confidence": 0.499,
+          "end": 225,
+          "word": "is",
+          "punct": "is",
+          "index": 12
+        },
+        {
+          "start": 225,
+          "confidence": 0.849,
+          "end": 225.1,
+          "word": "the",
+          "punct": "the",
+          "index": 13
+        },
+        {
+          "start": 225.1,
+          "confidence": 1,
+          "end": 225.43,
+          "word": "fact",
+          "punct": "fact",
+          "index": 14
+        },
+        {
+          "start": 225.43,
+          "confidence": 1,
+          "end": 225.56,
+          "word": "that",
+          "punct": "that",
+          "index": 15
+        },
+        {
+          "start": 225.56,
+          "confidence": 0.872,
+          "end": 225.72,
+          "word": "it's",
+          "punct": "it's",
+          "index": 16
+        },
+        {
+          "start": 225.72,
+          "confidence": 1,
+          "end": 226.22,
+          "word": "moving",
+          "punct": "moving",
+          "index": 17
+        },
+        {
+          "start": 226.22,
+          "confidence": 1,
+          "end": 226.54,
+          "word": "around",
+          "punct": "around",
+          "index": 18
+        },
+        {
+          "start": 226.54,
+          "confidence": 0.976,
+          "end": 226.66,
+          "word": "on",
+          "punct": "on",
+          "index": 19
+        },
+        {
+          "start": 226.66,
+          "confidence": 0.713,
+          "end": 226.78,
+          "word": "its",
+          "punct": "its",
+          "index": 20
+        },
+        {
+          "start": 226.78,
+          "confidence": 0.99,
+          "end": 227.09,
+          "word": "own",
+          "punct": "own",
+          "index": 21
+        },
+        {
+          "start": 227.09,
+          "confidence": 0.767,
+          "end": 227.21,
+          "word": "will",
+          "punct": "will",
+          "index": 22
+        },
+        {
+          "start": 227.21,
+          "confidence": 1,
+          "end": 227.53,
+          "word": "cause",
+          "punct": "cause",
+          "index": 23
+        },
+        {
+          "start": 227.53,
+          "confidence": 1,
+          "end": 227.78,
+          "word": "people",
+          "punct": "people",
+          "index": 24
+        },
+        {
+          "start": 227.78,
+          "confidence": 1,
+          "end": 227.96,
+          "word": "to",
+          "punct": "to",
+          "index": 25
+        },
+        {
+          "start": 227.96,
+          "confidence": 1,
+          "end": 228.36,
+          "word": "name",
+          "punct": "name",
+          "index": 26
+        },
+        {
+          "start": 228.36,
+          "confidence": 1,
+          "end": 228.48,
+          "word": "the",
+          "punct": "the",
+          "index": 27
+        },
+        {
+          "start": 228.48,
+          "confidence": 0.745,
+          "end": 228.81,
+          "word": "room",
+          "punct": "room",
+          "index": 28
+        },
+        {
+          "start": 229.31,
+          "confidence": 1,
+          "end": 229.48,
+          "word": "and",
+          "punct": "and",
+          "index": 29
+        },
+        {
+          "start": 229.48,
+          "confidence": 1,
+          "end": 229.7,
+          "word": "feel",
+          "punct": "feel",
+          "index": 30
+        },
+        {
+          "start": 229.7,
+          "confidence": 1,
+          "end": 230.11,
+          "word": "bad",
+          "punct": "bad",
+          "index": 31
+        },
+        {
+          "start": 230.11,
+          "confidence": 1,
+          "end": 230.27,
+          "word": "for",
+          "punct": "for",
+          "index": 32
+        },
+        {
+          "start": 230.27,
+          "confidence": 1,
+          "end": 230.38,
+          "word": "the",
+          "punct": "the",
+          "index": 33
+        },
+        {
+          "start": 230.38,
+          "confidence": 0.708,
+          "end": 230.59,
+          "word": "room",
+          "punct": "room",
+          "index": 34
+        },
+        {
+          "start": 230.59,
+          "confidence": 0.608,
+          "end": 230.75,
+          "word": "but",
+          "punct": "but",
+          "index": 35
+        },
+        {
+          "start": 230.75,
+          "confidence": 0.833,
+          "end": 230.87,
+          "word": "when",
+          "punct": "when",
+          "index": 36
+        },
+        {
+          "start": 230.87,
+          "confidence": 0.22,
+          "end": 230.93,
+          "word": "it",
+          "punct": "it",
+          "index": 37
+        },
+        {
+          "start": 230.93,
+          "confidence": 0.356,
+          "end": 231.09,
+          "word": "gets",
+          "punct": "gets",
+          "index": 38
+        },
+        {
+          "start": 231.09,
+          "confidence": 1,
+          "end": 231.43,
+          "word": "stuck",
+          "punct": "stuck",
+          "index": 39
+        },
+        {
+          "start": 231.43,
+          "confidence": 1,
+          "end": 231.6,
+          "word": "under",
+          "punct": "under",
+          "index": 40
+        },
+        {
+          "start": 231.6,
+          "confidence": 1,
+          "end": 231.72,
+          "word": "the",
+          "punct": "the",
+          "index": 41
+        },
+        {
+          "start": 231.72,
+          "confidence": 0.995,
+          "end": 232.45,
+          "word": "couch",
+          "punct": "couch.",
+          "index": 42
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 221.68,
+        "end": 221.9,
+        "confidence": 1,
+        "text": "Just",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 221.9,
+        "end": 221.99,
+        "confidence": 0.416,
+        "text": "the",
+        "offset": 5,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 221.99,
+        "end": 222.48,
+        "confidence": 0.485,
+        "text": "desk",
+        "offset": 9,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 222.48,
+        "end": 222.68,
+        "confidence": 0.994,
+        "text": "that",
+        "offset": 14,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 222.68,
+        "end": 222.97,
+        "confidence": 0.398,
+        "text": "roams",
+        "offset": 19,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 222.97,
+        "end": 223.24,
+        "confidence": 1,
+        "text": "around",
+        "offset": 25,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 223.24,
+        "end": 223.35,
+        "confidence": 0.762,
+        "text": "your",
+        "offset": 32,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 223.35,
+        "end": 223.77,
+        "confidence": 0.286,
+        "text": "floor",
+        "offset": 37,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 223.77,
+        "end": 223.86,
+        "confidence": 0.286,
+        "text": "to",
+        "offset": 43,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 223.86,
+        "end": 224.23,
+        "confidence": 0.883,
+        "text": "clean",
+        "offset": 46,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 224.23,
+        "end": 224.45,
+        "confidence": 0.924,
+        "text": "it",
+        "offset": 52,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 224.77,
+        "end": 224.9,
+        "confidence": 0.436,
+        "text": "which",
+        "offset": 55,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 224.9,
+        "end": 225,
+        "confidence": 0.499,
+        "text": "is",
+        "offset": 61,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 225,
+        "end": 225.1,
+        "confidence": 0.849,
+        "text": "the",
+        "offset": 64,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 225.1,
+        "end": 225.43,
+        "confidence": 1,
+        "text": "fact",
+        "offset": 68,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 225.43,
+        "end": 225.56,
+        "confidence": 1,
+        "text": "that",
+        "offset": 73,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 225.56,
+        "end": 225.72,
+        "confidence": 0.872,
+        "text": "it's",
+        "offset": 78,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 225.72,
+        "end": 226.22,
+        "confidence": 1,
+        "text": "moving",
+        "offset": 83,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 226.22,
+        "end": 226.54,
+        "confidence": 1,
+        "text": "around",
+        "offset": 90,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 226.54,
+        "end": 226.66,
+        "confidence": 0.976,
+        "text": "on",
+        "offset": 97,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 226.66,
+        "end": 226.78,
+        "confidence": 0.713,
+        "text": "its",
+        "offset": 100,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 226.78,
+        "end": 227.09,
+        "confidence": 0.99,
+        "text": "own",
+        "offset": 104,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 227.09,
+        "end": 227.21,
+        "confidence": 0.767,
+        "text": "will",
+        "offset": 108,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 227.21,
+        "end": 227.53,
+        "confidence": 1,
+        "text": "cause",
+        "offset": 113,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 227.53,
+        "end": 227.78,
+        "confidence": 1,
+        "text": "people",
+        "offset": 119,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 227.78,
+        "end": 227.96,
+        "confidence": 1,
+        "text": "to",
+        "offset": 126,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 227.96,
+        "end": 228.36,
+        "confidence": 1,
+        "text": "name",
+        "offset": 129,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 228.36,
+        "end": 228.48,
+        "confidence": 1,
+        "text": "the",
+        "offset": 134,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 228.48,
+        "end": 228.81,
+        "confidence": 0.745,
+        "text": "room",
+        "offset": 138,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 229.31,
+        "end": 229.48,
+        "confidence": 1,
+        "text": "and",
+        "offset": 143,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 229.48,
+        "end": 229.7,
+        "confidence": 1,
+        "text": "feel",
+        "offset": 147,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 229.7,
+        "end": 230.11,
+        "confidence": 1,
+        "text": "bad",
+        "offset": 152,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 230.11,
+        "end": 230.27,
+        "confidence": 1,
+        "text": "for",
+        "offset": 156,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 230.27,
+        "end": 230.38,
+        "confidence": 1,
+        "text": "the",
+        "offset": 160,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 230.38,
+        "end": 230.59,
+        "confidence": 0.708,
+        "text": "room",
+        "offset": 164,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 230.59,
+        "end": 230.75,
+        "confidence": 0.608,
+        "text": "but",
+        "offset": 169,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 230.75,
+        "end": 230.87,
+        "confidence": 0.833,
+        "text": "when",
+        "offset": 173,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 230.87,
+        "end": 230.93,
+        "confidence": 0.22,
+        "text": "it",
+        "offset": 178,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 230.93,
+        "end": 231.09,
+        "confidence": 0.356,
+        "text": "gets",
+        "offset": 181,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 231.09,
+        "end": 231.43,
+        "confidence": 1,
+        "text": "stuck",
+        "offset": 186,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 231.43,
+        "end": 231.6,
+        "confidence": 1,
+        "text": "under",
+        "offset": 192,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 231.6,
+        "end": 231.72,
+        "confidence": 1,
+        "text": "the",
+        "offset": 198,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 231.72,
+        "end": 232.45,
+        "confidence": 0.995,
+        "text": "couch.",
+        "offset": 202,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And we can design robot specifically to invoke this response using our eyes and faces or movements the people automatically subconsciously associate with states of mind.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 234.43,
+      "words": [
+        {
+          "start": 234.43,
+          "confidence": 1,
+          "end": 234.59,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 234.59,
+          "confidence": 1,
+          "end": 234.71,
+          "word": "we",
+          "punct": "we",
+          "index": 1
+        },
+        {
+          "start": 234.71,
+          "confidence": 1,
+          "end": 234.85,
+          "word": "can",
+          "punct": "can",
+          "index": 2
+        },
+        {
+          "start": 234.85,
+          "confidence": 0.542,
+          "end": 235.28,
+          "word": "design",
+          "punct": "design",
+          "index": 3
+        },
+        {
+          "start": 235.28,
+          "confidence": 0.403,
+          "end": 235.65,
+          "word": "robot",
+          "punct": "robot",
+          "index": 4
+        },
+        {
+          "start": 235.65,
+          "confidence": 0.975,
+          "end": 236.48,
+          "word": "specifically",
+          "punct": "specifically",
+          "index": 5
+        },
+        {
+          "start": 236.48,
+          "confidence": 0.995,
+          "end": 236.63,
+          "word": "to",
+          "punct": "to",
+          "index": 6
+        },
+        {
+          "start": 236.63,
+          "confidence": 0.231,
+          "end": 236.99,
+          "word": "invoke",
+          "punct": "invoke",
+          "index": 7
+        },
+        {
+          "start": 236.99,
+          "confidence": 0.977,
+          "end": 237.18,
+          "word": "this",
+          "punct": "this",
+          "index": 8
+        },
+        {
+          "start": 237.18,
+          "confidence": 0.992,
+          "end": 237.74,
+          "word": "response",
+          "punct": "response",
+          "index": 9
+        },
+        {
+          "start": 237.74,
+          "confidence": 0.995,
+          "end": 238.14,
+          "word": "using",
+          "punct": "using",
+          "index": 10
+        },
+        {
+          "start": 238.2,
+          "confidence": 0.645,
+          "end": 238.37,
+          "word": "our",
+          "punct": "our",
+          "index": 11
+        },
+        {
+          "start": 238.37,
+          "confidence": 0.866,
+          "end": 238.91,
+          "word": "eyes",
+          "punct": "eyes",
+          "index": 12
+        },
+        {
+          "start": 239.18,
+          "confidence": 0.395,
+          "end": 239.36,
+          "word": "and",
+          "punct": "and",
+          "index": 13
+        },
+        {
+          "start": 239.36,
+          "confidence": 0.855,
+          "end": 240.22,
+          "word": "faces",
+          "punct": "faces",
+          "index": 14
+        },
+        {
+          "start": 240.3,
+          "confidence": 0.516,
+          "end": 240.6,
+          "word": "or",
+          "punct": "or",
+          "index": 15
+        },
+        {
+          "start": 240.6,
+          "confidence": 0.817,
+          "end": 241.26,
+          "word": "movements",
+          "punct": "movements",
+          "index": 16
+        },
+        {
+          "start": 241.26,
+          "confidence": 0.774,
+          "end": 241.37,
+          "word": "the",
+          "punct": "the",
+          "index": 17
+        },
+        {
+          "start": 241.37,
+          "confidence": 0.988,
+          "end": 241.66,
+          "word": "people",
+          "punct": "people",
+          "index": 18
+        },
+        {
+          "start": 241.66,
+          "confidence": 0.972,
+          "end": 242.51,
+          "word": "automatically",
+          "punct": "automatically",
+          "index": 19
+        },
+        {
+          "start": 242.51,
+          "confidence": 1,
+          "end": 243.45,
+          "word": "subconsciously",
+          "punct": "subconsciously",
+          "index": 20
+        },
+        {
+          "start": 243.45,
+          "confidence": 1,
+          "end": 244.37,
+          "word": "associate",
+          "punct": "associate",
+          "index": 21
+        },
+        {
+          "start": 244.49,
+          "confidence": 1,
+          "end": 244.73,
+          "word": "with",
+          "punct": "with",
+          "index": 22
+        },
+        {
+          "start": 244.73,
+          "confidence": 0.608,
+          "end": 245.06,
+          "word": "states",
+          "punct": "states",
+          "index": 23
+        },
+        {
+          "start": 245.06,
+          "confidence": 0.971,
+          "end": 245.17,
+          "word": "of",
+          "punct": "of",
+          "index": 24
+        },
+        {
+          "start": 245.17,
+          "confidence": 0.349,
+          "end": 245.71,
+          "word": "mind",
+          "punct": "mind.",
+          "index": 25
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 234.43,
+        "end": 234.59,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 234.59,
+        "end": 234.71,
+        "confidence": 1,
+        "text": "we",
+        "offset": 4,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 234.71,
+        "end": 234.85,
+        "confidence": 1,
+        "text": "can",
+        "offset": 7,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 234.85,
+        "end": 235.28,
+        "confidence": 0.542,
+        "text": "design",
+        "offset": 11,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 235.28,
+        "end": 235.65,
+        "confidence": 0.403,
+        "text": "robot",
+        "offset": 18,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 235.65,
+        "end": 236.48,
+        "confidence": 0.975,
+        "text": "specifically",
+        "offset": 24,
+        "length": 12,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 236.48,
+        "end": 236.63,
+        "confidence": 0.995,
+        "text": "to",
+        "offset": 37,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 236.63,
+        "end": 236.99,
+        "confidence": 0.231,
+        "text": "invoke",
+        "offset": 40,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 236.99,
+        "end": 237.18,
+        "confidence": 0.977,
+        "text": "this",
+        "offset": 47,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 237.18,
+        "end": 237.74,
+        "confidence": 0.992,
+        "text": "response",
+        "offset": 52,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 237.74,
+        "end": 238.14,
+        "confidence": 0.995,
+        "text": "using",
+        "offset": 61,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 238.2,
+        "end": 238.37,
+        "confidence": 0.645,
+        "text": "our",
+        "offset": 67,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 238.37,
+        "end": 238.91,
+        "confidence": 0.866,
+        "text": "eyes",
+        "offset": 71,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 239.18,
+        "end": 239.36,
+        "confidence": 0.395,
+        "text": "and",
+        "offset": 76,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 239.36,
+        "end": 240.22,
+        "confidence": 0.855,
+        "text": "faces",
+        "offset": 80,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 240.3,
+        "end": 240.6,
+        "confidence": 0.516,
+        "text": "or",
+        "offset": 86,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 240.6,
+        "end": 241.26,
+        "confidence": 0.817,
+        "text": "movements",
+        "offset": 89,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 241.26,
+        "end": 241.37,
+        "confidence": 0.774,
+        "text": "the",
+        "offset": 99,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 241.37,
+        "end": 241.66,
+        "confidence": 0.988,
+        "text": "people",
+        "offset": 103,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 241.66,
+        "end": 242.51,
+        "confidence": 0.972,
+        "text": "automatically",
+        "offset": 110,
+        "length": 13,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 242.51,
+        "end": 243.45,
+        "confidence": 1,
+        "text": "subconsciously",
+        "offset": 124,
+        "length": 14,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 243.45,
+        "end": 244.37,
+        "confidence": 1,
+        "text": "associate",
+        "offset": 139,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 244.49,
+        "end": 244.73,
+        "confidence": 1,
+        "text": "with",
+        "offset": 149,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 244.73,
+        "end": 245.06,
+        "confidence": 0.608,
+        "text": "states",
+        "offset": 154,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 245.06,
+        "end": 245.17,
+        "confidence": 0.971,
+        "text": "of",
+        "offset": 161,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 245.17,
+        "end": 245.71,
+        "confidence": 0.349,
+        "text": "mind.",
+        "offset": 164,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And there's an entire body of research called human robot interaction that really shows how well this works so for example researchers at Stanford University found out that it makes people really uncomfortable when you ask them to touch a robust private parts.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 246.57,
+      "words": [
+        {
+          "start": 246.57,
+          "confidence": 0.989,
+          "end": 246.71,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 246.71,
+          "confidence": 0.575,
+          "end": 246.85,
+          "word": "there's",
+          "punct": "there's",
+          "index": 1
+        },
+        {
+          "start": 246.85,
+          "confidence": 0.968,
+          "end": 246.95,
+          "word": "an",
+          "punct": "an",
+          "index": 2
+        },
+        {
+          "start": 246.95,
+          "confidence": 1,
+          "end": 247.34,
+          "word": "entire",
+          "punct": "entire",
+          "index": 3
+        },
+        {
+          "start": 247.34,
+          "confidence": 1,
+          "end": 247.57,
+          "word": "body",
+          "punct": "body",
+          "index": 4
+        },
+        {
+          "start": 247.57,
+          "confidence": 0.801,
+          "end": 247.68,
+          "word": "of",
+          "punct": "of",
+          "index": 5
+        },
+        {
+          "start": 247.68,
+          "confidence": 1,
+          "end": 248.09,
+          "word": "research",
+          "punct": "research",
+          "index": 6
+        },
+        {
+          "start": 248.09,
+          "confidence": 0.839,
+          "end": 248.32,
+          "word": "called",
+          "punct": "called",
+          "index": 7
+        },
+        {
+          "start": 248.32,
+          "confidence": 0.993,
+          "end": 248.56,
+          "word": "human",
+          "punct": "human",
+          "index": 8
+        },
+        {
+          "start": 248.56,
+          "confidence": 1,
+          "end": 248.85,
+          "word": "robot",
+          "punct": "robot",
+          "index": 9
+        },
+        {
+          "start": 248.85,
+          "confidence": 1,
+          "end": 249.34,
+          "word": "interaction",
+          "punct": "interaction",
+          "index": 10
+        },
+        {
+          "start": 249.34,
+          "confidence": 0.575,
+          "end": 249.54,
+          "word": "that",
+          "punct": "that",
+          "index": 11
+        },
+        {
+          "start": 249.65,
+          "confidence": 1,
+          "end": 249.9,
+          "word": "really",
+          "punct": "really",
+          "index": 12
+        },
+        {
+          "start": 249.9,
+          "confidence": 1,
+          "end": 250.38,
+          "word": "shows",
+          "punct": "shows",
+          "index": 13
+        },
+        {
+          "start": 250.38,
+          "confidence": 1,
+          "end": 250.51,
+          "word": "how",
+          "punct": "how",
+          "index": 14
+        },
+        {
+          "start": 250.51,
+          "confidence": 1,
+          "end": 250.69,
+          "word": "well",
+          "punct": "well",
+          "index": 15
+        },
+        {
+          "start": 250.69,
+          "confidence": 1,
+          "end": 250.87,
+          "word": "this",
+          "punct": "this",
+          "index": 16
+        },
+        {
+          "start": 250.87,
+          "confidence": 1,
+          "end": 251.33,
+          "word": "works",
+          "punct": "works",
+          "index": 17
+        },
+        {
+          "start": 251.67,
+          "confidence": 1,
+          "end": 251.85,
+          "word": "so",
+          "punct": "so",
+          "index": 18
+        },
+        {
+          "start": 251.85,
+          "confidence": 1,
+          "end": 252.01,
+          "word": "for",
+          "punct": "for",
+          "index": 19
+        },
+        {
+          "start": 252.01,
+          "confidence": 1,
+          "end": 252.54,
+          "word": "example",
+          "punct": "example",
+          "index": 20
+        },
+        {
+          "start": 252.54,
+          "confidence": 1,
+          "end": 253.11,
+          "word": "researchers",
+          "punct": "researchers",
+          "index": 21
+        },
+        {
+          "start": 253.11,
+          "confidence": 1,
+          "end": 253.31,
+          "word": "at",
+          "punct": "at",
+          "index": 22
+        },
+        {
+          "start": 253.41,
+          "confidence": 1,
+          "end": 253.96,
+          "word": "Stanford",
+          "punct": "Stanford",
+          "index": 23
+        },
+        {
+          "start": 253.96,
+          "confidence": 1,
+          "end": 254.46,
+          "word": "University",
+          "punct": "University",
+          "index": 24
+        },
+        {
+          "start": 254.46,
+          "confidence": 1,
+          "end": 254.74,
+          "word": "found",
+          "punct": "found",
+          "index": 25
+        },
+        {
+          "start": 254.74,
+          "confidence": 1,
+          "end": 254.92,
+          "word": "out",
+          "punct": "out",
+          "index": 26
+        },
+        {
+          "start": 254.92,
+          "confidence": 0.99,
+          "end": 255.03,
+          "word": "that",
+          "punct": "that",
+          "index": 27
+        },
+        {
+          "start": 255.03,
+          "confidence": 0.548,
+          "end": 255.09,
+          "word": "it",
+          "punct": "it",
+          "index": 28
+        },
+        {
+          "start": 255.09,
+          "confidence": 1,
+          "end": 255.3,
+          "word": "makes",
+          "punct": "makes",
+          "index": 29
+        },
+        {
+          "start": 255.3,
+          "confidence": 1,
+          "end": 255.63,
+          "word": "people",
+          "punct": "people",
+          "index": 30
+        },
+        {
+          "start": 255.63,
+          "confidence": 1,
+          "end": 255.9,
+          "word": "really",
+          "punct": "really",
+          "index": 31
+        },
+        {
+          "start": 255.9,
+          "confidence": 0.818,
+          "end": 256.55,
+          "word": "uncomfortable",
+          "punct": "uncomfortable",
+          "index": 32
+        },
+        {
+          "start": 256.55,
+          "confidence": 0.711,
+          "end": 256.67,
+          "word": "when",
+          "punct": "when",
+          "index": 33
+        },
+        {
+          "start": 256.67,
+          "confidence": 0.847,
+          "end": 256.75,
+          "word": "you",
+          "punct": "you",
+          "index": 34
+        },
+        {
+          "start": 256.75,
+          "confidence": 0.638,
+          "end": 257.04,
+          "word": "ask",
+          "punct": "ask",
+          "index": 35
+        },
+        {
+          "start": 257.04,
+          "confidence": 0.633,
+          "end": 257.15,
+          "word": "them",
+          "punct": "them",
+          "index": 36
+        },
+        {
+          "start": 257.15,
+          "confidence": 1,
+          "end": 257.26,
+          "word": "to",
+          "punct": "to",
+          "index": 37
+        },
+        {
+          "start": 257.26,
+          "confidence": 0.973,
+          "end": 257.52,
+          "word": "touch",
+          "punct": "touch",
+          "index": 38
+        },
+        {
+          "start": 257.52,
+          "confidence": 0.378,
+          "end": 257.59,
+          "word": "a",
+          "punct": "a",
+          "index": 39
+        },
+        {
+          "start": 257.59,
+          "confidence": 0.058,
+          "end": 257.98,
+          "word": "robust",
+          "punct": "robust",
+          "index": 40
+        },
+        {
+          "start": 257.98,
+          "confidence": 1,
+          "end": 258.36,
+          "word": "private",
+          "punct": "private",
+          "index": 41
+        },
+        {
+          "start": 258.36,
+          "confidence": 0.681,
+          "end": 258.95,
+          "word": "parts",
+          "punct": "parts.",
+          "index": 42
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 246.57,
+        "end": 246.71,
+        "confidence": 0.989,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 246.71,
+        "end": 246.85,
+        "confidence": 0.575,
+        "text": "there's",
+        "offset": 4,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 246.85,
+        "end": 246.95,
+        "confidence": 0.968,
+        "text": "an",
+        "offset": 12,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 246.95,
+        "end": 247.34,
+        "confidence": 1,
+        "text": "entire",
+        "offset": 15,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 247.34,
+        "end": 247.57,
+        "confidence": 1,
+        "text": "body",
+        "offset": 22,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 247.57,
+        "end": 247.68,
+        "confidence": 0.801,
+        "text": "of",
+        "offset": 27,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 247.68,
+        "end": 248.09,
+        "confidence": 1,
+        "text": "research",
+        "offset": 30,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 248.09,
+        "end": 248.32,
+        "confidence": 0.839,
+        "text": "called",
+        "offset": 39,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 248.32,
+        "end": 248.56,
+        "confidence": 0.993,
+        "text": "human",
+        "offset": 46,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 248.56,
+        "end": 248.85,
+        "confidence": 1,
+        "text": "robot",
+        "offset": 52,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 248.85,
+        "end": 249.34,
+        "confidence": 1,
+        "text": "interaction",
+        "offset": 58,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 249.34,
+        "end": 249.54,
+        "confidence": 0.575,
+        "text": "that",
+        "offset": 70,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 249.65,
+        "end": 249.9,
+        "confidence": 1,
+        "text": "really",
+        "offset": 75,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 249.9,
+        "end": 250.38,
+        "confidence": 1,
+        "text": "shows",
+        "offset": 82,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 250.38,
+        "end": 250.51,
+        "confidence": 1,
+        "text": "how",
+        "offset": 88,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 250.51,
+        "end": 250.69,
+        "confidence": 1,
+        "text": "well",
+        "offset": 92,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 250.69,
+        "end": 250.87,
+        "confidence": 1,
+        "text": "this",
+        "offset": 97,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 250.87,
+        "end": 251.33,
+        "confidence": 1,
+        "text": "works",
+        "offset": 102,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 251.67,
+        "end": 251.85,
+        "confidence": 1,
+        "text": "so",
+        "offset": 108,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 251.85,
+        "end": 252.01,
+        "confidence": 1,
+        "text": "for",
+        "offset": 111,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 252.01,
+        "end": 252.54,
+        "confidence": 1,
+        "text": "example",
+        "offset": 115,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 252.54,
+        "end": 253.11,
+        "confidence": 1,
+        "text": "researchers",
+        "offset": 123,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 253.11,
+        "end": 253.31,
+        "confidence": 1,
+        "text": "at",
+        "offset": 135,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 253.41,
+        "end": 253.96,
+        "confidence": 1,
+        "text": "Stanford",
+        "offset": 138,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 253.96,
+        "end": 254.46,
+        "confidence": 1,
+        "text": "University",
+        "offset": 147,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 254.46,
+        "end": 254.74,
+        "confidence": 1,
+        "text": "found",
+        "offset": 158,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 254.74,
+        "end": 254.92,
+        "confidence": 1,
+        "text": "out",
+        "offset": 164,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 254.92,
+        "end": 255.03,
+        "confidence": 0.99,
+        "text": "that",
+        "offset": 168,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 255.03,
+        "end": 255.09,
+        "confidence": 0.548,
+        "text": "it",
+        "offset": 173,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 255.09,
+        "end": 255.3,
+        "confidence": 1,
+        "text": "makes",
+        "offset": 176,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 255.3,
+        "end": 255.63,
+        "confidence": 1,
+        "text": "people",
+        "offset": 182,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 255.63,
+        "end": 255.9,
+        "confidence": 1,
+        "text": "really",
+        "offset": 189,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 255.9,
+        "end": 256.55,
+        "confidence": 0.818,
+        "text": "uncomfortable",
+        "offset": 196,
+        "length": 13,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 256.55,
+        "end": 256.67,
+        "confidence": 0.711,
+        "text": "when",
+        "offset": 210,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 256.67,
+        "end": 256.75,
+        "confidence": 0.847,
+        "text": "you",
+        "offset": 215,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 256.75,
+        "end": 257.04,
+        "confidence": 0.638,
+        "text": "ask",
+        "offset": 219,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 257.04,
+        "end": 257.15,
+        "confidence": 0.633,
+        "text": "them",
+        "offset": 223,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 257.15,
+        "end": 257.26,
+        "confidence": 1,
+        "text": "to",
+        "offset": 228,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 257.26,
+        "end": 257.52,
+        "confidence": 0.973,
+        "text": "touch",
+        "offset": 231,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 257.52,
+        "end": 257.59,
+        "confidence": 0.378,
+        "text": "a",
+        "offset": 237,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 257.59,
+        "end": 257.98,
+        "confidence": 0.058,
+        "text": "robust",
+        "offset": 239,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 257.98,
+        "end": 258.36,
+        "confidence": 1,
+        "text": "private",
+        "offset": 246,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 258.36,
+        "end": 258.95,
+        "confidence": 0.681,
+        "text": "parts.",
+        "offset": 254,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "So from this but from many other studies we know we know the people respond to the cues given to them by these life like machines even if they know that they're not real.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 261.63,
+      "words": [
+        {
+          "start": 261.63,
+          "confidence": 0.234,
+          "end": 261.73,
+          "word": "so",
+          "punct": "So",
+          "index": 0
+        },
+        {
+          "start": 261.73,
+          "confidence": 0.863,
+          "end": 261.92,
+          "word": "from",
+          "punct": "from",
+          "index": 1
+        },
+        {
+          "start": 261.92,
+          "confidence": 0.472,
+          "end": 262.08,
+          "word": "this",
+          "punct": "this",
+          "index": 2
+        },
+        {
+          "start": 262.08,
+          "confidence": 0.651,
+          "end": 262.26,
+          "word": "but",
+          "punct": "but",
+          "index": 3
+        },
+        {
+          "start": 262.26,
+          "confidence": 0.524,
+          "end": 262.45,
+          "word": "from",
+          "punct": "from",
+          "index": 4
+        },
+        {
+          "start": 262.45,
+          "confidence": 0.94,
+          "end": 262.79,
+          "word": "many",
+          "punct": "many",
+          "index": 5
+        },
+        {
+          "start": 262.79,
+          "confidence": 0.841,
+          "end": 262.96,
+          "word": "other",
+          "punct": "other",
+          "index": 6
+        },
+        {
+          "start": 262.96,
+          "confidence": 0.924,
+          "end": 263.36,
+          "word": "studies",
+          "punct": "studies",
+          "index": 7
+        },
+        {
+          "start": 263.36,
+          "confidence": 0.947,
+          "end": 263.55,
+          "word": "we",
+          "punct": "we",
+          "index": 8
+        },
+        {
+          "start": 263.55,
+          "confidence": 0.384,
+          "end": 264.11,
+          "word": "know",
+          "punct": "know",
+          "index": 9
+        },
+        {
+          "start": 264.39,
+          "confidence": 1,
+          "end": 264.65,
+          "word": "we",
+          "punct": "we",
+          "index": 10
+        },
+        {
+          "start": 264.65,
+          "confidence": 0.984,
+          "end": 265.03,
+          "word": "know",
+          "punct": "know",
+          "index": 11
+        },
+        {
+          "start": 265.03,
+          "confidence": 0.538,
+          "end": 265.22,
+          "word": "the",
+          "punct": "the",
+          "index": 12
+        },
+        {
+          "start": 265.22,
+          "confidence": 0.953,
+          "end": 265.77,
+          "word": "people",
+          "punct": "people",
+          "index": 13
+        },
+        {
+          "start": 265.77,
+          "confidence": 1,
+          "end": 266.41,
+          "word": "respond",
+          "punct": "respond",
+          "index": 14
+        },
+        {
+          "start": 266.41,
+          "confidence": 1,
+          "end": 266.51,
+          "word": "to",
+          "punct": "to",
+          "index": 15
+        },
+        {
+          "start": 266.51,
+          "confidence": 1,
+          "end": 266.63,
+          "word": "the",
+          "punct": "the",
+          "index": 16
+        },
+        {
+          "start": 266.63,
+          "confidence": 0.999,
+          "end": 267.24,
+          "word": "cues",
+          "punct": "cues",
+          "index": 17
+        },
+        {
+          "start": 267.27,
+          "confidence": 0.968,
+          "end": 267.55,
+          "word": "given",
+          "punct": "given",
+          "index": 18
+        },
+        {
+          "start": 267.55,
+          "confidence": 1,
+          "end": 267.66,
+          "word": "to",
+          "punct": "to",
+          "index": 19
+        },
+        {
+          "start": 267.66,
+          "confidence": 1,
+          "end": 267.84,
+          "word": "them",
+          "punct": "them",
+          "index": 20
+        },
+        {
+          "start": 267.84,
+          "confidence": 1,
+          "end": 267.98,
+          "word": "by",
+          "punct": "by",
+          "index": 21
+        },
+        {
+          "start": 267.98,
+          "confidence": 0.383,
+          "end": 268.2,
+          "word": "these",
+          "punct": "these",
+          "index": 22
+        },
+        {
+          "start": 268.2,
+          "confidence": 0.823,
+          "end": 268.5,
+          "word": "life",
+          "punct": "life",
+          "index": 23
+        },
+        {
+          "start": 268.5,
+          "confidence": 0.857,
+          "end": 268.68,
+          "word": "like",
+          "punct": "like",
+          "index": 24
+        },
+        {
+          "start": 268.68,
+          "confidence": 0.99,
+          "end": 269.45,
+          "word": "machines",
+          "punct": "machines",
+          "index": 25
+        },
+        {
+          "start": 269.88,
+          "confidence": 1,
+          "end": 270.19,
+          "word": "even",
+          "punct": "even",
+          "index": 26
+        },
+        {
+          "start": 270.19,
+          "confidence": 0.56,
+          "end": 270.29,
+          "word": "if",
+          "punct": "if",
+          "index": 27
+        },
+        {
+          "start": 270.29,
+          "confidence": 1,
+          "end": 270.4,
+          "word": "they",
+          "punct": "they",
+          "index": 28
+        },
+        {
+          "start": 270.4,
+          "confidence": 1,
+          "end": 270.64,
+          "word": "know",
+          "punct": "know",
+          "index": 29
+        },
+        {
+          "start": 270.64,
+          "confidence": 1,
+          "end": 270.82,
+          "word": "that",
+          "punct": "that",
+          "index": 30
+        },
+        {
+          "start": 270.82,
+          "confidence": 0.785,
+          "end": 271,
+          "word": "they're",
+          "punct": "they're",
+          "index": 31
+        },
+        {
+          "start": 271,
+          "confidence": 1,
+          "end": 271.24,
+          "word": "not",
+          "punct": "not",
+          "index": 32
+        },
+        {
+          "start": 271.24,
+          "confidence": 0.992,
+          "end": 271.59,
+          "word": "real",
+          "punct": "real.",
+          "index": 33
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 261.63,
+        "end": 261.73,
+        "confidence": 0.234,
+        "text": "So",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 261.73,
+        "end": 261.92,
+        "confidence": 0.863,
+        "text": "from",
+        "offset": 3,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 261.92,
+        "end": 262.08,
+        "confidence": 0.472,
+        "text": "this",
+        "offset": 8,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 262.08,
+        "end": 262.26,
+        "confidence": 0.651,
+        "text": "but",
+        "offset": 13,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 262.26,
+        "end": 262.45,
+        "confidence": 0.524,
+        "text": "from",
+        "offset": 17,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 262.45,
+        "end": 262.79,
+        "confidence": 0.94,
+        "text": "many",
+        "offset": 22,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 262.79,
+        "end": 262.96,
+        "confidence": 0.841,
+        "text": "other",
+        "offset": 27,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 262.96,
+        "end": 263.36,
+        "confidence": 0.924,
+        "text": "studies",
+        "offset": 33,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 263.36,
+        "end": 263.55,
+        "confidence": 0.947,
+        "text": "we",
+        "offset": 41,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 263.55,
+        "end": 264.11,
+        "confidence": 0.384,
+        "text": "know",
+        "offset": 44,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 264.39,
+        "end": 264.65,
+        "confidence": 1,
+        "text": "we",
+        "offset": 49,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 264.65,
+        "end": 265.03,
+        "confidence": 0.984,
+        "text": "know",
+        "offset": 52,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 265.03,
+        "end": 265.22,
+        "confidence": 0.538,
+        "text": "the",
+        "offset": 57,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 265.22,
+        "end": 265.77,
+        "confidence": 0.953,
+        "text": "people",
+        "offset": 61,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 265.77,
+        "end": 266.41,
+        "confidence": 1,
+        "text": "respond",
+        "offset": 68,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 266.41,
+        "end": 266.51,
+        "confidence": 1,
+        "text": "to",
+        "offset": 76,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 266.51,
+        "end": 266.63,
+        "confidence": 1,
+        "text": "the",
+        "offset": 79,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 266.63,
+        "end": 267.24,
+        "confidence": 0.999,
+        "text": "cues",
+        "offset": 83,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 267.27,
+        "end": 267.55,
+        "confidence": 0.968,
+        "text": "given",
+        "offset": 88,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 267.55,
+        "end": 267.66,
+        "confidence": 1,
+        "text": "to",
+        "offset": 94,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 267.66,
+        "end": 267.84,
+        "confidence": 1,
+        "text": "them",
+        "offset": 97,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 267.84,
+        "end": 267.98,
+        "confidence": 1,
+        "text": "by",
+        "offset": 102,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 267.98,
+        "end": 268.2,
+        "confidence": 0.383,
+        "text": "these",
+        "offset": 105,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 268.2,
+        "end": 268.5,
+        "confidence": 0.823,
+        "text": "life",
+        "offset": 111,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 268.5,
+        "end": 268.68,
+        "confidence": 0.857,
+        "text": "like",
+        "offset": 116,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 268.68,
+        "end": 269.45,
+        "confidence": 0.99,
+        "text": "machines",
+        "offset": 121,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 269.88,
+        "end": 270.19,
+        "confidence": 1,
+        "text": "even",
+        "offset": 130,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 270.19,
+        "end": 270.29,
+        "confidence": 0.56,
+        "text": "if",
+        "offset": 135,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 270.29,
+        "end": 270.4,
+        "confidence": 1,
+        "text": "they",
+        "offset": 138,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 270.4,
+        "end": 270.64,
+        "confidence": 1,
+        "text": "know",
+        "offset": 143,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 270.64,
+        "end": 270.82,
+        "confidence": 1,
+        "text": "that",
+        "offset": 148,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 270.82,
+        "end": 271,
+        "confidence": 0.785,
+        "text": "they're",
+        "offset": 153,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 271,
+        "end": 271.24,
+        "confidence": 1,
+        "text": "not",
+        "offset": 161,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 271.24,
+        "end": 271.59,
+        "confidence": 0.992,
+        "text": "real.",
+        "offset": 165,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Now we're headed towards a world where robots are everywhere robotic technology is moving out from behind factory walls it's entering workplaces households and as these machines that can fence and make autonomous decisions and learn enter into the shared spaces I think that maybe the best analogy we have for this is our relationship with animals thousands of years ago we started to domesticate animals and we train them for work and weaponry and companionship and throughout history was treated some animals like tools or like products and other animals we treated with kindness we've given a place in society as our companions.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 273.6,
+      "words": [
+        {
+          "start": 273.6,
+          "confidence": 0.999,
+          "end": 274.14,
+          "word": "now",
+          "punct": "Now",
+          "index": 0
+        },
+        {
+          "start": 274.49,
+          "confidence": 0.706,
+          "end": 274.66,
+          "word": "we're",
+          "punct": "we're",
+          "index": 1
+        },
+        {
+          "start": 274.66,
+          "confidence": 1,
+          "end": 274.95,
+          "word": "headed",
+          "punct": "headed",
+          "index": 2
+        },
+        {
+          "start": 274.95,
+          "confidence": 0.729,
+          "end": 275.2,
+          "word": "towards",
+          "punct": "towards",
+          "index": 3
+        },
+        {
+          "start": 275.2,
+          "confidence": 0.692,
+          "end": 275.26,
+          "word": "a",
+          "punct": "a",
+          "index": 4
+        },
+        {
+          "start": 275.26,
+          "confidence": 0.993,
+          "end": 275.69,
+          "word": "world",
+          "punct": "world",
+          "index": 5
+        },
+        {
+          "start": 275.69,
+          "confidence": 1,
+          "end": 275.85,
+          "word": "where",
+          "punct": "where",
+          "index": 6
+        },
+        {
+          "start": 275.85,
+          "confidence": 1,
+          "end": 276.32,
+          "word": "robots",
+          "punct": "robots",
+          "index": 7
+        },
+        {
+          "start": 276.32,
+          "confidence": 1,
+          "end": 276.52,
+          "word": "are",
+          "punct": "are",
+          "index": 8
+        },
+        {
+          "start": 276.55,
+          "confidence": 0.996,
+          "end": 277.13,
+          "word": "everywhere",
+          "punct": "everywhere",
+          "index": 9
+        },
+        {
+          "start": 277.66,
+          "confidence": 1,
+          "end": 278.03,
+          "word": "robotic",
+          "punct": "robotic",
+          "index": 10
+        },
+        {
+          "start": 278.03,
+          "confidence": 1,
+          "end": 278.57,
+          "word": "technology",
+          "punct": "technology",
+          "index": 11
+        },
+        {
+          "start": 278.57,
+          "confidence": 1,
+          "end": 278.82,
+          "word": "is",
+          "punct": "is",
+          "index": 12
+        },
+        {
+          "start": 278.82,
+          "confidence": 1,
+          "end": 279.21,
+          "word": "moving",
+          "punct": "moving",
+          "index": 13
+        },
+        {
+          "start": 279.21,
+          "confidence": 1,
+          "end": 279.4,
+          "word": "out",
+          "punct": "out",
+          "index": 14
+        },
+        {
+          "start": 279.4,
+          "confidence": 1,
+          "end": 279.55,
+          "word": "from",
+          "punct": "from",
+          "index": 15
+        },
+        {
+          "start": 279.55,
+          "confidence": 0.983,
+          "end": 279.82,
+          "word": "behind",
+          "punct": "behind",
+          "index": 16
+        },
+        {
+          "start": 279.82,
+          "confidence": 0.995,
+          "end": 280.24,
+          "word": "factory",
+          "punct": "factory",
+          "index": 17
+        },
+        {
+          "start": 280.24,
+          "confidence": 0.974,
+          "end": 280.76,
+          "word": "walls",
+          "punct": "walls",
+          "index": 18
+        },
+        {
+          "start": 280.76,
+          "confidence": 0.759,
+          "end": 280.95,
+          "word": "it's",
+          "punct": "it's",
+          "index": 19
+        },
+        {
+          "start": 280.95,
+          "confidence": 0.91,
+          "end": 281.38,
+          "word": "entering",
+          "punct": "entering",
+          "index": 20
+        },
+        {
+          "start": 281.41,
+          "confidence": 0.077,
+          "end": 282.31,
+          "word": "workplaces",
+          "punct": "workplaces",
+          "index": 21
+        },
+        {
+          "start": 282.31,
+          "confidence": 1,
+          "end": 283.32,
+          "word": "households",
+          "punct": "households",
+          "index": 22
+        },
+        {
+          "start": 283.82,
+          "confidence": 0.897,
+          "end": 284.1,
+          "word": "and",
+          "punct": "and",
+          "index": 23
+        },
+        {
+          "start": 284.13,
+          "confidence": 0.876,
+          "end": 284.33,
+          "word": "as",
+          "punct": "as",
+          "index": 24
+        },
+        {
+          "start": 284.33,
+          "confidence": 1,
+          "end": 284.53,
+          "word": "these",
+          "punct": "these",
+          "index": 25
+        },
+        {
+          "start": 284.53,
+          "confidence": 1,
+          "end": 285.21,
+          "word": "machines",
+          "punct": "machines",
+          "index": 26
+        },
+        {
+          "start": 285.21,
+          "confidence": 0.624,
+          "end": 285.36,
+          "word": "that",
+          "punct": "that",
+          "index": 27
+        },
+        {
+          "start": 285.36,
+          "confidence": 1,
+          "end": 285.86,
+          "word": "can",
+          "punct": "can",
+          "index": 28
+        },
+        {
+          "start": 285.89,
+          "confidence": 0.598,
+          "end": 286.57,
+          "word": "fence",
+          "punct": "fence",
+          "index": 29
+        },
+        {
+          "start": 286.57,
+          "confidence": 0.859,
+          "end": 286.98,
+          "word": "and",
+          "punct": "and",
+          "index": 30
+        },
+        {
+          "start": 287.21,
+          "confidence": 1,
+          "end": 287.43,
+          "word": "make",
+          "punct": "make",
+          "index": 31
+        },
+        {
+          "start": 287.43,
+          "confidence": 1,
+          "end": 288.01,
+          "word": "autonomous",
+          "punct": "autonomous",
+          "index": 32
+        },
+        {
+          "start": 288.01,
+          "confidence": 1,
+          "end": 288.67,
+          "word": "decisions",
+          "punct": "decisions",
+          "index": 33
+        },
+        {
+          "start": 288.67,
+          "confidence": 0.396,
+          "end": 288.91,
+          "word": "and",
+          "punct": "and",
+          "index": 34
+        },
+        {
+          "start": 288.91,
+          "confidence": 0.519,
+          "end": 289.54,
+          "word": "learn",
+          "punct": "learn",
+          "index": 35
+        },
+        {
+          "start": 290.05,
+          "confidence": 0.77,
+          "end": 290.37,
+          "word": "enter",
+          "punct": "enter",
+          "index": 36
+        },
+        {
+          "start": 290.37,
+          "confidence": 0.898,
+          "end": 290.57,
+          "word": "into",
+          "punct": "into",
+          "index": 37
+        },
+        {
+          "start": 290.57,
+          "confidence": 0.566,
+          "end": 290.7,
+          "word": "the",
+          "punct": "the",
+          "index": 38
+        },
+        {
+          "start": 290.7,
+          "confidence": 0.941,
+          "end": 291.07,
+          "word": "shared",
+          "punct": "shared",
+          "index": 39
+        },
+        {
+          "start": 291.07,
+          "confidence": 0.996,
+          "end": 292.1,
+          "word": "spaces",
+          "punct": "spaces",
+          "index": 40
+        },
+        {
+          "start": 292.64,
+          "confidence": 1,
+          "end": 292.76,
+          "word": "I",
+          "punct": "I",
+          "index": 41
+        },
+        {
+          "start": 292.76,
+          "confidence": 1,
+          "end": 292.99,
+          "word": "think",
+          "punct": "think",
+          "index": 42
+        },
+        {
+          "start": 292.99,
+          "confidence": 1,
+          "end": 293.18,
+          "word": "that",
+          "punct": "that",
+          "index": 43
+        },
+        {
+          "start": 293.18,
+          "confidence": 0.772,
+          "end": 293.41,
+          "word": "maybe",
+          "punct": "maybe",
+          "index": 44
+        },
+        {
+          "start": 293.41,
+          "confidence": 1,
+          "end": 293.51,
+          "word": "the",
+          "punct": "the",
+          "index": 45
+        },
+        {
+          "start": 293.51,
+          "confidence": 1,
+          "end": 293.75,
+          "word": "best",
+          "punct": "best",
+          "index": 46
+        },
+        {
+          "start": 293.75,
+          "confidence": 1,
+          "end": 294.31,
+          "word": "analogy",
+          "punct": "analogy",
+          "index": 47
+        },
+        {
+          "start": 294.31,
+          "confidence": 1,
+          "end": 294.42,
+          "word": "we",
+          "punct": "we",
+          "index": 48
+        },
+        {
+          "start": 294.42,
+          "confidence": 1,
+          "end": 294.7,
+          "word": "have",
+          "punct": "have",
+          "index": 49
+        },
+        {
+          "start": 294.7,
+          "confidence": 1,
+          "end": 294.83,
+          "word": "for",
+          "punct": "for",
+          "index": 50
+        },
+        {
+          "start": 294.83,
+          "confidence": 1,
+          "end": 295.06,
+          "word": "this",
+          "punct": "this",
+          "index": 51
+        },
+        {
+          "start": 295.06,
+          "confidence": 0.799,
+          "end": 295.18,
+          "word": "is",
+          "punct": "is",
+          "index": 52
+        },
+        {
+          "start": 295.18,
+          "confidence": 0.761,
+          "end": 295.31,
+          "word": "our",
+          "punct": "our",
+          "index": 53
+        },
+        {
+          "start": 295.31,
+          "confidence": 1,
+          "end": 296.02,
+          "word": "relationship",
+          "punct": "relationship",
+          "index": 54
+        },
+        {
+          "start": 296.02,
+          "confidence": 1,
+          "end": 296.2,
+          "word": "with",
+          "punct": "with",
+          "index": 55
+        },
+        {
+          "start": 296.23,
+          "confidence": 0.997,
+          "end": 296.99,
+          "word": "animals",
+          "punct": "animals",
+          "index": 56
+        },
+        {
+          "start": 297.48,
+          "confidence": 1,
+          "end": 297.97,
+          "word": "thousands",
+          "punct": "thousands",
+          "index": 57
+        },
+        {
+          "start": 297.97,
+          "confidence": 1,
+          "end": 298.06,
+          "word": "of",
+          "punct": "of",
+          "index": 58
+        },
+        {
+          "start": 298.06,
+          "confidence": 1,
+          "end": 298.3,
+          "word": "years",
+          "punct": "years",
+          "index": 59
+        },
+        {
+          "start": 298.3,
+          "confidence": 1,
+          "end": 298.84,
+          "word": "ago",
+          "punct": "ago",
+          "index": 60
+        },
+        {
+          "start": 299.11,
+          "confidence": 1,
+          "end": 299.44,
+          "word": "we",
+          "punct": "we",
+          "index": 61
+        },
+        {
+          "start": 299.44,
+          "confidence": 1,
+          "end": 299.76,
+          "word": "started",
+          "punct": "started",
+          "index": 62
+        },
+        {
+          "start": 299.76,
+          "confidence": 1,
+          "end": 299.85,
+          "word": "to",
+          "punct": "to",
+          "index": 63
+        },
+        {
+          "start": 299.85,
+          "confidence": 0.843,
+          "end": 300.47,
+          "word": "domesticate",
+          "punct": "domesticate",
+          "index": 64
+        },
+        {
+          "start": 300.47,
+          "confidence": 0.991,
+          "end": 301.15,
+          "word": "animals",
+          "punct": "animals",
+          "index": 65
+        },
+        {
+          "start": 301.41,
+          "confidence": 0.687,
+          "end": 301.54,
+          "word": "and",
+          "punct": "and",
+          "index": 66
+        },
+        {
+          "start": 301.54,
+          "confidence": 1,
+          "end": 301.64,
+          "word": "we",
+          "punct": "we",
+          "index": 67
+        },
+        {
+          "start": 301.64,
+          "confidence": 0.841,
+          "end": 301.96,
+          "word": "train",
+          "punct": "train",
+          "index": 68
+        },
+        {
+          "start": 301.96,
+          "confidence": 0.97,
+          "end": 302.12,
+          "word": "them",
+          "punct": "them",
+          "index": 69
+        },
+        {
+          "start": 302.12,
+          "confidence": 1,
+          "end": 302.3,
+          "word": "for",
+          "punct": "for",
+          "index": 70
+        },
+        {
+          "start": 302.3,
+          "confidence": 0.994,
+          "end": 302.88,
+          "word": "work",
+          "punct": "work",
+          "index": 71
+        },
+        {
+          "start": 302.91,
+          "confidence": 1,
+          "end": 303.14,
+          "word": "and",
+          "punct": "and",
+          "index": 72
+        },
+        {
+          "start": 303.14,
+          "confidence": 1,
+          "end": 303.83,
+          "word": "weaponry",
+          "punct": "weaponry",
+          "index": 73
+        },
+        {
+          "start": 303.86,
+          "confidence": 0.598,
+          "end": 303.97,
+          "word": "and",
+          "punct": "and",
+          "index": 74
+        },
+        {
+          "start": 303.97,
+          "confidence": 1,
+          "end": 304.88,
+          "word": "companionship",
+          "punct": "companionship",
+          "index": 75
+        },
+        {
+          "start": 305.51,
+          "confidence": 1,
+          "end": 305.66,
+          "word": "and",
+          "punct": "and",
+          "index": 76
+        },
+        {
+          "start": 305.66,
+          "confidence": 0.637,
+          "end": 305.9,
+          "word": "throughout",
+          "punct": "throughout",
+          "index": 77
+        },
+        {
+          "start": 305.9,
+          "confidence": 0.987,
+          "end": 306.42,
+          "word": "history",
+          "punct": "history",
+          "index": 78
+        },
+        {
+          "start": 306.42,
+          "confidence": 0.271,
+          "end": 306.57,
+          "word": "was",
+          "punct": "was",
+          "index": 79
+        },
+        {
+          "start": 306.57,
+          "confidence": 0.577,
+          "end": 306.92,
+          "word": "treated",
+          "punct": "treated",
+          "index": 80
+        },
+        {
+          "start": 306.92,
+          "confidence": 1,
+          "end": 307.17,
+          "word": "some",
+          "punct": "some",
+          "index": 81
+        },
+        {
+          "start": 307.17,
+          "confidence": 1,
+          "end": 307.74,
+          "word": "animals",
+          "punct": "animals",
+          "index": 82
+        },
+        {
+          "start": 307.74,
+          "confidence": 0.97,
+          "end": 307.93,
+          "word": "like",
+          "punct": "like",
+          "index": 83
+        },
+        {
+          "start": 307.93,
+          "confidence": 0.977,
+          "end": 308.58,
+          "word": "tools",
+          "punct": "tools",
+          "index": 84
+        },
+        {
+          "start": 308.88,
+          "confidence": 0.438,
+          "end": 309.04,
+          "word": "or",
+          "punct": "or",
+          "index": 85
+        },
+        {
+          "start": 309.04,
+          "confidence": 0.736,
+          "end": 309.23,
+          "word": "like",
+          "punct": "like",
+          "index": 86
+        },
+        {
+          "start": 309.23,
+          "confidence": 0.999,
+          "end": 310.06,
+          "word": "products",
+          "punct": "products",
+          "index": 87
+        },
+        {
+          "start": 310.47,
+          "confidence": 0.86,
+          "end": 310.73,
+          "word": "and",
+          "punct": "and",
+          "index": 88
+        },
+        {
+          "start": 310.76,
+          "confidence": 0.976,
+          "end": 310.96,
+          "word": "other",
+          "punct": "other",
+          "index": 89
+        },
+        {
+          "start": 310.96,
+          "confidence": 0.735,
+          "end": 311.31,
+          "word": "animals",
+          "punct": "animals",
+          "index": 90
+        },
+        {
+          "start": 311.31,
+          "confidence": 0.891,
+          "end": 311.44,
+          "word": "we",
+          "punct": "we",
+          "index": 91
+        },
+        {
+          "start": 311.44,
+          "confidence": 0.714,
+          "end": 311.71,
+          "word": "treated",
+          "punct": "treated",
+          "index": 92
+        },
+        {
+          "start": 311.71,
+          "confidence": 0.982,
+          "end": 311.86,
+          "word": "with",
+          "punct": "with",
+          "index": 93
+        },
+        {
+          "start": 311.86,
+          "confidence": 1,
+          "end": 312.56,
+          "word": "kindness",
+          "punct": "kindness",
+          "index": 94
+        },
+        {
+          "start": 312.59,
+          "confidence": 0.343,
+          "end": 312.85,
+          "word": "we've",
+          "punct": "we've",
+          "index": 95
+        },
+        {
+          "start": 312.85,
+          "confidence": 0.98,
+          "end": 313.08,
+          "word": "given",
+          "punct": "given",
+          "index": 96
+        },
+        {
+          "start": 313.08,
+          "confidence": 0.61,
+          "end": 313.14,
+          "word": "a",
+          "punct": "a",
+          "index": 97
+        },
+        {
+          "start": 313.14,
+          "confidence": 0.989,
+          "end": 313.53,
+          "word": "place",
+          "punct": "place",
+          "index": 98
+        },
+        {
+          "start": 313.53,
+          "confidence": 1,
+          "end": 313.62,
+          "word": "in",
+          "punct": "in",
+          "index": 99
+        },
+        {
+          "start": 313.62,
+          "confidence": 0.948,
+          "end": 314.11,
+          "word": "society",
+          "punct": "society",
+          "index": 100
+        },
+        {
+          "start": 314.11,
+          "confidence": 0.584,
+          "end": 314.21,
+          "word": "as",
+          "punct": "as",
+          "index": 101
+        },
+        {
+          "start": 314.21,
+          "confidence": 0.999,
+          "end": 314.31,
+          "word": "our",
+          "punct": "our",
+          "index": 102
+        },
+        {
+          "start": 314.31,
+          "confidence": 0.998,
+          "end": 315.17,
+          "word": "companions",
+          "punct": "companions.",
+          "index": 103
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 273.6,
+        "end": 274.14,
+        "confidence": 0.999,
+        "text": "Now",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 274.49,
+        "end": 274.66,
+        "confidence": 0.706,
+        "text": "we're",
+        "offset": 4,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 274.66,
+        "end": 274.95,
+        "confidence": 1,
+        "text": "headed",
+        "offset": 10,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 274.95,
+        "end": 275.2,
+        "confidence": 0.729,
+        "text": "towards",
+        "offset": 17,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 275.2,
+        "end": 275.26,
+        "confidence": 0.692,
+        "text": "a",
+        "offset": 25,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 275.26,
+        "end": 275.69,
+        "confidence": 0.993,
+        "text": "world",
+        "offset": 27,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 275.69,
+        "end": 275.85,
+        "confidence": 1,
+        "text": "where",
+        "offset": 33,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 275.85,
+        "end": 276.32,
+        "confidence": 1,
+        "text": "robots",
+        "offset": 39,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 276.32,
+        "end": 276.52,
+        "confidence": 1,
+        "text": "are",
+        "offset": 46,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 276.55,
+        "end": 277.13,
+        "confidence": 0.996,
+        "text": "everywhere",
+        "offset": 50,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 277.66,
+        "end": 278.03,
+        "confidence": 1,
+        "text": "robotic",
+        "offset": 61,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 278.03,
+        "end": 278.57,
+        "confidence": 1,
+        "text": "technology",
+        "offset": 69,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 278.57,
+        "end": 278.82,
+        "confidence": 1,
+        "text": "is",
+        "offset": 80,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 278.82,
+        "end": 279.21,
+        "confidence": 1,
+        "text": "moving",
+        "offset": 83,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 279.21,
+        "end": 279.4,
+        "confidence": 1,
+        "text": "out",
+        "offset": 90,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 279.4,
+        "end": 279.55,
+        "confidence": 1,
+        "text": "from",
+        "offset": 94,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 279.55,
+        "end": 279.82,
+        "confidence": 0.983,
+        "text": "behind",
+        "offset": 99,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 279.82,
+        "end": 280.24,
+        "confidence": 0.995,
+        "text": "factory",
+        "offset": 106,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 280.24,
+        "end": 280.76,
+        "confidence": 0.974,
+        "text": "walls",
+        "offset": 114,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 280.76,
+        "end": 280.95,
+        "confidence": 0.759,
+        "text": "it's",
+        "offset": 120,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 280.95,
+        "end": 281.38,
+        "confidence": 0.91,
+        "text": "entering",
+        "offset": 125,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 281.41,
+        "end": 282.31,
+        "confidence": 0.077,
+        "text": "workplaces",
+        "offset": 134,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 282.31,
+        "end": 283.32,
+        "confidence": 1,
+        "text": "households",
+        "offset": 145,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 283.82,
+        "end": 284.1,
+        "confidence": 0.897,
+        "text": "and",
+        "offset": 156,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 284.13,
+        "end": 284.33,
+        "confidence": 0.876,
+        "text": "as",
+        "offset": 160,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 284.33,
+        "end": 284.53,
+        "confidence": 1,
+        "text": "these",
+        "offset": 163,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 284.53,
+        "end": 285.21,
+        "confidence": 1,
+        "text": "machines",
+        "offset": 169,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 285.21,
+        "end": 285.36,
+        "confidence": 0.624,
+        "text": "that",
+        "offset": 178,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 285.36,
+        "end": 285.86,
+        "confidence": 1,
+        "text": "can",
+        "offset": 183,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 285.89,
+        "end": 286.57,
+        "confidence": 0.598,
+        "text": "fence",
+        "offset": 187,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 286.57,
+        "end": 286.98,
+        "confidence": 0.859,
+        "text": "and",
+        "offset": 193,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 287.21,
+        "end": 287.43,
+        "confidence": 1,
+        "text": "make",
+        "offset": 197,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 287.43,
+        "end": 288.01,
+        "confidence": 1,
+        "text": "autonomous",
+        "offset": 202,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 288.01,
+        "end": 288.67,
+        "confidence": 1,
+        "text": "decisions",
+        "offset": 213,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 288.67,
+        "end": 288.91,
+        "confidence": 0.396,
+        "text": "and",
+        "offset": 223,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 288.91,
+        "end": 289.54,
+        "confidence": 0.519,
+        "text": "learn",
+        "offset": 227,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 290.05,
+        "end": 290.37,
+        "confidence": 0.77,
+        "text": "enter",
+        "offset": 233,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 290.37,
+        "end": 290.57,
+        "confidence": 0.898,
+        "text": "into",
+        "offset": 239,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 290.57,
+        "end": 290.7,
+        "confidence": 0.566,
+        "text": "the",
+        "offset": 244,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 290.7,
+        "end": 291.07,
+        "confidence": 0.941,
+        "text": "shared",
+        "offset": 248,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 291.07,
+        "end": 292.1,
+        "confidence": 0.996,
+        "text": "spaces",
+        "offset": 255,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 292.64,
+        "end": 292.76,
+        "confidence": 1,
+        "text": "I",
+        "offset": 262,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 292.76,
+        "end": 292.99,
+        "confidence": 1,
+        "text": "think",
+        "offset": 264,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 292.99,
+        "end": 293.18,
+        "confidence": 1,
+        "text": "that",
+        "offset": 270,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 293.18,
+        "end": 293.41,
+        "confidence": 0.772,
+        "text": "maybe",
+        "offset": 275,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 293.41,
+        "end": 293.51,
+        "confidence": 1,
+        "text": "the",
+        "offset": 281,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 293.51,
+        "end": 293.75,
+        "confidence": 1,
+        "text": "best",
+        "offset": 285,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 293.75,
+        "end": 294.31,
+        "confidence": 1,
+        "text": "analogy",
+        "offset": 290,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 294.31,
+        "end": 294.42,
+        "confidence": 1,
+        "text": "we",
+        "offset": 298,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 294.42,
+        "end": 294.7,
+        "confidence": 1,
+        "text": "have",
+        "offset": 301,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 294.7,
+        "end": 294.83,
+        "confidence": 1,
+        "text": "for",
+        "offset": 306,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 294.83,
+        "end": 295.06,
+        "confidence": 1,
+        "text": "this",
+        "offset": 310,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 295.06,
+        "end": 295.18,
+        "confidence": 0.799,
+        "text": "is",
+        "offset": 315,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 295.18,
+        "end": 295.31,
+        "confidence": 0.761,
+        "text": "our",
+        "offset": 318,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 295.31,
+        "end": 296.02,
+        "confidence": 1,
+        "text": "relationship",
+        "offset": 322,
+        "length": 12,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 296.02,
+        "end": 296.2,
+        "confidence": 1,
+        "text": "with",
+        "offset": 335,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 296.23,
+        "end": 296.99,
+        "confidence": 0.997,
+        "text": "animals",
+        "offset": 340,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 297.48,
+        "end": 297.97,
+        "confidence": 1,
+        "text": "thousands",
+        "offset": 348,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 297.97,
+        "end": 298.06,
+        "confidence": 1,
+        "text": "of",
+        "offset": 358,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 298.06,
+        "end": 298.3,
+        "confidence": 1,
+        "text": "years",
+        "offset": 361,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 298.3,
+        "end": 298.84,
+        "confidence": 1,
+        "text": "ago",
+        "offset": 367,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 299.11,
+        "end": 299.44,
+        "confidence": 1,
+        "text": "we",
+        "offset": 371,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 299.44,
+        "end": 299.76,
+        "confidence": 1,
+        "text": "started",
+        "offset": 374,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 299.76,
+        "end": 299.85,
+        "confidence": 1,
+        "text": "to",
+        "offset": 382,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 299.85,
+        "end": 300.47,
+        "confidence": 0.843,
+        "text": "domesticate",
+        "offset": 385,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 300.47,
+        "end": 301.15,
+        "confidence": 0.991,
+        "text": "animals",
+        "offset": 397,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 301.41,
+        "end": 301.54,
+        "confidence": 0.687,
+        "text": "and",
+        "offset": 405,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 301.54,
+        "end": 301.64,
+        "confidence": 1,
+        "text": "we",
+        "offset": 409,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 301.64,
+        "end": 301.96,
+        "confidence": 0.841,
+        "text": "train",
+        "offset": 412,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 301.96,
+        "end": 302.12,
+        "confidence": 0.97,
+        "text": "them",
+        "offset": 418,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 302.12,
+        "end": 302.3,
+        "confidence": 1,
+        "text": "for",
+        "offset": 423,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 302.3,
+        "end": 302.88,
+        "confidence": 0.994,
+        "text": "work",
+        "offset": 427,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 302.91,
+        "end": 303.14,
+        "confidence": 1,
+        "text": "and",
+        "offset": 432,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 303.14,
+        "end": 303.83,
+        "confidence": 1,
+        "text": "weaponry",
+        "offset": 436,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 303.86,
+        "end": 303.97,
+        "confidence": 0.598,
+        "text": "and",
+        "offset": 445,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 303.97,
+        "end": 304.88,
+        "confidence": 1,
+        "text": "companionship",
+        "offset": 449,
+        "length": 13,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 305.51,
+        "end": 305.66,
+        "confidence": 1,
+        "text": "and",
+        "offset": 463,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 305.66,
+        "end": 305.9,
+        "confidence": 0.637,
+        "text": "throughout",
+        "offset": 467,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 305.9,
+        "end": 306.42,
+        "confidence": 0.987,
+        "text": "history",
+        "offset": 478,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 306.42,
+        "end": 306.57,
+        "confidence": 0.271,
+        "text": "was",
+        "offset": 486,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 306.57,
+        "end": 306.92,
+        "confidence": 0.577,
+        "text": "treated",
+        "offset": 490,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 306.92,
+        "end": 307.17,
+        "confidence": 1,
+        "text": "some",
+        "offset": 498,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 307.17,
+        "end": 307.74,
+        "confidence": 1,
+        "text": "animals",
+        "offset": 503,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 307.74,
+        "end": 307.93,
+        "confidence": 0.97,
+        "text": "like",
+        "offset": 511,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 307.93,
+        "end": 308.58,
+        "confidence": 0.977,
+        "text": "tools",
+        "offset": 516,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 308.88,
+        "end": 309.04,
+        "confidence": 0.438,
+        "text": "or",
+        "offset": 522,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 309.04,
+        "end": 309.23,
+        "confidence": 0.736,
+        "text": "like",
+        "offset": 525,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 309.23,
+        "end": 310.06,
+        "confidence": 0.999,
+        "text": "products",
+        "offset": 530,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 310.47,
+        "end": 310.73,
+        "confidence": 0.86,
+        "text": "and",
+        "offset": 539,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 310.76,
+        "end": 310.96,
+        "confidence": 0.976,
+        "text": "other",
+        "offset": 543,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 310.96,
+        "end": 311.31,
+        "confidence": 0.735,
+        "text": "animals",
+        "offset": 549,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 311.31,
+        "end": 311.44,
+        "confidence": 0.891,
+        "text": "we",
+        "offset": 557,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 311.44,
+        "end": 311.71,
+        "confidence": 0.714,
+        "text": "treated",
+        "offset": 560,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 311.71,
+        "end": 311.86,
+        "confidence": 0.982,
+        "text": "with",
+        "offset": 568,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 311.86,
+        "end": 312.56,
+        "confidence": 1,
+        "text": "kindness",
+        "offset": 573,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 312.59,
+        "end": 312.85,
+        "confidence": 0.343,
+        "text": "we've",
+        "offset": 582,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 312.85,
+        "end": 313.08,
+        "confidence": 0.98,
+        "text": "given",
+        "offset": 588,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 313.08,
+        "end": 313.14,
+        "confidence": 0.61,
+        "text": "a",
+        "offset": 594,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 313.14,
+        "end": 313.53,
+        "confidence": 0.989,
+        "text": "place",
+        "offset": 596,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 313.53,
+        "end": 313.62,
+        "confidence": 1,
+        "text": "in",
+        "offset": 602,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 313.62,
+        "end": 314.11,
+        "confidence": 0.948,
+        "text": "society",
+        "offset": 605,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 314.11,
+        "end": 314.21,
+        "confidence": 0.584,
+        "text": "as",
+        "offset": 613,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 314.21,
+        "end": 314.31,
+        "confidence": 0.999,
+        "text": "our",
+        "offset": 616,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 314.31,
+        "end": 315.17,
+        "confidence": 0.998,
+        "text": "companions.",
+        "offset": 620,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "I think it's plausible we might start to integrate robots in similar ways.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 315.8,
+      "words": [
+        {
+          "start": 315.8,
+          "confidence": 1,
+          "end": 315.92,
+          "word": "I",
+          "punct": "I",
+          "index": 0
+        },
+        {
+          "start": 315.92,
+          "confidence": 1,
+          "end": 316.09,
+          "word": "think",
+          "punct": "think",
+          "index": 1
+        },
+        {
+          "start": 316.09,
+          "confidence": 0.723,
+          "end": 316.2,
+          "word": "it's",
+          "punct": "it's",
+          "index": 2
+        },
+        {
+          "start": 316.2,
+          "confidence": 0.591,
+          "end": 316.68,
+          "word": "plausible",
+          "punct": "plausible",
+          "index": 3
+        },
+        {
+          "start": 316.68,
+          "confidence": 1,
+          "end": 316.81,
+          "word": "we",
+          "punct": "we",
+          "index": 4
+        },
+        {
+          "start": 316.81,
+          "confidence": 1,
+          "end": 317.01,
+          "word": "might",
+          "punct": "might",
+          "index": 5
+        },
+        {
+          "start": 317.01,
+          "confidence": 1,
+          "end": 317.25,
+          "word": "start",
+          "punct": "start",
+          "index": 6
+        },
+        {
+          "start": 317.25,
+          "confidence": 1,
+          "end": 317.34,
+          "word": "to",
+          "punct": "to",
+          "index": 7
+        },
+        {
+          "start": 317.34,
+          "confidence": 0.81,
+          "end": 317.78,
+          "word": "integrate",
+          "punct": "integrate",
+          "index": 8
+        },
+        {
+          "start": 317.78,
+          "confidence": 0.99,
+          "end": 318.36,
+          "word": "robots",
+          "punct": "robots",
+          "index": 9
+        },
+        {
+          "start": 318.36,
+          "confidence": 0.603,
+          "end": 318.49,
+          "word": "in",
+          "punct": "in",
+          "index": 10
+        },
+        {
+          "start": 318.49,
+          "confidence": 0.974,
+          "end": 318.91,
+          "word": "similar",
+          "punct": "similar",
+          "index": 11
+        },
+        {
+          "start": 318.91,
+          "confidence": 0.473,
+          "end": 319.56,
+          "word": "ways",
+          "punct": "ways.",
+          "index": 12
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 315.8,
+        "end": 315.92,
+        "confidence": 1,
+        "text": "I",
+        "offset": 0,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 315.92,
+        "end": 316.09,
+        "confidence": 1,
+        "text": "think",
+        "offset": 2,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 316.09,
+        "end": 316.2,
+        "confidence": 0.723,
+        "text": "it's",
+        "offset": 8,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 316.2,
+        "end": 316.68,
+        "confidence": 0.591,
+        "text": "plausible",
+        "offset": 13,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 316.68,
+        "end": 316.81,
+        "confidence": 1,
+        "text": "we",
+        "offset": 23,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 316.81,
+        "end": 317.01,
+        "confidence": 1,
+        "text": "might",
+        "offset": 26,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 317.01,
+        "end": 317.25,
+        "confidence": 1,
+        "text": "start",
+        "offset": 32,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 317.25,
+        "end": 317.34,
+        "confidence": 1,
+        "text": "to",
+        "offset": 38,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 317.34,
+        "end": 317.78,
+        "confidence": 0.81,
+        "text": "integrate",
+        "offset": 41,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 317.78,
+        "end": 318.36,
+        "confidence": 0.99,
+        "text": "robots",
+        "offset": 51,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 318.36,
+        "end": 318.49,
+        "confidence": 0.603,
+        "text": "in",
+        "offset": 58,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 318.49,
+        "end": 318.91,
+        "confidence": 0.974,
+        "text": "similar",
+        "offset": 61,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 318.91,
+        "end": 319.56,
+        "confidence": 0.473,
+        "text": "ways.",
+        "offset": 69,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "ensure.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 321.45,
+      "words": [
+        {
+          "start": 321.45,
+          "confidence": 0.221,
+          "end": 322.04,
+          "word": "ensure",
+          "punct": "ensure.",
+          "index": 0
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 321.45,
+        "end": 322.04,
+        "confidence": 0.221,
+        "text": "ensure.",
+        "offset": 0,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Animals are live robots are not and I can tell you from working with roboticist that were pretty far away from developing robust I can feel anything.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 323.02,
+      "words": [
+        {
+          "start": 323.02,
+          "confidence": 1,
+          "end": 323.5,
+          "word": "animals",
+          "punct": "Animals",
+          "index": 0
+        },
+        {
+          "start": 323.5,
+          "confidence": 0.939,
+          "end": 323.71,
+          "word": "are",
+          "punct": "are",
+          "index": 1
+        },
+        {
+          "start": 323.71,
+          "confidence": 0.613,
+          "end": 324.16,
+          "word": "live",
+          "punct": "live",
+          "index": 2
+        },
+        {
+          "start": 324.6,
+          "confidence": 1,
+          "end": 325.01,
+          "word": "robots",
+          "punct": "robots",
+          "index": 3
+        },
+        {
+          "start": 325.01,
+          "confidence": 0.577,
+          "end": 325.11,
+          "word": "are",
+          "punct": "are",
+          "index": 4
+        },
+        {
+          "start": 325.11,
+          "confidence": 0.99,
+          "end": 325.38,
+          "word": "not",
+          "punct": "not",
+          "index": 5
+        },
+        {
+          "start": 327.62,
+          "confidence": 0.703,
+          "end": 327.81,
+          "word": "and",
+          "punct": "and",
+          "index": 6
+        },
+        {
+          "start": 327.81,
+          "confidence": 0.962,
+          "end": 327.87,
+          "word": "I",
+          "punct": "I",
+          "index": 7
+        },
+        {
+          "start": 327.87,
+          "confidence": 1,
+          "end": 328.02,
+          "word": "can",
+          "punct": "can",
+          "index": 8
+        },
+        {
+          "start": 328.02,
+          "confidence": 1,
+          "end": 328.24,
+          "word": "tell",
+          "punct": "tell",
+          "index": 9
+        },
+        {
+          "start": 328.24,
+          "confidence": 1,
+          "end": 328.33,
+          "word": "you",
+          "punct": "you",
+          "index": 10
+        },
+        {
+          "start": 328.33,
+          "confidence": 1,
+          "end": 328.57,
+          "word": "from",
+          "punct": "from",
+          "index": 11
+        },
+        {
+          "start": 328.57,
+          "confidence": 1,
+          "end": 328.92,
+          "word": "working",
+          "punct": "working",
+          "index": 12
+        },
+        {
+          "start": 328.92,
+          "confidence": 0.882,
+          "end": 329.04,
+          "word": "with",
+          "punct": "with",
+          "index": 13
+        },
+        {
+          "start": 329.04,
+          "confidence": 0.081,
+          "end": 329.68,
+          "word": "roboticist",
+          "punct": "roboticist",
+          "index": 14
+        },
+        {
+          "start": 329.68,
+          "confidence": 0.295,
+          "end": 329.8,
+          "word": "that",
+          "punct": "that",
+          "index": 15
+        },
+        {
+          "start": 329.8,
+          "confidence": 0.307,
+          "end": 330.01,
+          "word": "were",
+          "punct": "were",
+          "index": 16
+        },
+        {
+          "start": 330.23,
+          "confidence": 1,
+          "end": 330.5,
+          "word": "pretty",
+          "punct": "pretty",
+          "index": 17
+        },
+        {
+          "start": 330.5,
+          "confidence": 1,
+          "end": 330.72,
+          "word": "far",
+          "punct": "far",
+          "index": 18
+        },
+        {
+          "start": 330.72,
+          "confidence": 1,
+          "end": 330.99,
+          "word": "away",
+          "punct": "away",
+          "index": 19
+        },
+        {
+          "start": 330.99,
+          "confidence": 1,
+          "end": 331.22,
+          "word": "from",
+          "punct": "from",
+          "index": 20
+        },
+        {
+          "start": 331.22,
+          "confidence": 1,
+          "end": 331.69,
+          "word": "developing",
+          "punct": "developing",
+          "index": 21
+        },
+        {
+          "start": 331.69,
+          "confidence": 0.641,
+          "end": 332.08,
+          "word": "robust",
+          "punct": "robust",
+          "index": 22
+        },
+        {
+          "start": 332.08,
+          "confidence": 0.083,
+          "end": 332.12,
+          "word": "I",
+          "punct": "I",
+          "index": 23
+        },
+        {
+          "start": 332.12,
+          "confidence": 0.5,
+          "end": 332.27,
+          "word": "can",
+          "punct": "can",
+          "index": 24
+        },
+        {
+          "start": 332.27,
+          "confidence": 0.563,
+          "end": 332.66,
+          "word": "feel",
+          "punct": "feel",
+          "index": 25
+        },
+        {
+          "start": 332.66,
+          "confidence": 0.928,
+          "end": 333.19,
+          "word": "anything",
+          "punct": "anything.",
+          "index": 26
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 323.02,
+        "end": 323.5,
+        "confidence": 1,
+        "text": "Animals",
+        "offset": 0,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 323.5,
+        "end": 323.71,
+        "confidence": 0.939,
+        "text": "are",
+        "offset": 8,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 323.71,
+        "end": 324.16,
+        "confidence": 0.613,
+        "text": "live",
+        "offset": 12,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 324.6,
+        "end": 325.01,
+        "confidence": 1,
+        "text": "robots",
+        "offset": 17,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 325.01,
+        "end": 325.11,
+        "confidence": 0.577,
+        "text": "are",
+        "offset": 24,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 325.11,
+        "end": 325.38,
+        "confidence": 0.99,
+        "text": "not",
+        "offset": 28,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 327.62,
+        "end": 327.81,
+        "confidence": 0.703,
+        "text": "and",
+        "offset": 32,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 327.81,
+        "end": 327.87,
+        "confidence": 0.962,
+        "text": "I",
+        "offset": 36,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 327.87,
+        "end": 328.02,
+        "confidence": 1,
+        "text": "can",
+        "offset": 38,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 328.02,
+        "end": 328.24,
+        "confidence": 1,
+        "text": "tell",
+        "offset": 42,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 328.24,
+        "end": 328.33,
+        "confidence": 1,
+        "text": "you",
+        "offset": 47,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 328.33,
+        "end": 328.57,
+        "confidence": 1,
+        "text": "from",
+        "offset": 51,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 328.57,
+        "end": 328.92,
+        "confidence": 1,
+        "text": "working",
+        "offset": 56,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 328.92,
+        "end": 329.04,
+        "confidence": 0.882,
+        "text": "with",
+        "offset": 64,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 329.04,
+        "end": 329.68,
+        "confidence": 0.081,
+        "text": "roboticist",
+        "offset": 69,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 329.68,
+        "end": 329.8,
+        "confidence": 0.295,
+        "text": "that",
+        "offset": 80,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 329.8,
+        "end": 330.01,
+        "confidence": 0.307,
+        "text": "were",
+        "offset": 85,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 330.23,
+        "end": 330.5,
+        "confidence": 1,
+        "text": "pretty",
+        "offset": 90,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 330.5,
+        "end": 330.72,
+        "confidence": 1,
+        "text": "far",
+        "offset": 97,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 330.72,
+        "end": 330.99,
+        "confidence": 1,
+        "text": "away",
+        "offset": 101,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 330.99,
+        "end": 331.22,
+        "confidence": 1,
+        "text": "from",
+        "offset": 106,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 331.22,
+        "end": 331.69,
+        "confidence": 1,
+        "text": "developing",
+        "offset": 111,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 331.69,
+        "end": 332.08,
+        "confidence": 0.641,
+        "text": "robust",
+        "offset": 122,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 332.08,
+        "end": 332.12,
+        "confidence": 0.083,
+        "text": "I",
+        "offset": 129,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 332.12,
+        "end": 332.27,
+        "confidence": 0.5,
+        "text": "can",
+        "offset": 131,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 332.27,
+        "end": 332.66,
+        "confidence": 0.563,
+        "text": "feel",
+        "offset": 135,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 332.66,
+        "end": 333.19,
+        "confidence": 0.928,
+        "text": "anything.",
+        "offset": 140,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "But we feel for them.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 335.03,
+      "words": [
+        {
+          "start": 335.03,
+          "confidence": 0.715,
+          "end": 335.24,
+          "word": "but",
+          "punct": "But",
+          "index": 0
+        },
+        {
+          "start": 335.24,
+          "confidence": 1,
+          "end": 335.49,
+          "word": "we",
+          "punct": "we",
+          "index": 1
+        },
+        {
+          "start": 335.49,
+          "confidence": 1,
+          "end": 335.76,
+          "word": "feel",
+          "punct": "feel",
+          "index": 2
+        },
+        {
+          "start": 335.76,
+          "confidence": 1,
+          "end": 335.95,
+          "word": "for",
+          "punct": "for",
+          "index": 3
+        },
+        {
+          "start": 335.95,
+          "confidence": 0.995,
+          "end": 336.43,
+          "word": "them",
+          "punct": "them.",
+          "index": 4
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 335.03,
+        "end": 335.24,
+        "confidence": 0.715,
+        "text": "But",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 335.24,
+        "end": 335.49,
+        "confidence": 1,
+        "text": "we",
+        "offset": 4,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 335.49,
+        "end": 335.76,
+        "confidence": 1,
+        "text": "feel",
+        "offset": 7,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 335.76,
+        "end": 335.95,
+        "confidence": 1,
+        "text": "for",
+        "offset": 12,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 335.95,
+        "end": 336.43,
+        "confidence": 0.995,
+        "text": "them.",
+        "offset": 16,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And that matters because if we're trying to integrate robots into the shared spaces we need to understand that people will treat them differently than other devices.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 337.79,
+      "words": [
+        {
+          "start": 337.79,
+          "confidence": 0.916,
+          "end": 338.01,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 338.01,
+          "confidence": 0.6,
+          "end": 338.2,
+          "word": "that",
+          "punct": "that",
+          "index": 1
+        },
+        {
+          "start": 338.2,
+          "confidence": 0.994,
+          "end": 338.98,
+          "word": "matters",
+          "punct": "matters",
+          "index": 2
+        },
+        {
+          "start": 339.01,
+          "confidence": 1,
+          "end": 339.53,
+          "word": "because",
+          "punct": "because",
+          "index": 3
+        },
+        {
+          "start": 339.56,
+          "confidence": 1,
+          "end": 339.76,
+          "word": "if",
+          "punct": "if",
+          "index": 4
+        },
+        {
+          "start": 339.76,
+          "confidence": 0.76,
+          "end": 339.86,
+          "word": "we're",
+          "punct": "we're",
+          "index": 5
+        },
+        {
+          "start": 339.86,
+          "confidence": 0.997,
+          "end": 340.16,
+          "word": "trying",
+          "punct": "trying",
+          "index": 6
+        },
+        {
+          "start": 340.16,
+          "confidence": 1,
+          "end": 340.26,
+          "word": "to",
+          "punct": "to",
+          "index": 7
+        },
+        {
+          "start": 340.29,
+          "confidence": 1,
+          "end": 340.94,
+          "word": "integrate",
+          "punct": "integrate",
+          "index": 8
+        },
+        {
+          "start": 340.94,
+          "confidence": 0.937,
+          "end": 341.4,
+          "word": "robots",
+          "punct": "robots",
+          "index": 9
+        },
+        {
+          "start": 341.4,
+          "confidence": 0.409,
+          "end": 341.56,
+          "word": "into",
+          "punct": "into",
+          "index": 10
+        },
+        {
+          "start": 341.56,
+          "confidence": 1,
+          "end": 341.67,
+          "word": "the",
+          "punct": "the",
+          "index": 11
+        },
+        {
+          "start": 341.67,
+          "confidence": 1,
+          "end": 342.03,
+          "word": "shared",
+          "punct": "shared",
+          "index": 12
+        },
+        {
+          "start": 342.03,
+          "confidence": 0.658,
+          "end": 342.68,
+          "word": "spaces",
+          "punct": "spaces",
+          "index": 13
+        },
+        {
+          "start": 342.68,
+          "confidence": 0.856,
+          "end": 342.79,
+          "word": "we",
+          "punct": "we",
+          "index": 14
+        },
+        {
+          "start": 342.79,
+          "confidence": 1,
+          "end": 342.96,
+          "word": "need",
+          "punct": "need",
+          "index": 15
+        },
+        {
+          "start": 342.96,
+          "confidence": 1,
+          "end": 343.05,
+          "word": "to",
+          "punct": "to",
+          "index": 16
+        },
+        {
+          "start": 343.05,
+          "confidence": 1,
+          "end": 343.8,
+          "word": "understand",
+          "punct": "understand",
+          "index": 17
+        },
+        {
+          "start": 343.8,
+          "confidence": 0.673,
+          "end": 343.93,
+          "word": "that",
+          "punct": "that",
+          "index": 18
+        },
+        {
+          "start": 343.93,
+          "confidence": 1,
+          "end": 344.24,
+          "word": "people",
+          "punct": "people",
+          "index": 19
+        },
+        {
+          "start": 344.24,
+          "confidence": 0.599,
+          "end": 344.37,
+          "word": "will",
+          "punct": "will",
+          "index": 20
+        },
+        {
+          "start": 344.37,
+          "confidence": 0.986,
+          "end": 344.61,
+          "word": "treat",
+          "punct": "treat",
+          "index": 21
+        },
+        {
+          "start": 344.61,
+          "confidence": 1,
+          "end": 344.76,
+          "word": "them",
+          "punct": "them",
+          "index": 22
+        },
+        {
+          "start": 344.76,
+          "confidence": 1,
+          "end": 345.36,
+          "word": "differently",
+          "punct": "differently",
+          "index": 23
+        },
+        {
+          "start": 345.36,
+          "confidence": 1,
+          "end": 345.51,
+          "word": "than",
+          "punct": "than",
+          "index": 24
+        },
+        {
+          "start": 345.51,
+          "confidence": 1,
+          "end": 345.73,
+          "word": "other",
+          "punct": "other",
+          "index": 25
+        },
+        {
+          "start": 345.73,
+          "confidence": 0.949,
+          "end": 346.6,
+          "word": "devices",
+          "punct": "devices.",
+          "index": 26
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 337.79,
+        "end": 338.01,
+        "confidence": 0.916,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 338.01,
+        "end": 338.2,
+        "confidence": 0.6,
+        "text": "that",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 338.2,
+        "end": 338.98,
+        "confidence": 0.994,
+        "text": "matters",
+        "offset": 9,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 339.01,
+        "end": 339.53,
+        "confidence": 1,
+        "text": "because",
+        "offset": 17,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 339.56,
+        "end": 339.76,
+        "confidence": 1,
+        "text": "if",
+        "offset": 25,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 339.76,
+        "end": 339.86,
+        "confidence": 0.76,
+        "text": "we're",
+        "offset": 28,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 339.86,
+        "end": 340.16,
+        "confidence": 0.997,
+        "text": "trying",
+        "offset": 34,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 340.16,
+        "end": 340.26,
+        "confidence": 1,
+        "text": "to",
+        "offset": 41,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 340.29,
+        "end": 340.94,
+        "confidence": 1,
+        "text": "integrate",
+        "offset": 44,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 340.94,
+        "end": 341.4,
+        "confidence": 0.937,
+        "text": "robots",
+        "offset": 54,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 341.4,
+        "end": 341.56,
+        "confidence": 0.409,
+        "text": "into",
+        "offset": 61,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 341.56,
+        "end": 341.67,
+        "confidence": 1,
+        "text": "the",
+        "offset": 66,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 341.67,
+        "end": 342.03,
+        "confidence": 1,
+        "text": "shared",
+        "offset": 70,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 342.03,
+        "end": 342.68,
+        "confidence": 0.658,
+        "text": "spaces",
+        "offset": 77,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 342.68,
+        "end": 342.79,
+        "confidence": 0.856,
+        "text": "we",
+        "offset": 84,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 342.79,
+        "end": 342.96,
+        "confidence": 1,
+        "text": "need",
+        "offset": 87,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 342.96,
+        "end": 343.05,
+        "confidence": 1,
+        "text": "to",
+        "offset": 92,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 343.05,
+        "end": 343.8,
+        "confidence": 1,
+        "text": "understand",
+        "offset": 95,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 343.8,
+        "end": 343.93,
+        "confidence": 0.673,
+        "text": "that",
+        "offset": 106,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 343.93,
+        "end": 344.24,
+        "confidence": 1,
+        "text": "people",
+        "offset": 111,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 344.24,
+        "end": 344.37,
+        "confidence": 0.599,
+        "text": "will",
+        "offset": 118,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 344.37,
+        "end": 344.61,
+        "confidence": 0.986,
+        "text": "treat",
+        "offset": 123,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 344.61,
+        "end": 344.76,
+        "confidence": 1,
+        "text": "them",
+        "offset": 129,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 344.76,
+        "end": 345.36,
+        "confidence": 1,
+        "text": "differently",
+        "offset": 134,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 345.36,
+        "end": 345.51,
+        "confidence": 1,
+        "text": "than",
+        "offset": 146,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 345.51,
+        "end": 345.73,
+        "confidence": 1,
+        "text": "other",
+        "offset": 151,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 345.73,
+        "end": 346.6,
+        "confidence": 0.949,
+        "text": "devices.",
+        "offset": 157,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And that in some cases for example the case of a soldier who becomes emotionally attached to the robot that they work with that can be anything from an efficient too dangerous.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 347.33,
+      "words": [
+        {
+          "start": 347.33,
+          "confidence": 1,
+          "end": 347.51,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 347.51,
+          "confidence": 0.799,
+          "end": 347.64,
+          "word": "that",
+          "punct": "that",
+          "index": 1
+        },
+        {
+          "start": 347.64,
+          "confidence": 1,
+          "end": 347.75,
+          "word": "in",
+          "punct": "in",
+          "index": 2
+        },
+        {
+          "start": 347.75,
+          "confidence": 1,
+          "end": 348.04,
+          "word": "some",
+          "punct": "some",
+          "index": 3
+        },
+        {
+          "start": 348.04,
+          "confidence": 1,
+          "end": 348.94,
+          "word": "cases",
+          "punct": "cases",
+          "index": 4
+        },
+        {
+          "start": 349.2,
+          "confidence": 1,
+          "end": 349.35,
+          "word": "for",
+          "punct": "for",
+          "index": 5
+        },
+        {
+          "start": 349.35,
+          "confidence": 1,
+          "end": 349.97,
+          "word": "example",
+          "punct": "example",
+          "index": 6
+        },
+        {
+          "start": 349.97,
+          "confidence": 1,
+          "end": 350.09,
+          "word": "the",
+          "punct": "the",
+          "index": 7
+        },
+        {
+          "start": 350.09,
+          "confidence": 1,
+          "end": 350.37,
+          "word": "case",
+          "punct": "case",
+          "index": 8
+        },
+        {
+          "start": 350.37,
+          "confidence": 0.977,
+          "end": 350.45,
+          "word": "of",
+          "punct": "of",
+          "index": 9
+        },
+        {
+          "start": 350.45,
+          "confidence": 0.819,
+          "end": 350.52,
+          "word": "a",
+          "punct": "a",
+          "index": 10
+        },
+        {
+          "start": 350.52,
+          "confidence": 1,
+          "end": 350.98,
+          "word": "soldier",
+          "punct": "soldier",
+          "index": 11
+        },
+        {
+          "start": 350.98,
+          "confidence": 1,
+          "end": 351.08,
+          "word": "who",
+          "punct": "who",
+          "index": 12
+        },
+        {
+          "start": 351.08,
+          "confidence": 1,
+          "end": 351.41,
+          "word": "becomes",
+          "punct": "becomes",
+          "index": 13
+        },
+        {
+          "start": 351.41,
+          "confidence": 1,
+          "end": 351.98,
+          "word": "emotionally",
+          "punct": "emotionally",
+          "index": 14
+        },
+        {
+          "start": 351.98,
+          "confidence": 1,
+          "end": 352.51,
+          "word": "attached",
+          "punct": "attached",
+          "index": 15
+        },
+        {
+          "start": 352.51,
+          "confidence": 1,
+          "end": 352.6,
+          "word": "to",
+          "punct": "to",
+          "index": 16
+        },
+        {
+          "start": 352.6,
+          "confidence": 1,
+          "end": 352.73,
+          "word": "the",
+          "punct": "the",
+          "index": 17
+        },
+        {
+          "start": 352.73,
+          "confidence": 1,
+          "end": 353.1,
+          "word": "robot",
+          "punct": "robot",
+          "index": 18
+        },
+        {
+          "start": 353.1,
+          "confidence": 1,
+          "end": 353.21,
+          "word": "that",
+          "punct": "that",
+          "index": 19
+        },
+        {
+          "start": 353.21,
+          "confidence": 1,
+          "end": 353.31,
+          "word": "they",
+          "punct": "they",
+          "index": 20
+        },
+        {
+          "start": 353.31,
+          "confidence": 1,
+          "end": 353.59,
+          "word": "work",
+          "punct": "work",
+          "index": 21
+        },
+        {
+          "start": 353.59,
+          "confidence": 1,
+          "end": 354.02,
+          "word": "with",
+          "punct": "with",
+          "index": 22
+        },
+        {
+          "start": 354.49,
+          "confidence": 1,
+          "end": 354.66,
+          "word": "that",
+          "punct": "that",
+          "index": 23
+        },
+        {
+          "start": 354.66,
+          "confidence": 1,
+          "end": 354.79,
+          "word": "can",
+          "punct": "can",
+          "index": 24
+        },
+        {
+          "start": 354.79,
+          "confidence": 1,
+          "end": 354.89,
+          "word": "be",
+          "punct": "be",
+          "index": 25
+        },
+        {
+          "start": 354.89,
+          "confidence": 1,
+          "end": 355.28,
+          "word": "anything",
+          "punct": "anything",
+          "index": 26
+        },
+        {
+          "start": 355.28,
+          "confidence": 0.982,
+          "end": 355.46,
+          "word": "from",
+          "punct": "from",
+          "index": 27
+        },
+        {
+          "start": 355.46,
+          "confidence": 0.339,
+          "end": 355.61,
+          "word": "an",
+          "punct": "an",
+          "index": 28
+        },
+        {
+          "start": 355.61,
+          "confidence": 0.69,
+          "end": 356.03,
+          "word": "efficient",
+          "punct": "efficient",
+          "index": 29
+        },
+        {
+          "start": 356.03,
+          "confidence": 0.892,
+          "end": 356.14,
+          "word": "too",
+          "punct": "too",
+          "index": 30
+        },
+        {
+          "start": 356.14,
+          "confidence": 0.991,
+          "end": 356.94,
+          "word": "dangerous",
+          "punct": "dangerous.",
+          "index": 31
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 347.33,
+        "end": 347.51,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 347.51,
+        "end": 347.64,
+        "confidence": 0.799,
+        "text": "that",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 347.64,
+        "end": 347.75,
+        "confidence": 1,
+        "text": "in",
+        "offset": 9,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 347.75,
+        "end": 348.04,
+        "confidence": 1,
+        "text": "some",
+        "offset": 12,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 348.04,
+        "end": 348.94,
+        "confidence": 1,
+        "text": "cases",
+        "offset": 17,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 349.2,
+        "end": 349.35,
+        "confidence": 1,
+        "text": "for",
+        "offset": 23,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 349.35,
+        "end": 349.97,
+        "confidence": 1,
+        "text": "example",
+        "offset": 27,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 349.97,
+        "end": 350.09,
+        "confidence": 1,
+        "text": "the",
+        "offset": 35,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 350.09,
+        "end": 350.37,
+        "confidence": 1,
+        "text": "case",
+        "offset": 39,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 350.37,
+        "end": 350.45,
+        "confidence": 0.977,
+        "text": "of",
+        "offset": 44,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 350.45,
+        "end": 350.52,
+        "confidence": 0.819,
+        "text": "a",
+        "offset": 47,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 350.52,
+        "end": 350.98,
+        "confidence": 1,
+        "text": "soldier",
+        "offset": 49,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 350.98,
+        "end": 351.08,
+        "confidence": 1,
+        "text": "who",
+        "offset": 57,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 351.08,
+        "end": 351.41,
+        "confidence": 1,
+        "text": "becomes",
+        "offset": 61,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 351.41,
+        "end": 351.98,
+        "confidence": 1,
+        "text": "emotionally",
+        "offset": 69,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 351.98,
+        "end": 352.51,
+        "confidence": 1,
+        "text": "attached",
+        "offset": 81,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 352.51,
+        "end": 352.6,
+        "confidence": 1,
+        "text": "to",
+        "offset": 90,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 352.6,
+        "end": 352.73,
+        "confidence": 1,
+        "text": "the",
+        "offset": 93,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 352.73,
+        "end": 353.1,
+        "confidence": 1,
+        "text": "robot",
+        "offset": 97,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 353.1,
+        "end": 353.21,
+        "confidence": 1,
+        "text": "that",
+        "offset": 103,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 353.21,
+        "end": 353.31,
+        "confidence": 1,
+        "text": "they",
+        "offset": 108,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 353.31,
+        "end": 353.59,
+        "confidence": 1,
+        "text": "work",
+        "offset": 113,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 353.59,
+        "end": 354.02,
+        "confidence": 1,
+        "text": "with",
+        "offset": 118,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 354.49,
+        "end": 354.66,
+        "confidence": 1,
+        "text": "that",
+        "offset": 123,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 354.66,
+        "end": 354.79,
+        "confidence": 1,
+        "text": "can",
+        "offset": 128,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 354.79,
+        "end": 354.89,
+        "confidence": 1,
+        "text": "be",
+        "offset": 132,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 354.89,
+        "end": 355.28,
+        "confidence": 1,
+        "text": "anything",
+        "offset": 135,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 355.28,
+        "end": 355.46,
+        "confidence": 0.982,
+        "text": "from",
+        "offset": 144,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 355.46,
+        "end": 355.61,
+        "confidence": 0.339,
+        "text": "an",
+        "offset": 149,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 355.61,
+        "end": 356.03,
+        "confidence": 0.69,
+        "text": "efficient",
+        "offset": 152,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 356.03,
+        "end": 356.14,
+        "confidence": 0.892,
+        "text": "too",
+        "offset": 162,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 356.14,
+        "end": 356.94,
+        "confidence": 0.991,
+        "text": "dangerous.",
+        "offset": 166,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "But in other cases it can actually be useful to foster this emotional connection to robots.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 358.51,
+      "words": [
+        {
+          "start": 358.51,
+          "confidence": 1,
+          "end": 358.68,
+          "word": "but",
+          "punct": "But",
+          "index": 0
+        },
+        {
+          "start": 358.68,
+          "confidence": 1,
+          "end": 358.78,
+          "word": "in",
+          "punct": "in",
+          "index": 1
+        },
+        {
+          "start": 358.78,
+          "confidence": 1,
+          "end": 359,
+          "word": "other",
+          "punct": "other",
+          "index": 2
+        },
+        {
+          "start": 359,
+          "confidence": 0.969,
+          "end": 359.41,
+          "word": "cases",
+          "punct": "cases",
+          "index": 3
+        },
+        {
+          "start": 359.41,
+          "confidence": 0.23,
+          "end": 359.48,
+          "word": "it",
+          "punct": "it",
+          "index": 4
+        },
+        {
+          "start": 359.48,
+          "confidence": 1,
+          "end": 359.61,
+          "word": "can",
+          "punct": "can",
+          "index": 5
+        },
+        {
+          "start": 359.61,
+          "confidence": 1,
+          "end": 359.93,
+          "word": "actually",
+          "punct": "actually",
+          "index": 6
+        },
+        {
+          "start": 359.93,
+          "confidence": 1,
+          "end": 360.09,
+          "word": "be",
+          "punct": "be",
+          "index": 7
+        },
+        {
+          "start": 360.09,
+          "confidence": 0.823,
+          "end": 360.67,
+          "word": "useful",
+          "punct": "useful",
+          "index": 8
+        },
+        {
+          "start": 360.67,
+          "confidence": 0.538,
+          "end": 360.75,
+          "word": "to",
+          "punct": "to",
+          "index": 9
+        },
+        {
+          "start": 360.75,
+          "confidence": 0.991,
+          "end": 361.33,
+          "word": "foster",
+          "punct": "foster",
+          "index": 10
+        },
+        {
+          "start": 361.33,
+          "confidence": 1,
+          "end": 361.49,
+          "word": "this",
+          "punct": "this",
+          "index": 11
+        },
+        {
+          "start": 361.49,
+          "confidence": 1,
+          "end": 361.92,
+          "word": "emotional",
+          "punct": "emotional",
+          "index": 12
+        },
+        {
+          "start": 361.92,
+          "confidence": 1,
+          "end": 362.43,
+          "word": "connection",
+          "punct": "connection",
+          "index": 13
+        },
+        {
+          "start": 362.43,
+          "confidence": 0.972,
+          "end": 362.56,
+          "word": "to",
+          "punct": "to",
+          "index": 14
+        },
+        {
+          "start": 362.56,
+          "confidence": 0.35,
+          "end": 363.23,
+          "word": "robots",
+          "punct": "robots.",
+          "index": 15
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 358.51,
+        "end": 358.68,
+        "confidence": 1,
+        "text": "But",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 358.68,
+        "end": 358.78,
+        "confidence": 1,
+        "text": "in",
+        "offset": 4,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 358.78,
+        "end": 359,
+        "confidence": 1,
+        "text": "other",
+        "offset": 7,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 359,
+        "end": 359.41,
+        "confidence": 0.969,
+        "text": "cases",
+        "offset": 13,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 359.41,
+        "end": 359.48,
+        "confidence": 0.23,
+        "text": "it",
+        "offset": 19,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 359.48,
+        "end": 359.61,
+        "confidence": 1,
+        "text": "can",
+        "offset": 22,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 359.61,
+        "end": 359.93,
+        "confidence": 1,
+        "text": "actually",
+        "offset": 26,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 359.93,
+        "end": 360.09,
+        "confidence": 1,
+        "text": "be",
+        "offset": 35,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 360.09,
+        "end": 360.67,
+        "confidence": 0.823,
+        "text": "useful",
+        "offset": 38,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 360.67,
+        "end": 360.75,
+        "confidence": 0.538,
+        "text": "to",
+        "offset": 45,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 360.75,
+        "end": 361.33,
+        "confidence": 0.991,
+        "text": "foster",
+        "offset": 48,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 361.33,
+        "end": 361.49,
+        "confidence": 1,
+        "text": "this",
+        "offset": 55,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 361.49,
+        "end": 361.92,
+        "confidence": 1,
+        "text": "emotional",
+        "offset": 60,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 361.92,
+        "end": 362.43,
+        "confidence": 1,
+        "text": "connection",
+        "offset": 70,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 362.43,
+        "end": 362.56,
+        "confidence": 0.972,
+        "text": "to",
+        "offset": 81,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 362.56,
+        "end": 363.23,
+        "confidence": 0.35,
+        "text": "robots.",
+        "offset": 84,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "We're already seeing some great use cases for example robots working with autistic children to engage them in ways that we haven't seen previously or robots working with teachers to engage kids in learning with new results.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 364.15,
+      "words": [
+        {
+          "start": 364.15,
+          "confidence": 0.817,
+          "end": 364.33,
+          "word": "we're",
+          "punct": "We're",
+          "index": 0
+        },
+        {
+          "start": 364.33,
+          "confidence": 1,
+          "end": 364.61,
+          "word": "already",
+          "punct": "already",
+          "index": 1
+        },
+        {
+          "start": 364.61,
+          "confidence": 1,
+          "end": 364.93,
+          "word": "seeing",
+          "punct": "seeing",
+          "index": 2
+        },
+        {
+          "start": 364.93,
+          "confidence": 0.78,
+          "end": 365.13,
+          "word": "some",
+          "punct": "some",
+          "index": 3
+        },
+        {
+          "start": 365.13,
+          "confidence": 0.994,
+          "end": 365.46,
+          "word": "great",
+          "punct": "great",
+          "index": 4
+        },
+        {
+          "start": 365.46,
+          "confidence": 0.996,
+          "end": 365.72,
+          "word": "use",
+          "punct": "use",
+          "index": 5
+        },
+        {
+          "start": 365.72,
+          "confidence": 0.8,
+          "end": 366.23,
+          "word": "cases",
+          "punct": "cases",
+          "index": 6
+        },
+        {
+          "start": 366.23,
+          "confidence": 1,
+          "end": 366.37,
+          "word": "for",
+          "punct": "for",
+          "index": 7
+        },
+        {
+          "start": 366.37,
+          "confidence": 1,
+          "end": 366.84,
+          "word": "example",
+          "punct": "example",
+          "index": 8
+        },
+        {
+          "start": 366.84,
+          "confidence": 0.864,
+          "end": 367.27,
+          "word": "robots",
+          "punct": "robots",
+          "index": 9
+        },
+        {
+          "start": 367.27,
+          "confidence": 1,
+          "end": 367.57,
+          "word": "working",
+          "punct": "working",
+          "index": 10
+        },
+        {
+          "start": 367.57,
+          "confidence": 1,
+          "end": 367.78,
+          "word": "with",
+          "punct": "with",
+          "index": 11
+        },
+        {
+          "start": 367.78,
+          "confidence": 1,
+          "end": 368.4,
+          "word": "autistic",
+          "punct": "autistic",
+          "index": 12
+        },
+        {
+          "start": 368.4,
+          "confidence": 1,
+          "end": 368.92,
+          "word": "children",
+          "punct": "children",
+          "index": 13
+        },
+        {
+          "start": 368.92,
+          "confidence": 0.954,
+          "end": 369.11,
+          "word": "to",
+          "punct": "to",
+          "index": 14
+        },
+        {
+          "start": 369.11,
+          "confidence": 0.997,
+          "end": 369.62,
+          "word": "engage",
+          "punct": "engage",
+          "index": 15
+        },
+        {
+          "start": 369.62,
+          "confidence": 0.993,
+          "end": 369.91,
+          "word": "them",
+          "punct": "them",
+          "index": 16
+        },
+        {
+          "start": 369.91,
+          "confidence": 0.8,
+          "end": 370.02,
+          "word": "in",
+          "punct": "in",
+          "index": 17
+        },
+        {
+          "start": 370.02,
+          "confidence": 0.757,
+          "end": 370.37,
+          "word": "ways",
+          "punct": "ways",
+          "index": 18
+        },
+        {
+          "start": 370.37,
+          "confidence": 1,
+          "end": 370.47,
+          "word": "that",
+          "punct": "that",
+          "index": 19
+        },
+        {
+          "start": 370.47,
+          "confidence": 1,
+          "end": 370.56,
+          "word": "we",
+          "punct": "we",
+          "index": 20
+        },
+        {
+          "start": 370.56,
+          "confidence": 1,
+          "end": 370.95,
+          "word": "haven't",
+          "punct": "haven't",
+          "index": 21
+        },
+        {
+          "start": 370.95,
+          "confidence": 1,
+          "end": 371.16,
+          "word": "seen",
+          "punct": "seen",
+          "index": 22
+        },
+        {
+          "start": 371.16,
+          "confidence": 0.997,
+          "end": 372.03,
+          "word": "previously",
+          "punct": "previously",
+          "index": 23
+        },
+        {
+          "start": 372.49,
+          "confidence": 0.896,
+          "end": 372.78,
+          "word": "or",
+          "punct": "or",
+          "index": 24
+        },
+        {
+          "start": 372.78,
+          "confidence": 0.933,
+          "end": 373.14,
+          "word": "robots",
+          "punct": "robots",
+          "index": 25
+        },
+        {
+          "start": 373.14,
+          "confidence": 1,
+          "end": 373.49,
+          "word": "working",
+          "punct": "working",
+          "index": 26
+        },
+        {
+          "start": 373.49,
+          "confidence": 1,
+          "end": 373.64,
+          "word": "with",
+          "punct": "with",
+          "index": 27
+        },
+        {
+          "start": 373.64,
+          "confidence": 1,
+          "end": 374.2,
+          "word": "teachers",
+          "punct": "teachers",
+          "index": 28
+        },
+        {
+          "start": 374.2,
+          "confidence": 1,
+          "end": 374.34,
+          "word": "to",
+          "punct": "to",
+          "index": 29
+        },
+        {
+          "start": 374.34,
+          "confidence": 1,
+          "end": 374.73,
+          "word": "engage",
+          "punct": "engage",
+          "index": 30
+        },
+        {
+          "start": 374.73,
+          "confidence": 1,
+          "end": 375,
+          "word": "kids",
+          "punct": "kids",
+          "index": 31
+        },
+        {
+          "start": 375,
+          "confidence": 0.749,
+          "end": 375.12,
+          "word": "in",
+          "punct": "in",
+          "index": 32
+        },
+        {
+          "start": 375.12,
+          "confidence": 0.937,
+          "end": 375.56,
+          "word": "learning",
+          "punct": "learning",
+          "index": 33
+        },
+        {
+          "start": 375.56,
+          "confidence": 1,
+          "end": 375.76,
+          "word": "with",
+          "punct": "with",
+          "index": 34
+        },
+        {
+          "start": 375.76,
+          "confidence": 0.847,
+          "end": 375.87,
+          "word": "new",
+          "punct": "new",
+          "index": 35
+        },
+        {
+          "start": 375.87,
+          "confidence": 0.993,
+          "end": 376.57,
+          "word": "results",
+          "punct": "results.",
+          "index": 36
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 364.15,
+        "end": 364.33,
+        "confidence": 0.817,
+        "text": "We're",
+        "offset": 0,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 364.33,
+        "end": 364.61,
+        "confidence": 1,
+        "text": "already",
+        "offset": 6,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 364.61,
+        "end": 364.93,
+        "confidence": 1,
+        "text": "seeing",
+        "offset": 14,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 364.93,
+        "end": 365.13,
+        "confidence": 0.78,
+        "text": "some",
+        "offset": 21,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 365.13,
+        "end": 365.46,
+        "confidence": 0.994,
+        "text": "great",
+        "offset": 26,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 365.46,
+        "end": 365.72,
+        "confidence": 0.996,
+        "text": "use",
+        "offset": 32,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 365.72,
+        "end": 366.23,
+        "confidence": 0.8,
+        "text": "cases",
+        "offset": 36,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 366.23,
+        "end": 366.37,
+        "confidence": 1,
+        "text": "for",
+        "offset": 42,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 366.37,
+        "end": 366.84,
+        "confidence": 1,
+        "text": "example",
+        "offset": 46,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 366.84,
+        "end": 367.27,
+        "confidence": 0.864,
+        "text": "robots",
+        "offset": 54,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 367.27,
+        "end": 367.57,
+        "confidence": 1,
+        "text": "working",
+        "offset": 61,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 367.57,
+        "end": 367.78,
+        "confidence": 1,
+        "text": "with",
+        "offset": 69,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 367.78,
+        "end": 368.4,
+        "confidence": 1,
+        "text": "autistic",
+        "offset": 74,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 368.4,
+        "end": 368.92,
+        "confidence": 1,
+        "text": "children",
+        "offset": 83,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 368.92,
+        "end": 369.11,
+        "confidence": 0.954,
+        "text": "to",
+        "offset": 92,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 369.11,
+        "end": 369.62,
+        "confidence": 0.997,
+        "text": "engage",
+        "offset": 95,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 369.62,
+        "end": 369.91,
+        "confidence": 0.993,
+        "text": "them",
+        "offset": 102,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 369.91,
+        "end": 370.02,
+        "confidence": 0.8,
+        "text": "in",
+        "offset": 107,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 370.02,
+        "end": 370.37,
+        "confidence": 0.757,
+        "text": "ways",
+        "offset": 110,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 370.37,
+        "end": 370.47,
+        "confidence": 1,
+        "text": "that",
+        "offset": 115,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 370.47,
+        "end": 370.56,
+        "confidence": 1,
+        "text": "we",
+        "offset": 120,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 370.56,
+        "end": 370.95,
+        "confidence": 1,
+        "text": "haven't",
+        "offset": 123,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 370.95,
+        "end": 371.16,
+        "confidence": 1,
+        "text": "seen",
+        "offset": 131,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 371.16,
+        "end": 372.03,
+        "confidence": 0.997,
+        "text": "previously",
+        "offset": 136,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 372.49,
+        "end": 372.78,
+        "confidence": 0.896,
+        "text": "or",
+        "offset": 147,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 372.78,
+        "end": 373.14,
+        "confidence": 0.933,
+        "text": "robots",
+        "offset": 150,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 373.14,
+        "end": 373.49,
+        "confidence": 1,
+        "text": "working",
+        "offset": 157,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 373.49,
+        "end": 373.64,
+        "confidence": 1,
+        "text": "with",
+        "offset": 165,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 373.64,
+        "end": 374.2,
+        "confidence": 1,
+        "text": "teachers",
+        "offset": 170,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 374.2,
+        "end": 374.34,
+        "confidence": 1,
+        "text": "to",
+        "offset": 179,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 374.34,
+        "end": 374.73,
+        "confidence": 1,
+        "text": "engage",
+        "offset": 182,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 374.73,
+        "end": 375,
+        "confidence": 1,
+        "text": "kids",
+        "offset": 189,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 375,
+        "end": 375.12,
+        "confidence": 0.749,
+        "text": "in",
+        "offset": 194,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 375.12,
+        "end": 375.56,
+        "confidence": 0.937,
+        "text": "learning",
+        "offset": 197,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 375.56,
+        "end": 375.76,
+        "confidence": 1,
+        "text": "with",
+        "offset": 206,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 375.76,
+        "end": 375.87,
+        "confidence": 0.847,
+        "text": "new",
+        "offset": 211,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 375.87,
+        "end": 376.57,
+        "confidence": 0.993,
+        "text": "results.",
+        "offset": 215,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And it's not just for kids.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 377.41,
+      "words": [
+        {
+          "start": 377.41,
+          "confidence": 1,
+          "end": 377.55,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 377.55,
+          "confidence": 1,
+          "end": 377.68,
+          "word": "it's",
+          "punct": "it's",
+          "index": 1
+        },
+        {
+          "start": 377.68,
+          "confidence": 1,
+          "end": 377.88,
+          "word": "not",
+          "punct": "not",
+          "index": 2
+        },
+        {
+          "start": 377.88,
+          "confidence": 1,
+          "end": 378.05,
+          "word": "just",
+          "punct": "just",
+          "index": 3
+        },
+        {
+          "start": 378.05,
+          "confidence": 1,
+          "end": 378.16,
+          "word": "for",
+          "punct": "for",
+          "index": 4
+        },
+        {
+          "start": 378.16,
+          "confidence": 0.822,
+          "end": 378.84,
+          "word": "kids",
+          "punct": "kids.",
+          "index": 5
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 377.41,
+        "end": 377.55,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 377.55,
+        "end": 377.68,
+        "confidence": 1,
+        "text": "it's",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 377.68,
+        "end": 377.88,
+        "confidence": 1,
+        "text": "not",
+        "offset": 9,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 377.88,
+        "end": 378.05,
+        "confidence": 1,
+        "text": "just",
+        "offset": 13,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 378.05,
+        "end": 378.16,
+        "confidence": 1,
+        "text": "for",
+        "offset": 18,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 378.16,
+        "end": 378.84,
+        "confidence": 0.822,
+        "text": "kids.",
+        "offset": 22,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Early studies show that robots can help doctors and patients in health care settings.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 379.72,
+      "words": [
+        {
+          "start": 379.72,
+          "confidence": 1,
+          "end": 380.03,
+          "word": "early",
+          "punct": "Early",
+          "index": 0
+        },
+        {
+          "start": 380.03,
+          "confidence": 1,
+          "end": 380.4,
+          "word": "studies",
+          "punct": "studies",
+          "index": 1
+        },
+        {
+          "start": 380.4,
+          "confidence": 1,
+          "end": 380.7,
+          "word": "show",
+          "punct": "show",
+          "index": 2
+        },
+        {
+          "start": 380.7,
+          "confidence": 1,
+          "end": 381.03,
+          "word": "that",
+          "punct": "that",
+          "index": 3
+        },
+        {
+          "start": 381.06,
+          "confidence": 0.21,
+          "end": 381.39,
+          "word": "robots",
+          "punct": "robots",
+          "index": 4
+        },
+        {
+          "start": 381.39,
+          "confidence": 0.984,
+          "end": 381.54,
+          "word": "can",
+          "punct": "can",
+          "index": 5
+        },
+        {
+          "start": 381.54,
+          "confidence": 0.965,
+          "end": 381.75,
+          "word": "help",
+          "punct": "help",
+          "index": 6
+        },
+        {
+          "start": 381.75,
+          "confidence": 1,
+          "end": 382.25,
+          "word": "doctors",
+          "punct": "doctors",
+          "index": 7
+        },
+        {
+          "start": 382.25,
+          "confidence": 1,
+          "end": 382.38,
+          "word": "and",
+          "punct": "and",
+          "index": 8
+        },
+        {
+          "start": 382.38,
+          "confidence": 1,
+          "end": 382.98,
+          "word": "patients",
+          "punct": "patients",
+          "index": 9
+        },
+        {
+          "start": 382.98,
+          "confidence": 0.449,
+          "end": 383.08,
+          "word": "in",
+          "punct": "in",
+          "index": 10
+        },
+        {
+          "start": 383.08,
+          "confidence": 0.677,
+          "end": 383.42,
+          "word": "health",
+          "punct": "health",
+          "index": 11
+        },
+        {
+          "start": 383.42,
+          "confidence": 0.718,
+          "end": 383.65,
+          "word": "care",
+          "punct": "care",
+          "index": 12
+        },
+        {
+          "start": 383.65,
+          "confidence": 0.998,
+          "end": 384.37,
+          "word": "settings",
+          "punct": "settings.",
+          "index": 13
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 379.72,
+        "end": 380.03,
+        "confidence": 1,
+        "text": "Early",
+        "offset": 0,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 380.03,
+        "end": 380.4,
+        "confidence": 1,
+        "text": "studies",
+        "offset": 6,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 380.4,
+        "end": 380.7,
+        "confidence": 1,
+        "text": "show",
+        "offset": 14,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 380.7,
+        "end": 381.03,
+        "confidence": 1,
+        "text": "that",
+        "offset": 19,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 381.06,
+        "end": 381.39,
+        "confidence": 0.21,
+        "text": "robots",
+        "offset": 24,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 381.39,
+        "end": 381.54,
+        "confidence": 0.984,
+        "text": "can",
+        "offset": 31,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 381.54,
+        "end": 381.75,
+        "confidence": 0.965,
+        "text": "help",
+        "offset": 35,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 381.75,
+        "end": 382.25,
+        "confidence": 1,
+        "text": "doctors",
+        "offset": 40,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 382.25,
+        "end": 382.38,
+        "confidence": 1,
+        "text": "and",
+        "offset": 48,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 382.38,
+        "end": 382.98,
+        "confidence": 1,
+        "text": "patients",
+        "offset": 52,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 382.98,
+        "end": 383.08,
+        "confidence": 0.449,
+        "text": "in",
+        "offset": 61,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 383.08,
+        "end": 383.42,
+        "confidence": 0.677,
+        "text": "health",
+        "offset": 64,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 383.42,
+        "end": 383.65,
+        "confidence": 0.718,
+        "text": "care",
+        "offset": 71,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 383.65,
+        "end": 384.37,
+        "confidence": 0.998,
+        "text": "settings.",
+        "offset": 76,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "This is the part baby seal robot is used in nursing homes and with dementia patients been around for awhile and I remember years ago being at a party and telling someone about this robot.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 385.53,
+      "words": [
+        {
+          "start": 385.53,
+          "confidence": 1,
+          "end": 385.72,
+          "word": "this",
+          "punct": "This",
+          "index": 0
+        },
+        {
+          "start": 385.72,
+          "confidence": 1,
+          "end": 385.89,
+          "word": "is",
+          "punct": "is",
+          "index": 1
+        },
+        {
+          "start": 385.89,
+          "confidence": 1,
+          "end": 385.98,
+          "word": "the",
+          "punct": "the",
+          "index": 2
+        },
+        {
+          "start": 385.98,
+          "confidence": 0.644,
+          "end": 386.41,
+          "word": "part",
+          "punct": "part",
+          "index": 3
+        },
+        {
+          "start": 386.41,
+          "confidence": 0.697,
+          "end": 386.64,
+          "word": "baby",
+          "punct": "baby",
+          "index": 4
+        },
+        {
+          "start": 386.64,
+          "confidence": 0.456,
+          "end": 386.91,
+          "word": "seal",
+          "punct": "seal",
+          "index": 5
+        },
+        {
+          "start": 386.91,
+          "confidence": 1,
+          "end": 387.32,
+          "word": "robot",
+          "punct": "robot",
+          "index": 6
+        },
+        {
+          "start": 387.35,
+          "confidence": 0.282,
+          "end": 387.52,
+          "word": "is",
+          "punct": "is",
+          "index": 7
+        },
+        {
+          "start": 387.52,
+          "confidence": 0.879,
+          "end": 387.86,
+          "word": "used",
+          "punct": "used",
+          "index": 8
+        },
+        {
+          "start": 387.89,
+          "confidence": 0.976,
+          "end": 388.05,
+          "word": "in",
+          "punct": "in",
+          "index": 9
+        },
+        {
+          "start": 388.05,
+          "confidence": 0.996,
+          "end": 388.45,
+          "word": "nursing",
+          "punct": "nursing",
+          "index": 10
+        },
+        {
+          "start": 388.45,
+          "confidence": 0.803,
+          "end": 388.91,
+          "word": "homes",
+          "punct": "homes",
+          "index": 11
+        },
+        {
+          "start": 388.91,
+          "confidence": 0.222,
+          "end": 389,
+          "word": "and",
+          "punct": "and",
+          "index": 12
+        },
+        {
+          "start": 389,
+          "confidence": 1,
+          "end": 389.15,
+          "word": "with",
+          "punct": "with",
+          "index": 13
+        },
+        {
+          "start": 389.15,
+          "confidence": 1,
+          "end": 389.61,
+          "word": "dementia",
+          "punct": "dementia",
+          "index": 14
+        },
+        {
+          "start": 389.61,
+          "confidence": 0.907,
+          "end": 390.36,
+          "word": "patients",
+          "punct": "patients",
+          "index": 15
+        },
+        {
+          "start": 390.66,
+          "confidence": 0.458,
+          "end": 390.77,
+          "word": "been",
+          "punct": "been",
+          "index": 16
+        },
+        {
+          "start": 390.77,
+          "confidence": 0.975,
+          "end": 391.07,
+          "word": "around",
+          "punct": "around",
+          "index": 17
+        },
+        {
+          "start": 391.07,
+          "confidence": 0.969,
+          "end": 391.23,
+          "word": "for",
+          "punct": "for",
+          "index": 18
+        },
+        {
+          "start": 391.23,
+          "confidence": 0.51,
+          "end": 391.81,
+          "word": "awhile",
+          "punct": "awhile",
+          "index": 19
+        },
+        {
+          "start": 392.21,
+          "confidence": 1,
+          "end": 392.38,
+          "word": "and",
+          "punct": "and",
+          "index": 20
+        },
+        {
+          "start": 392.38,
+          "confidence": 1,
+          "end": 392.43,
+          "word": "I",
+          "punct": "I",
+          "index": 21
+        },
+        {
+          "start": 392.43,
+          "confidence": 1,
+          "end": 393.05,
+          "word": "remember",
+          "punct": "remember",
+          "index": 22
+        },
+        {
+          "start": 393.34,
+          "confidence": 1,
+          "end": 393.79,
+          "word": "years",
+          "punct": "years",
+          "index": 23
+        },
+        {
+          "start": 393.79,
+          "confidence": 1,
+          "end": 394.03,
+          "word": "ago",
+          "punct": "ago",
+          "index": 24
+        },
+        {
+          "start": 394.03,
+          "confidence": 1,
+          "end": 394.22,
+          "word": "being",
+          "punct": "being",
+          "index": 25
+        },
+        {
+          "start": 394.22,
+          "confidence": 0.84,
+          "end": 394.31,
+          "word": "at",
+          "punct": "at",
+          "index": 26
+        },
+        {
+          "start": 394.31,
+          "confidence": 1,
+          "end": 394.37,
+          "word": "a",
+          "punct": "a",
+          "index": 27
+        },
+        {
+          "start": 394.37,
+          "confidence": 1,
+          "end": 395.12,
+          "word": "party",
+          "punct": "party",
+          "index": 28
+        },
+        {
+          "start": 395.6,
+          "confidence": 0.663,
+          "end": 395.76,
+          "word": "and",
+          "punct": "and",
+          "index": 29
+        },
+        {
+          "start": 395.76,
+          "confidence": 1,
+          "end": 396.16,
+          "word": "telling",
+          "punct": "telling",
+          "index": 30
+        },
+        {
+          "start": 396.16,
+          "confidence": 1,
+          "end": 396.44,
+          "word": "someone",
+          "punct": "someone",
+          "index": 31
+        },
+        {
+          "start": 396.44,
+          "confidence": 1,
+          "end": 396.68,
+          "word": "about",
+          "punct": "about",
+          "index": 32
+        },
+        {
+          "start": 396.68,
+          "confidence": 1,
+          "end": 396.84,
+          "word": "this",
+          "punct": "this",
+          "index": 33
+        },
+        {
+          "start": 396.84,
+          "confidence": 0.947,
+          "end": 397.42,
+          "word": "robot",
+          "punct": "robot.",
+          "index": 34
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 385.53,
+        "end": 385.72,
+        "confidence": 1,
+        "text": "This",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 385.72,
+        "end": 385.89,
+        "confidence": 1,
+        "text": "is",
+        "offset": 5,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 385.89,
+        "end": 385.98,
+        "confidence": 1,
+        "text": "the",
+        "offset": 8,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 385.98,
+        "end": 386.41,
+        "confidence": 0.644,
+        "text": "part",
+        "offset": 12,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 386.41,
+        "end": 386.64,
+        "confidence": 0.697,
+        "text": "baby",
+        "offset": 17,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 386.64,
+        "end": 386.91,
+        "confidence": 0.456,
+        "text": "seal",
+        "offset": 22,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 386.91,
+        "end": 387.32,
+        "confidence": 1,
+        "text": "robot",
+        "offset": 27,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 387.35,
+        "end": 387.52,
+        "confidence": 0.282,
+        "text": "is",
+        "offset": 33,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 387.52,
+        "end": 387.86,
+        "confidence": 0.879,
+        "text": "used",
+        "offset": 36,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 387.89,
+        "end": 388.05,
+        "confidence": 0.976,
+        "text": "in",
+        "offset": 41,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 388.05,
+        "end": 388.45,
+        "confidence": 0.996,
+        "text": "nursing",
+        "offset": 44,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 388.45,
+        "end": 388.91,
+        "confidence": 0.803,
+        "text": "homes",
+        "offset": 52,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 388.91,
+        "end": 389,
+        "confidence": 0.222,
+        "text": "and",
+        "offset": 58,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 389,
+        "end": 389.15,
+        "confidence": 1,
+        "text": "with",
+        "offset": 62,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 389.15,
+        "end": 389.61,
+        "confidence": 1,
+        "text": "dementia",
+        "offset": 67,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 389.61,
+        "end": 390.36,
+        "confidence": 0.907,
+        "text": "patients",
+        "offset": 76,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 390.66,
+        "end": 390.77,
+        "confidence": 0.458,
+        "text": "been",
+        "offset": 85,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 390.77,
+        "end": 391.07,
+        "confidence": 0.975,
+        "text": "around",
+        "offset": 90,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 391.07,
+        "end": 391.23,
+        "confidence": 0.969,
+        "text": "for",
+        "offset": 97,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 391.23,
+        "end": 391.81,
+        "confidence": 0.51,
+        "text": "awhile",
+        "offset": 101,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 392.21,
+        "end": 392.38,
+        "confidence": 1,
+        "text": "and",
+        "offset": 108,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 392.38,
+        "end": 392.43,
+        "confidence": 1,
+        "text": "I",
+        "offset": 112,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 392.43,
+        "end": 393.05,
+        "confidence": 1,
+        "text": "remember",
+        "offset": 114,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 393.34,
+        "end": 393.79,
+        "confidence": 1,
+        "text": "years",
+        "offset": 123,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 393.79,
+        "end": 394.03,
+        "confidence": 1,
+        "text": "ago",
+        "offset": 129,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 394.03,
+        "end": 394.22,
+        "confidence": 1,
+        "text": "being",
+        "offset": 133,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 394.22,
+        "end": 394.31,
+        "confidence": 0.84,
+        "text": "at",
+        "offset": 139,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 394.31,
+        "end": 394.37,
+        "confidence": 1,
+        "text": "a",
+        "offset": 142,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 394.37,
+        "end": 395.12,
+        "confidence": 1,
+        "text": "party",
+        "offset": 144,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 395.6,
+        "end": 395.76,
+        "confidence": 0.663,
+        "text": "and",
+        "offset": 150,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 395.76,
+        "end": 396.16,
+        "confidence": 1,
+        "text": "telling",
+        "offset": 154,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 396.16,
+        "end": 396.44,
+        "confidence": 1,
+        "text": "someone",
+        "offset": 162,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 396.44,
+        "end": 396.68,
+        "confidence": 1,
+        "text": "about",
+        "offset": 170,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 396.68,
+        "end": 396.84,
+        "confidence": 1,
+        "text": "this",
+        "offset": 176,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 396.84,
+        "end": 397.42,
+        "confidence": 0.947,
+        "text": "robot.",
+        "offset": 181,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And her response was.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 398.26,
+      "words": [
+        {
+          "start": 398.26,
+          "confidence": 0.582,
+          "end": 398.36,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 398.36,
+          "confidence": 1,
+          "end": 398.52,
+          "word": "her",
+          "punct": "her",
+          "index": 1
+        },
+        {
+          "start": 398.52,
+          "confidence": 1,
+          "end": 399.04,
+          "word": "response",
+          "punct": "response",
+          "index": 2
+        },
+        {
+          "start": 399.04,
+          "confidence": 0.997,
+          "end": 399.57,
+          "word": "was",
+          "punct": "was.",
+          "index": 3
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 398.26,
+        "end": 398.36,
+        "confidence": 0.582,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 398.36,
+        "end": 398.52,
+        "confidence": 1,
+        "text": "her",
+        "offset": 4,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 398.52,
+        "end": 399.04,
+        "confidence": 1,
+        "text": "response",
+        "offset": 8,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 399.04,
+        "end": 399.57,
+        "confidence": 0.997,
+        "text": "was.",
+        "offset": 17,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Oh my gosh.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 400.33,
+      "words": [
+        {
+          "start": 400.33,
+          "confidence": 0.591,
+          "end": 400.44,
+          "word": "oh",
+          "punct": "Oh",
+          "index": 0
+        },
+        {
+          "start": 400.44,
+          "confidence": 0.776,
+          "end": 400.61,
+          "word": "my",
+          "punct": "my",
+          "index": 1
+        },
+        {
+          "start": 400.61,
+          "confidence": 0.915,
+          "end": 401.34,
+          "word": "gosh",
+          "punct": "gosh.",
+          "index": 2
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 400.33,
+        "end": 400.44,
+        "confidence": 0.591,
+        "text": "Oh",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 400.44,
+        "end": 400.61,
+        "confidence": 0.776,
+        "text": "my",
+        "offset": 3,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 400.61,
+        "end": 401.34,
+        "confidence": 0.915,
+        "text": "gosh.",
+        "offset": 6,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "That's horrible.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 402.49,
+      "words": [
+        {
+          "start": 402.49,
+          "confidence": 1,
+          "end": 402.75,
+          "word": "that's",
+          "punct": "That's",
+          "index": 0
+        },
+        {
+          "start": 402.75,
+          "confidence": 0.997,
+          "end": 403.49,
+          "word": "horrible",
+          "punct": "horrible.",
+          "index": 1
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 402.49,
+        "end": 402.75,
+        "confidence": 1,
+        "text": "That's",
+        "offset": 0,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 402.75,
+        "end": 403.49,
+        "confidence": 0.997,
+        "text": "horrible.",
+        "offset": 7,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "I can't believe we're giving people robots instead of human care.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 405.01,
+      "words": [
+        {
+          "start": 405.01,
+          "confidence": 1,
+          "end": 405.13,
+          "word": "I",
+          "punct": "I",
+          "index": 0
+        },
+        {
+          "start": 405.13,
+          "confidence": 1,
+          "end": 405.44,
+          "word": "can't",
+          "punct": "can't",
+          "index": 1
+        },
+        {
+          "start": 405.44,
+          "confidence": 1,
+          "end": 405.76,
+          "word": "believe",
+          "punct": "believe",
+          "index": 2
+        },
+        {
+          "start": 405.76,
+          "confidence": 0.801,
+          "end": 405.86,
+          "word": "we're",
+          "punct": "we're",
+          "index": 3
+        },
+        {
+          "start": 405.86,
+          "confidence": 1,
+          "end": 406.14,
+          "word": "giving",
+          "punct": "giving",
+          "index": 4
+        },
+        {
+          "start": 406.14,
+          "confidence": 1,
+          "end": 406.47,
+          "word": "people",
+          "punct": "people",
+          "index": 5
+        },
+        {
+          "start": 406.47,
+          "confidence": 0.961,
+          "end": 407.08,
+          "word": "robots",
+          "punct": "robots",
+          "index": 6
+        },
+        {
+          "start": 407.08,
+          "confidence": 1,
+          "end": 407.44,
+          "word": "instead",
+          "punct": "instead",
+          "index": 7
+        },
+        {
+          "start": 407.44,
+          "confidence": 1,
+          "end": 407.52,
+          "word": "of",
+          "punct": "of",
+          "index": 8
+        },
+        {
+          "start": 407.52,
+          "confidence": 1,
+          "end": 407.86,
+          "word": "human",
+          "punct": "human",
+          "index": 9
+        },
+        {
+          "start": 407.86,
+          "confidence": 0.615,
+          "end": 408.47,
+          "word": "care",
+          "punct": "care.",
+          "index": 10
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 405.01,
+        "end": 405.13,
+        "confidence": 1,
+        "text": "I",
+        "offset": 0,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 405.13,
+        "end": 405.44,
+        "confidence": 1,
+        "text": "can't",
+        "offset": 2,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 405.44,
+        "end": 405.76,
+        "confidence": 1,
+        "text": "believe",
+        "offset": 8,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 405.76,
+        "end": 405.86,
+        "confidence": 0.801,
+        "text": "we're",
+        "offset": 16,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 405.86,
+        "end": 406.14,
+        "confidence": 1,
+        "text": "giving",
+        "offset": 22,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 406.14,
+        "end": 406.47,
+        "confidence": 1,
+        "text": "people",
+        "offset": 29,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 406.47,
+        "end": 407.08,
+        "confidence": 0.961,
+        "text": "robots",
+        "offset": 36,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 407.08,
+        "end": 407.44,
+        "confidence": 1,
+        "text": "instead",
+        "offset": 43,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 407.44,
+        "end": 407.52,
+        "confidence": 1,
+        "text": "of",
+        "offset": 51,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 407.52,
+        "end": 407.86,
+        "confidence": 1,
+        "text": "human",
+        "offset": 54,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 407.86,
+        "end": 408.47,
+        "confidence": 0.615,
+        "text": "care.",
+        "offset": 60,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And this is a really common response and I think it's absolutely correct because that would be terrible.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 410.53,
+      "words": [
+        {
+          "start": 410.53,
+          "confidence": 1,
+          "end": 410.68,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 410.68,
+          "confidence": 1,
+          "end": 410.81,
+          "word": "this",
+          "punct": "this",
+          "index": 1
+        },
+        {
+          "start": 410.81,
+          "confidence": 1,
+          "end": 410.92,
+          "word": "is",
+          "punct": "is",
+          "index": 2
+        },
+        {
+          "start": 410.92,
+          "confidence": 0.81,
+          "end": 411,
+          "word": "a",
+          "punct": "a",
+          "index": 3
+        },
+        {
+          "start": 411,
+          "confidence": 1,
+          "end": 411.35,
+          "word": "really",
+          "punct": "really",
+          "index": 4
+        },
+        {
+          "start": 411.35,
+          "confidence": 1,
+          "end": 411.66,
+          "word": "common",
+          "punct": "common",
+          "index": 5
+        },
+        {
+          "start": 411.66,
+          "confidence": 0.804,
+          "end": 412.36,
+          "word": "response",
+          "punct": "response",
+          "index": 6
+        },
+        {
+          "start": 412.39,
+          "confidence": 1,
+          "end": 412.67,
+          "word": "and",
+          "punct": "and",
+          "index": 7
+        },
+        {
+          "start": 412.7,
+          "confidence": 1,
+          "end": 412.79,
+          "word": "I",
+          "punct": "I",
+          "index": 8
+        },
+        {
+          "start": 412.79,
+          "confidence": 1,
+          "end": 413,
+          "word": "think",
+          "punct": "think",
+          "index": 9
+        },
+        {
+          "start": 413,
+          "confidence": 0.521,
+          "end": 413.16,
+          "word": "it's",
+          "punct": "it's",
+          "index": 10
+        },
+        {
+          "start": 413.24,
+          "confidence": 1,
+          "end": 414.02,
+          "word": "absolutely",
+          "punct": "absolutely",
+          "index": 11
+        },
+        {
+          "start": 414.02,
+          "confidence": 0.997,
+          "end": 414.72,
+          "word": "correct",
+          "punct": "correct",
+          "index": 12
+        },
+        {
+          "start": 414.92,
+          "confidence": 1,
+          "end": 415.28,
+          "word": "because",
+          "punct": "because",
+          "index": 13
+        },
+        {
+          "start": 415.28,
+          "confidence": 1,
+          "end": 415.55,
+          "word": "that",
+          "punct": "that",
+          "index": 14
+        },
+        {
+          "start": 415.55,
+          "confidence": 1,
+          "end": 415.85,
+          "word": "would",
+          "punct": "would",
+          "index": 15
+        },
+        {
+          "start": 415.85,
+          "confidence": 0.99,
+          "end": 416.11,
+          "word": "be",
+          "punct": "be",
+          "index": 16
+        },
+        {
+          "start": 416.11,
+          "confidence": 0.997,
+          "end": 416.97,
+          "word": "terrible",
+          "punct": "terrible.",
+          "index": 17
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 410.53,
+        "end": 410.68,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 410.68,
+        "end": 410.81,
+        "confidence": 1,
+        "text": "this",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 410.81,
+        "end": 410.92,
+        "confidence": 1,
+        "text": "is",
+        "offset": 9,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 410.92,
+        "end": 411,
+        "confidence": 0.81,
+        "text": "a",
+        "offset": 12,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 411,
+        "end": 411.35,
+        "confidence": 1,
+        "text": "really",
+        "offset": 14,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 411.35,
+        "end": 411.66,
+        "confidence": 1,
+        "text": "common",
+        "offset": 21,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 411.66,
+        "end": 412.36,
+        "confidence": 0.804,
+        "text": "response",
+        "offset": 28,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 412.39,
+        "end": 412.67,
+        "confidence": 1,
+        "text": "and",
+        "offset": 37,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 412.7,
+        "end": 412.79,
+        "confidence": 1,
+        "text": "I",
+        "offset": 41,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 412.79,
+        "end": 413,
+        "confidence": 1,
+        "text": "think",
+        "offset": 43,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 413,
+        "end": 413.16,
+        "confidence": 0.521,
+        "text": "it's",
+        "offset": 49,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 413.24,
+        "end": 414.02,
+        "confidence": 1,
+        "text": "absolutely",
+        "offset": 54,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 414.02,
+        "end": 414.72,
+        "confidence": 0.997,
+        "text": "correct",
+        "offset": 65,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 414.92,
+        "end": 415.28,
+        "confidence": 1,
+        "text": "because",
+        "offset": 73,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 415.28,
+        "end": 415.55,
+        "confidence": 1,
+        "text": "that",
+        "offset": 81,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 415.55,
+        "end": 415.85,
+        "confidence": 1,
+        "text": "would",
+        "offset": 86,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 415.85,
+        "end": 416.11,
+        "confidence": 0.99,
+        "text": "be",
+        "offset": 92,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 416.11,
+        "end": 416.97,
+        "confidence": 0.997,
+        "text": "terrible.",
+        "offset": 95,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "But in this case it's not with his robot replaces with his robot replaces is animal fair.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 417.81,
+      "words": [
+        {
+          "start": 417.81,
+          "confidence": 1,
+          "end": 417.93,
+          "word": "but",
+          "punct": "But",
+          "index": 0
+        },
+        {
+          "start": 417.93,
+          "confidence": 1,
+          "end": 418.04,
+          "word": "in",
+          "punct": "in",
+          "index": 1
+        },
+        {
+          "start": 418.04,
+          "confidence": 1,
+          "end": 418.22,
+          "word": "this",
+          "punct": "this",
+          "index": 2
+        },
+        {
+          "start": 418.22,
+          "confidence": 1,
+          "end": 418.44,
+          "word": "case",
+          "punct": "case",
+          "index": 3
+        },
+        {
+          "start": 418.44,
+          "confidence": 0.849,
+          "end": 418.58,
+          "word": "it's",
+          "punct": "it's",
+          "index": 4
+        },
+        {
+          "start": 418.58,
+          "confidence": 0.997,
+          "end": 418.81,
+          "word": "not",
+          "punct": "not",
+          "index": 5
+        },
+        {
+          "start": 418.81,
+          "confidence": 0.614,
+          "end": 418.9,
+          "word": "with",
+          "punct": "with",
+          "index": 6
+        },
+        {
+          "start": 418.9,
+          "confidence": 0.206,
+          "end": 419.04,
+          "word": "his",
+          "punct": "his",
+          "index": 7
+        },
+        {
+          "start": 419.04,
+          "confidence": 1,
+          "end": 419.4,
+          "word": "robot",
+          "punct": "robot",
+          "index": 8
+        },
+        {
+          "start": 419.4,
+          "confidence": 0.822,
+          "end": 420.22,
+          "word": "replaces",
+          "punct": "replaces",
+          "index": 9
+        },
+        {
+          "start": 420.74,
+          "confidence": 0.68,
+          "end": 420.98,
+          "word": "with",
+          "punct": "with",
+          "index": 10
+        },
+        {
+          "start": 420.98,
+          "confidence": 0.354,
+          "end": 421.13,
+          "word": "his",
+          "punct": "his",
+          "index": 11
+        },
+        {
+          "start": 421.13,
+          "confidence": 0.928,
+          "end": 421.54,
+          "word": "robot",
+          "punct": "robot",
+          "index": 12
+        },
+        {
+          "start": 421.54,
+          "confidence": 1,
+          "end": 422.2,
+          "word": "replaces",
+          "punct": "replaces",
+          "index": 13
+        },
+        {
+          "start": 422.23,
+          "confidence": 0.923,
+          "end": 422.47,
+          "word": "is",
+          "punct": "is",
+          "index": 14
+        },
+        {
+          "start": 422.5,
+          "confidence": 0.973,
+          "end": 422.9,
+          "word": "animal",
+          "punct": "animal",
+          "index": 15
+        },
+        {
+          "start": 422.9,
+          "confidence": 0.793,
+          "end": 423.23,
+          "word": "fair",
+          "punct": "fair.",
+          "index": 16
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 417.81,
+        "end": 417.93,
+        "confidence": 1,
+        "text": "But",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 417.93,
+        "end": 418.04,
+        "confidence": 1,
+        "text": "in",
+        "offset": 4,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 418.04,
+        "end": 418.22,
+        "confidence": 1,
+        "text": "this",
+        "offset": 7,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 418.22,
+        "end": 418.44,
+        "confidence": 1,
+        "text": "case",
+        "offset": 12,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 418.44,
+        "end": 418.58,
+        "confidence": 0.849,
+        "text": "it's",
+        "offset": 17,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 418.58,
+        "end": 418.81,
+        "confidence": 0.997,
+        "text": "not",
+        "offset": 22,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 418.81,
+        "end": 418.9,
+        "confidence": 0.614,
+        "text": "with",
+        "offset": 26,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 418.9,
+        "end": 419.04,
+        "confidence": 0.206,
+        "text": "his",
+        "offset": 31,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 419.04,
+        "end": 419.4,
+        "confidence": 1,
+        "text": "robot",
+        "offset": 35,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 419.4,
+        "end": 420.22,
+        "confidence": 0.822,
+        "text": "replaces",
+        "offset": 41,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 420.74,
+        "end": 420.98,
+        "confidence": 0.68,
+        "text": "with",
+        "offset": 50,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 420.98,
+        "end": 421.13,
+        "confidence": 0.354,
+        "text": "his",
+        "offset": 55,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 421.13,
+        "end": 421.54,
+        "confidence": 0.928,
+        "text": "robot",
+        "offset": 59,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 421.54,
+        "end": 422.2,
+        "confidence": 1,
+        "text": "replaces",
+        "offset": 65,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 422.23,
+        "end": 422.47,
+        "confidence": 0.923,
+        "text": "is",
+        "offset": 74,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 422.5,
+        "end": 422.9,
+        "confidence": 0.973,
+        "text": "animal",
+        "offset": 77,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 422.9,
+        "end": 423.23,
+        "confidence": 0.793,
+        "text": "fair.",
+        "offset": 84,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "In contexts where we can't use real animals but we can use robots because people will consistently treat them like more like more like an animal in a device.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 424.07,
+      "words": [
+        {
+          "start": 424.07,
+          "confidence": 0.438,
+          "end": 424.13,
+          "word": "in",
+          "punct": "In",
+          "index": 0
+        },
+        {
+          "start": 424.13,
+          "confidence": 0.371,
+          "end": 424.74,
+          "word": "contexts",
+          "punct": "contexts",
+          "index": 1
+        },
+        {
+          "start": 424.74,
+          "confidence": 0.33,
+          "end": 424.88,
+          "word": "where",
+          "punct": "where",
+          "index": 2
+        },
+        {
+          "start": 424.88,
+          "confidence": 0.569,
+          "end": 425,
+          "word": "we",
+          "punct": "we",
+          "index": 3
+        },
+        {
+          "start": 425,
+          "confidence": 0.798,
+          "end": 425.47,
+          "word": "can't",
+          "punct": "can't",
+          "index": 4
+        },
+        {
+          "start": 425.47,
+          "confidence": 1,
+          "end": 425.79,
+          "word": "use",
+          "punct": "use",
+          "index": 5
+        },
+        {
+          "start": 425.79,
+          "confidence": 1,
+          "end": 426.03,
+          "word": "real",
+          "punct": "real",
+          "index": 6
+        },
+        {
+          "start": 426.03,
+          "confidence": 1,
+          "end": 426.84,
+          "word": "animals",
+          "punct": "animals",
+          "index": 7
+        },
+        {
+          "start": 427.14,
+          "confidence": 0.754,
+          "end": 427.3,
+          "word": "but",
+          "punct": "but",
+          "index": 8
+        },
+        {
+          "start": 427.3,
+          "confidence": 1,
+          "end": 427.42,
+          "word": "we",
+          "punct": "we",
+          "index": 9
+        },
+        {
+          "start": 427.42,
+          "confidence": 0.676,
+          "end": 427.75,
+          "word": "can",
+          "punct": "can",
+          "index": 10
+        },
+        {
+          "start": 427.75,
+          "confidence": 0.964,
+          "end": 427.93,
+          "word": "use",
+          "punct": "use",
+          "index": 11
+        },
+        {
+          "start": 427.93,
+          "confidence": 0.822,
+          "end": 428.35,
+          "word": "robots",
+          "punct": "robots",
+          "index": 12
+        },
+        {
+          "start": 428.35,
+          "confidence": 0.965,
+          "end": 428.63,
+          "word": "because",
+          "punct": "because",
+          "index": 13
+        },
+        {
+          "start": 428.63,
+          "confidence": 1,
+          "end": 428.91,
+          "word": "people",
+          "punct": "people",
+          "index": 14
+        },
+        {
+          "start": 428.91,
+          "confidence": 0.547,
+          "end": 429.02,
+          "word": "will",
+          "punct": "will",
+          "index": 15
+        },
+        {
+          "start": 429.02,
+          "confidence": 1,
+          "end": 429.93,
+          "word": "consistently",
+          "punct": "consistently",
+          "index": 16
+        },
+        {
+          "start": 429.93,
+          "confidence": 1,
+          "end": 430.3,
+          "word": "treat",
+          "punct": "treat",
+          "index": 17
+        },
+        {
+          "start": 430.3,
+          "confidence": 1,
+          "end": 430.61,
+          "word": "them",
+          "punct": "them",
+          "index": 18
+        },
+        {
+          "start": 430.64,
+          "confidence": 1,
+          "end": 430.85,
+          "word": "like",
+          "punct": "like",
+          "index": 19
+        },
+        {
+          "start": 430.85,
+          "confidence": 1,
+          "end": 431.36,
+          "word": "more",
+          "punct": "more",
+          "index": 20
+        },
+        {
+          "start": 431.68,
+          "confidence": 0.199,
+          "end": 431.82,
+          "word": "like",
+          "punct": "like",
+          "index": 21
+        },
+        {
+          "start": 431.82,
+          "confidence": 0.974,
+          "end": 432.05,
+          "word": "more",
+          "punct": "more",
+          "index": 22
+        },
+        {
+          "start": 432.05,
+          "confidence": 1,
+          "end": 432.2,
+          "word": "like",
+          "punct": "like",
+          "index": 23
+        },
+        {
+          "start": 432.2,
+          "confidence": 0.523,
+          "end": 432.28,
+          "word": "an",
+          "punct": "an",
+          "index": 24
+        },
+        {
+          "start": 432.31,
+          "confidence": 0.986,
+          "end": 432.87,
+          "word": "animal",
+          "punct": "animal",
+          "index": 25
+        },
+        {
+          "start": 432.91,
+          "confidence": 0.143,
+          "end": 433.02,
+          "word": "in",
+          "punct": "in",
+          "index": 26
+        },
+        {
+          "start": 433.02,
+          "confidence": 0.128,
+          "end": 433.09,
+          "word": "a",
+          "punct": "a",
+          "index": 27
+        },
+        {
+          "start": 433.09,
+          "confidence": 0.145,
+          "end": 433.65,
+          "word": "device",
+          "punct": "device.",
+          "index": 28
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 424.07,
+        "end": 424.13,
+        "confidence": 0.438,
+        "text": "In",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 424.13,
+        "end": 424.74,
+        "confidence": 0.371,
+        "text": "contexts",
+        "offset": 3,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 424.74,
+        "end": 424.88,
+        "confidence": 0.33,
+        "text": "where",
+        "offset": 12,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 424.88,
+        "end": 425,
+        "confidence": 0.569,
+        "text": "we",
+        "offset": 18,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 425,
+        "end": 425.47,
+        "confidence": 0.798,
+        "text": "can't",
+        "offset": 21,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 425.47,
+        "end": 425.79,
+        "confidence": 1,
+        "text": "use",
+        "offset": 27,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 425.79,
+        "end": 426.03,
+        "confidence": 1,
+        "text": "real",
+        "offset": 31,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 426.03,
+        "end": 426.84,
+        "confidence": 1,
+        "text": "animals",
+        "offset": 36,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 427.14,
+        "end": 427.3,
+        "confidence": 0.754,
+        "text": "but",
+        "offset": 44,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 427.3,
+        "end": 427.42,
+        "confidence": 1,
+        "text": "we",
+        "offset": 48,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 427.42,
+        "end": 427.75,
+        "confidence": 0.676,
+        "text": "can",
+        "offset": 51,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 427.75,
+        "end": 427.93,
+        "confidence": 0.964,
+        "text": "use",
+        "offset": 55,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 427.93,
+        "end": 428.35,
+        "confidence": 0.822,
+        "text": "robots",
+        "offset": 59,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 428.35,
+        "end": 428.63,
+        "confidence": 0.965,
+        "text": "because",
+        "offset": 66,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 428.63,
+        "end": 428.91,
+        "confidence": 1,
+        "text": "people",
+        "offset": 74,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 428.91,
+        "end": 429.02,
+        "confidence": 0.547,
+        "text": "will",
+        "offset": 81,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 429.02,
+        "end": 429.93,
+        "confidence": 1,
+        "text": "consistently",
+        "offset": 86,
+        "length": 12,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 429.93,
+        "end": 430.3,
+        "confidence": 1,
+        "text": "treat",
+        "offset": 99,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 430.3,
+        "end": 430.61,
+        "confidence": 1,
+        "text": "them",
+        "offset": 105,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 430.64,
+        "end": 430.85,
+        "confidence": 1,
+        "text": "like",
+        "offset": 110,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 430.85,
+        "end": 431.36,
+        "confidence": 1,
+        "text": "more",
+        "offset": 115,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 431.68,
+        "end": 431.82,
+        "confidence": 0.199,
+        "text": "like",
+        "offset": 120,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 431.82,
+        "end": 432.05,
+        "confidence": 0.974,
+        "text": "more",
+        "offset": 125,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 432.05,
+        "end": 432.2,
+        "confidence": 1,
+        "text": "like",
+        "offset": 130,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 432.2,
+        "end": 432.28,
+        "confidence": 0.523,
+        "text": "an",
+        "offset": 135,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 432.31,
+        "end": 432.87,
+        "confidence": 0.986,
+        "text": "animal",
+        "offset": 138,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 432.91,
+        "end": 433.02,
+        "confidence": 0.143,
+        "text": "in",
+        "offset": 145,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 433.02,
+        "end": 433.09,
+        "confidence": 0.128,
+        "text": "a",
+        "offset": 148,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 433.09,
+        "end": 433.65,
+        "confidence": 0.145,
+        "text": "device.",
+        "offset": 150,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Technology in this emotional connection to robots can also help us anticipate challenges as these devices move into more intimate areas of people's lives.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 435.5,
+      "words": [
+        {
+          "start": 435.5,
+          "confidence": 0.703,
+          "end": 436.11,
+          "word": "technology",
+          "punct": "Technology",
+          "index": 0
+        },
+        {
+          "start": 436.11,
+          "confidence": 0.48,
+          "end": 436.18,
+          "word": "in",
+          "punct": "in",
+          "index": 1
+        },
+        {
+          "start": 436.18,
+          "confidence": 0.686,
+          "end": 436.34,
+          "word": "this",
+          "punct": "this",
+          "index": 2
+        },
+        {
+          "start": 436.34,
+          "confidence": 1,
+          "end": 436.74,
+          "word": "emotional",
+          "punct": "emotional",
+          "index": 3
+        },
+        {
+          "start": 436.74,
+          "confidence": 1,
+          "end": 437.18,
+          "word": "connection",
+          "punct": "connection",
+          "index": 4
+        },
+        {
+          "start": 437.18,
+          "confidence": 0.544,
+          "end": 437.26,
+          "word": "to",
+          "punct": "to",
+          "index": 5
+        },
+        {
+          "start": 437.26,
+          "confidence": 0.179,
+          "end": 437.56,
+          "word": "robots",
+          "punct": "robots",
+          "index": 6
+        },
+        {
+          "start": 437.56,
+          "confidence": 1,
+          "end": 437.72,
+          "word": "can",
+          "punct": "can",
+          "index": 7
+        },
+        {
+          "start": 437.72,
+          "confidence": 1,
+          "end": 438,
+          "word": "also",
+          "punct": "also",
+          "index": 8
+        },
+        {
+          "start": 438,
+          "confidence": 1,
+          "end": 438.24,
+          "word": "help",
+          "punct": "help",
+          "index": 9
+        },
+        {
+          "start": 438.24,
+          "confidence": 1,
+          "end": 438.36,
+          "word": "us",
+          "punct": "us",
+          "index": 10
+        },
+        {
+          "start": 438.36,
+          "confidence": 1,
+          "end": 438.91,
+          "word": "anticipate",
+          "punct": "anticipate",
+          "index": 11
+        },
+        {
+          "start": 438.91,
+          "confidence": 1,
+          "end": 439.83,
+          "word": "challenges",
+          "punct": "challenges",
+          "index": 12
+        },
+        {
+          "start": 439.86,
+          "confidence": 0.79,
+          "end": 440.12,
+          "word": "as",
+          "punct": "as",
+          "index": 13
+        },
+        {
+          "start": 440.12,
+          "confidence": 1,
+          "end": 440.27,
+          "word": "these",
+          "punct": "these",
+          "index": 14
+        },
+        {
+          "start": 440.27,
+          "confidence": 0.998,
+          "end": 440.84,
+          "word": "devices",
+          "punct": "devices",
+          "index": 15
+        },
+        {
+          "start": 440.84,
+          "confidence": 0.463,
+          "end": 441.2,
+          "word": "move",
+          "punct": "move",
+          "index": 16
+        },
+        {
+          "start": 441.2,
+          "confidence": 0.478,
+          "end": 441.42,
+          "word": "into",
+          "punct": "into",
+          "index": 17
+        },
+        {
+          "start": 441.42,
+          "confidence": 0.932,
+          "end": 441.56,
+          "word": "more",
+          "punct": "more",
+          "index": 18
+        },
+        {
+          "start": 441.56,
+          "confidence": 0.738,
+          "end": 441.98,
+          "word": "intimate",
+          "punct": "intimate",
+          "index": 19
+        },
+        {
+          "start": 441.98,
+          "confidence": 1,
+          "end": 442.32,
+          "word": "areas",
+          "punct": "areas",
+          "index": 20
+        },
+        {
+          "start": 442.32,
+          "confidence": 1,
+          "end": 442.42,
+          "word": "of",
+          "punct": "of",
+          "index": 21
+        },
+        {
+          "start": 442.42,
+          "confidence": 0.861,
+          "end": 442.77,
+          "word": "people's",
+          "punct": "people's",
+          "index": 22
+        },
+        {
+          "start": 442.77,
+          "confidence": 0.855,
+          "end": 443.36,
+          "word": "lives",
+          "punct": "lives.",
+          "index": 23
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 435.5,
+        "end": 436.11,
+        "confidence": 0.703,
+        "text": "Technology",
+        "offset": 0,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 436.11,
+        "end": 436.18,
+        "confidence": 0.48,
+        "text": "in",
+        "offset": 11,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 436.18,
+        "end": 436.34,
+        "confidence": 0.686,
+        "text": "this",
+        "offset": 14,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 436.34,
+        "end": 436.74,
+        "confidence": 1,
+        "text": "emotional",
+        "offset": 19,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 436.74,
+        "end": 437.18,
+        "confidence": 1,
+        "text": "connection",
+        "offset": 29,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 437.18,
+        "end": 437.26,
+        "confidence": 0.544,
+        "text": "to",
+        "offset": 40,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 437.26,
+        "end": 437.56,
+        "confidence": 0.179,
+        "text": "robots",
+        "offset": 43,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 437.56,
+        "end": 437.72,
+        "confidence": 1,
+        "text": "can",
+        "offset": 50,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 437.72,
+        "end": 438,
+        "confidence": 1,
+        "text": "also",
+        "offset": 54,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 438,
+        "end": 438.24,
+        "confidence": 1,
+        "text": "help",
+        "offset": 59,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 438.24,
+        "end": 438.36,
+        "confidence": 1,
+        "text": "us",
+        "offset": 64,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 438.36,
+        "end": 438.91,
+        "confidence": 1,
+        "text": "anticipate",
+        "offset": 67,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 438.91,
+        "end": 439.83,
+        "confidence": 1,
+        "text": "challenges",
+        "offset": 78,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 439.86,
+        "end": 440.12,
+        "confidence": 0.79,
+        "text": "as",
+        "offset": 89,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 440.12,
+        "end": 440.27,
+        "confidence": 1,
+        "text": "these",
+        "offset": 92,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 440.27,
+        "end": 440.84,
+        "confidence": 0.998,
+        "text": "devices",
+        "offset": 98,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 440.84,
+        "end": 441.2,
+        "confidence": 0.463,
+        "text": "move",
+        "offset": 106,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 441.2,
+        "end": 441.42,
+        "confidence": 0.478,
+        "text": "into",
+        "offset": 111,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 441.42,
+        "end": 441.56,
+        "confidence": 0.932,
+        "text": "more",
+        "offset": 116,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 441.56,
+        "end": 441.98,
+        "confidence": 0.738,
+        "text": "intimate",
+        "offset": 121,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 441.98,
+        "end": 442.32,
+        "confidence": 1,
+        "text": "areas",
+        "offset": 130,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 442.32,
+        "end": 442.42,
+        "confidence": 1,
+        "text": "of",
+        "offset": 136,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 442.42,
+        "end": 442.77,
+        "confidence": 0.861,
+        "text": "people's",
+        "offset": 139,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 442.77,
+        "end": 443.36,
+        "confidence": 0.855,
+        "text": "lives.",
+        "offset": 148,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "For example is it okay if your child's teddy bear robot records private conversations is it okay if your sex robot have compelling in app purchases.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 444.08,
+      "words": [
+        {
+          "start": 444.08,
+          "confidence": 1,
+          "end": 444.23,
+          "word": "for",
+          "punct": "For",
+          "index": 0
+        },
+        {
+          "start": 444.23,
+          "confidence": 1,
+          "end": 444.75,
+          "word": "example",
+          "punct": "example",
+          "index": 1
+        },
+        {
+          "start": 444.75,
+          "confidence": 0.92,
+          "end": 444.96,
+          "word": "is",
+          "punct": "is",
+          "index": 2
+        },
+        {
+          "start": 444.96,
+          "confidence": 0.935,
+          "end": 445.06,
+          "word": "it",
+          "punct": "it",
+          "index": 3
+        },
+        {
+          "start": 445.06,
+          "confidence": 1,
+          "end": 445.47,
+          "word": "okay",
+          "punct": "okay",
+          "index": 4
+        },
+        {
+          "start": 445.47,
+          "confidence": 0.845,
+          "end": 445.61,
+          "word": "if",
+          "punct": "if",
+          "index": 5
+        },
+        {
+          "start": 445.61,
+          "confidence": 0.985,
+          "end": 445.71,
+          "word": "your",
+          "punct": "your",
+          "index": 6
+        },
+        {
+          "start": 445.71,
+          "confidence": 0.897,
+          "end": 446.36,
+          "word": "child's",
+          "punct": "child's",
+          "index": 7
+        },
+        {
+          "start": 446.68,
+          "confidence": 1,
+          "end": 446.98,
+          "word": "teddy",
+          "punct": "teddy",
+          "index": 8
+        },
+        {
+          "start": 446.98,
+          "confidence": 1,
+          "end": 447.19,
+          "word": "bear",
+          "punct": "bear",
+          "index": 9
+        },
+        {
+          "start": 447.19,
+          "confidence": 1,
+          "end": 447.53,
+          "word": "robot",
+          "punct": "robot",
+          "index": 10
+        },
+        {
+          "start": 447.53,
+          "confidence": 0.792,
+          "end": 447.85,
+          "word": "records",
+          "punct": "records",
+          "index": 11
+        },
+        {
+          "start": 447.85,
+          "confidence": 1,
+          "end": 448.18,
+          "word": "private",
+          "punct": "private",
+          "index": 12
+        },
+        {
+          "start": 448.18,
+          "confidence": 0.794,
+          "end": 449.11,
+          "word": "conversations",
+          "punct": "conversations",
+          "index": 13
+        },
+        {
+          "start": 449.76,
+          "confidence": 0.719,
+          "end": 449.87,
+          "word": "is",
+          "punct": "is",
+          "index": 14
+        },
+        {
+          "start": 449.87,
+          "confidence": 0.883,
+          "end": 449.97,
+          "word": "it",
+          "punct": "it",
+          "index": 15
+        },
+        {
+          "start": 449.97,
+          "confidence": 1,
+          "end": 450.28,
+          "word": "okay",
+          "punct": "okay",
+          "index": 16
+        },
+        {
+          "start": 450.28,
+          "confidence": 0.731,
+          "end": 450.4,
+          "word": "if",
+          "punct": "if",
+          "index": 17
+        },
+        {
+          "start": 450.4,
+          "confidence": 0.992,
+          "end": 450.53,
+          "word": "your",
+          "punct": "your",
+          "index": 18
+        },
+        {
+          "start": 450.53,
+          "confidence": 1,
+          "end": 451.01,
+          "word": "sex",
+          "punct": "sex",
+          "index": 19
+        },
+        {
+          "start": 451.01,
+          "confidence": 0.645,
+          "end": 451.39,
+          "word": "robot",
+          "punct": "robot",
+          "index": 20
+        },
+        {
+          "start": 451.42,
+          "confidence": 0.568,
+          "end": 451.63,
+          "word": "have",
+          "punct": "have",
+          "index": 21
+        },
+        {
+          "start": 451.63,
+          "confidence": 0.99,
+          "end": 452.3,
+          "word": "compelling",
+          "punct": "compelling",
+          "index": 22
+        },
+        {
+          "start": 452.33,
+          "confidence": 1,
+          "end": 452.51,
+          "word": "in",
+          "punct": "in",
+          "index": 23
+        },
+        {
+          "start": 452.51,
+          "confidence": 0.945,
+          "end": 452.8,
+          "word": "app",
+          "punct": "app",
+          "index": 24
+        },
+        {
+          "start": 452.8,
+          "confidence": 0.998,
+          "end": 453.6,
+          "word": "purchases",
+          "punct": "purchases.",
+          "index": 25
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 444.08,
+        "end": 444.23,
+        "confidence": 1,
+        "text": "For",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 444.23,
+        "end": 444.75,
+        "confidence": 1,
+        "text": "example",
+        "offset": 4,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 444.75,
+        "end": 444.96,
+        "confidence": 0.92,
+        "text": "is",
+        "offset": 12,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 444.96,
+        "end": 445.06,
+        "confidence": 0.935,
+        "text": "it",
+        "offset": 15,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 445.06,
+        "end": 445.47,
+        "confidence": 1,
+        "text": "okay",
+        "offset": 18,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 445.47,
+        "end": 445.61,
+        "confidence": 0.845,
+        "text": "if",
+        "offset": 23,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 445.61,
+        "end": 445.71,
+        "confidence": 0.985,
+        "text": "your",
+        "offset": 26,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 445.71,
+        "end": 446.36,
+        "confidence": 0.897,
+        "text": "child's",
+        "offset": 31,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 446.68,
+        "end": 446.98,
+        "confidence": 1,
+        "text": "teddy",
+        "offset": 39,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 446.98,
+        "end": 447.19,
+        "confidence": 1,
+        "text": "bear",
+        "offset": 45,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 447.19,
+        "end": 447.53,
+        "confidence": 1,
+        "text": "robot",
+        "offset": 50,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 447.53,
+        "end": 447.85,
+        "confidence": 0.792,
+        "text": "records",
+        "offset": 56,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 447.85,
+        "end": 448.18,
+        "confidence": 1,
+        "text": "private",
+        "offset": 64,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 448.18,
+        "end": 449.11,
+        "confidence": 0.794,
+        "text": "conversations",
+        "offset": 72,
+        "length": 13,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 449.76,
+        "end": 449.87,
+        "confidence": 0.719,
+        "text": "is",
+        "offset": 86,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 449.87,
+        "end": 449.97,
+        "confidence": 0.883,
+        "text": "it",
+        "offset": 89,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 449.97,
+        "end": 450.28,
+        "confidence": 1,
+        "text": "okay",
+        "offset": 92,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 450.28,
+        "end": 450.4,
+        "confidence": 0.731,
+        "text": "if",
+        "offset": 97,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 450.4,
+        "end": 450.53,
+        "confidence": 0.992,
+        "text": "your",
+        "offset": 100,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 450.53,
+        "end": 451.01,
+        "confidence": 1,
+        "text": "sex",
+        "offset": 105,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 451.01,
+        "end": 451.39,
+        "confidence": 0.645,
+        "text": "robot",
+        "offset": 109,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 451.42,
+        "end": 451.63,
+        "confidence": 0.568,
+        "text": "have",
+        "offset": 115,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 451.63,
+        "end": 452.3,
+        "confidence": 0.99,
+        "text": "compelling",
+        "offset": 120,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 452.33,
+        "end": 452.51,
+        "confidence": 1,
+        "text": "in",
+        "offset": 131,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 452.51,
+        "end": 452.8,
+        "confidence": 0.945,
+        "text": "app",
+        "offset": 134,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 452.8,
+        "end": 453.6,
+        "confidence": 0.998,
+        "text": "purchases.",
+        "offset": 138,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Because of rope plus capitalism equals questions around consumer protection and privacy.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 455.28,
+      "words": [
+        {
+          "start": 455.28,
+          "confidence": 0.994,
+          "end": 455.63,
+          "word": "because",
+          "punct": "Because",
+          "index": 0
+        },
+        {
+          "start": 455.63,
+          "confidence": 0.424,
+          "end": 455.74,
+          "word": "of",
+          "punct": "of",
+          "index": 1
+        },
+        {
+          "start": 455.74,
+          "confidence": 0.257,
+          "end": 456.02,
+          "word": "rope",
+          "punct": "rope",
+          "index": 2
+        },
+        {
+          "start": 456.32,
+          "confidence": 0.502,
+          "end": 456.62,
+          "word": "plus",
+          "punct": "plus",
+          "index": 3
+        },
+        {
+          "start": 456.62,
+          "confidence": 1,
+          "end": 457.77,
+          "word": "capitalism",
+          "punct": "capitalism",
+          "index": 4
+        },
+        {
+          "start": 457.8,
+          "confidence": 0.767,
+          "end": 458.16,
+          "word": "equals",
+          "punct": "equals",
+          "index": 5
+        },
+        {
+          "start": 458.16,
+          "confidence": 0.952,
+          "end": 458.89,
+          "word": "questions",
+          "punct": "questions",
+          "index": 6
+        },
+        {
+          "start": 458.92,
+          "confidence": 0.997,
+          "end": 459.48,
+          "word": "around",
+          "punct": "around",
+          "index": 7
+        },
+        {
+          "start": 459.72,
+          "confidence": 1,
+          "end": 460.17,
+          "word": "consumer",
+          "punct": "consumer",
+          "index": 8
+        },
+        {
+          "start": 460.17,
+          "confidence": 0.999,
+          "end": 460.77,
+          "word": "protection",
+          "punct": "protection",
+          "index": 9
+        },
+        {
+          "start": 460.77,
+          "confidence": 0.671,
+          "end": 460.9,
+          "word": "and",
+          "punct": "and",
+          "index": 10
+        },
+        {
+          "start": 460.9,
+          "confidence": 0.997,
+          "end": 461.52,
+          "word": "privacy",
+          "punct": "privacy.",
+          "index": 11
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 455.28,
+        "end": 455.63,
+        "confidence": 0.994,
+        "text": "Because",
+        "offset": 0,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 455.63,
+        "end": 455.74,
+        "confidence": 0.424,
+        "text": "of",
+        "offset": 8,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 455.74,
+        "end": 456.02,
+        "confidence": 0.257,
+        "text": "rope",
+        "offset": 11,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 456.32,
+        "end": 456.62,
+        "confidence": 0.502,
+        "text": "plus",
+        "offset": 16,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 456.62,
+        "end": 457.77,
+        "confidence": 1,
+        "text": "capitalism",
+        "offset": 21,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 457.8,
+        "end": 458.16,
+        "confidence": 0.767,
+        "text": "equals",
+        "offset": 32,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 458.16,
+        "end": 458.89,
+        "confidence": 0.952,
+        "text": "questions",
+        "offset": 39,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 458.92,
+        "end": 459.48,
+        "confidence": 0.997,
+        "text": "around",
+        "offset": 49,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 459.72,
+        "end": 460.17,
+        "confidence": 1,
+        "text": "consumer",
+        "offset": 56,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 460.17,
+        "end": 460.77,
+        "confidence": 0.999,
+        "text": "protection",
+        "offset": 65,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 460.77,
+        "end": 460.9,
+        "confidence": 0.671,
+        "text": "and",
+        "offset": 76,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 460.9,
+        "end": 461.52,
+        "confidence": 0.997,
+        "text": "privacy.",
+        "offset": 80,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And those aren't the only reasons that our behavior around these machines could matter.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 462.55,
+      "words": [
+        {
+          "start": 462.55,
+          "confidence": 1,
+          "end": 462.7,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 462.7,
+          "confidence": 0.741,
+          "end": 462.86,
+          "word": "those",
+          "punct": "those",
+          "index": 1
+        },
+        {
+          "start": 462.86,
+          "confidence": 0.827,
+          "end": 463.11,
+          "word": "aren't",
+          "punct": "aren't",
+          "index": 2
+        },
+        {
+          "start": 463.11,
+          "confidence": 0.988,
+          "end": 463.25,
+          "word": "the",
+          "punct": "the",
+          "index": 3
+        },
+        {
+          "start": 463.25,
+          "confidence": 1,
+          "end": 463.51,
+          "word": "only",
+          "punct": "only",
+          "index": 4
+        },
+        {
+          "start": 463.51,
+          "confidence": 0.971,
+          "end": 463.93,
+          "word": "reasons",
+          "punct": "reasons",
+          "index": 5
+        },
+        {
+          "start": 463.93,
+          "confidence": 0.817,
+          "end": 464.06,
+          "word": "that",
+          "punct": "that",
+          "index": 6
+        },
+        {
+          "start": 464.06,
+          "confidence": 0.931,
+          "end": 464.15,
+          "word": "our",
+          "punct": "our",
+          "index": 7
+        },
+        {
+          "start": 464.15,
+          "confidence": 0.994,
+          "end": 464.78,
+          "word": "behavior",
+          "punct": "behavior",
+          "index": 8
+        },
+        {
+          "start": 464.78,
+          "confidence": 0.941,
+          "end": 465.03,
+          "word": "around",
+          "punct": "around",
+          "index": 9
+        },
+        {
+          "start": 465.03,
+          "confidence": 1,
+          "end": 465.19,
+          "word": "these",
+          "punct": "these",
+          "index": 10
+        },
+        {
+          "start": 465.19,
+          "confidence": 1,
+          "end": 465.62,
+          "word": "machines",
+          "punct": "machines",
+          "index": 11
+        },
+        {
+          "start": 465.62,
+          "confidence": 1,
+          "end": 465.82,
+          "word": "could",
+          "punct": "could",
+          "index": 12
+        },
+        {
+          "start": 465.82,
+          "confidence": 0.976,
+          "end": 466.25,
+          "word": "matter",
+          "punct": "matter.",
+          "index": 13
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 462.55,
+        "end": 462.7,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 462.7,
+        "end": 462.86,
+        "confidence": 0.741,
+        "text": "those",
+        "offset": 4,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 462.86,
+        "end": 463.11,
+        "confidence": 0.827,
+        "text": "aren't",
+        "offset": 10,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 463.11,
+        "end": 463.25,
+        "confidence": 0.988,
+        "text": "the",
+        "offset": 17,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 463.25,
+        "end": 463.51,
+        "confidence": 1,
+        "text": "only",
+        "offset": 21,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 463.51,
+        "end": 463.93,
+        "confidence": 0.971,
+        "text": "reasons",
+        "offset": 26,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 463.93,
+        "end": 464.06,
+        "confidence": 0.817,
+        "text": "that",
+        "offset": 34,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 464.06,
+        "end": 464.15,
+        "confidence": 0.931,
+        "text": "our",
+        "offset": 39,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 464.15,
+        "end": 464.78,
+        "confidence": 0.994,
+        "text": "behavior",
+        "offset": 43,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 464.78,
+        "end": 465.03,
+        "confidence": 0.941,
+        "text": "around",
+        "offset": 52,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 465.03,
+        "end": 465.19,
+        "confidence": 1,
+        "text": "these",
+        "offset": 59,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 465.19,
+        "end": 465.62,
+        "confidence": 1,
+        "text": "machines",
+        "offset": 65,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 465.62,
+        "end": 465.82,
+        "confidence": 1,
+        "text": "could",
+        "offset": 74,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 465.82,
+        "end": 466.25,
+        "confidence": 0.976,
+        "text": "matter.",
+        "offset": 80,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "A few years after that first initial experience I had with this baby dinosaur robot.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 468.73,
+      "words": [
+        {
+          "start": 468.73,
+          "confidence": 1,
+          "end": 468.82,
+          "word": "a",
+          "punct": "A",
+          "index": 0
+        },
+        {
+          "start": 468.82,
+          "confidence": 1,
+          "end": 469.05,
+          "word": "few",
+          "punct": "few",
+          "index": 1
+        },
+        {
+          "start": 469.05,
+          "confidence": 1,
+          "end": 469.31,
+          "word": "years",
+          "punct": "years",
+          "index": 2
+        },
+        {
+          "start": 469.31,
+          "confidence": 1,
+          "end": 470.03,
+          "word": "after",
+          "punct": "after",
+          "index": 3
+        },
+        {
+          "start": 470.13,
+          "confidence": 1,
+          "end": 470.34,
+          "word": "that",
+          "punct": "that",
+          "index": 4
+        },
+        {
+          "start": 470.34,
+          "confidence": 1,
+          "end": 470.7,
+          "word": "first",
+          "punct": "first",
+          "index": 5
+        },
+        {
+          "start": 470.7,
+          "confidence": 1,
+          "end": 471.07,
+          "word": "initial",
+          "punct": "initial",
+          "index": 6
+        },
+        {
+          "start": 471.07,
+          "confidence": 1,
+          "end": 471.69,
+          "word": "experience",
+          "punct": "experience",
+          "index": 7
+        },
+        {
+          "start": 471.69,
+          "confidence": 1,
+          "end": 471.77,
+          "word": "I",
+          "punct": "I",
+          "index": 8
+        },
+        {
+          "start": 471.77,
+          "confidence": 1,
+          "end": 472.06,
+          "word": "had",
+          "punct": "had",
+          "index": 9
+        },
+        {
+          "start": 472.06,
+          "confidence": 1,
+          "end": 472.19,
+          "word": "with",
+          "punct": "with",
+          "index": 10
+        },
+        {
+          "start": 472.19,
+          "confidence": 1,
+          "end": 472.37,
+          "word": "this",
+          "punct": "this",
+          "index": 11
+        },
+        {
+          "start": 472.37,
+          "confidence": 0.949,
+          "end": 472.66,
+          "word": "baby",
+          "punct": "baby",
+          "index": 12
+        },
+        {
+          "start": 472.66,
+          "confidence": 0.811,
+          "end": 473.07,
+          "word": "dinosaur",
+          "punct": "dinosaur",
+          "index": 13
+        },
+        {
+          "start": 473.07,
+          "confidence": 0.894,
+          "end": 473.59,
+          "word": "robot",
+          "punct": "robot.",
+          "index": 14
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 468.73,
+        "end": 468.82,
+        "confidence": 1,
+        "text": "A",
+        "offset": 0,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 468.82,
+        "end": 469.05,
+        "confidence": 1,
+        "text": "few",
+        "offset": 2,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 469.05,
+        "end": 469.31,
+        "confidence": 1,
+        "text": "years",
+        "offset": 6,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 469.31,
+        "end": 470.03,
+        "confidence": 1,
+        "text": "after",
+        "offset": 12,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 470.13,
+        "end": 470.34,
+        "confidence": 1,
+        "text": "that",
+        "offset": 18,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 470.34,
+        "end": 470.7,
+        "confidence": 1,
+        "text": "first",
+        "offset": 23,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 470.7,
+        "end": 471.07,
+        "confidence": 1,
+        "text": "initial",
+        "offset": 29,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 471.07,
+        "end": 471.69,
+        "confidence": 1,
+        "text": "experience",
+        "offset": 37,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 471.69,
+        "end": 471.77,
+        "confidence": 1,
+        "text": "I",
+        "offset": 48,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 471.77,
+        "end": 472.06,
+        "confidence": 1,
+        "text": "had",
+        "offset": 50,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 472.06,
+        "end": 472.19,
+        "confidence": 1,
+        "text": "with",
+        "offset": 54,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 472.19,
+        "end": 472.37,
+        "confidence": 1,
+        "text": "this",
+        "offset": 59,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 472.37,
+        "end": 472.66,
+        "confidence": 0.949,
+        "text": "baby",
+        "offset": 64,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 472.66,
+        "end": 473.07,
+        "confidence": 0.811,
+        "text": "dinosaur",
+        "offset": 69,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 473.07,
+        "end": 473.59,
+        "confidence": 0.894,
+        "text": "robot.",
+        "offset": 78,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "I did a workshop with my friend harness gossip and we took five of these baby dinosaur robots and we gave them the five teams of people and we have them name them and play with them and interact with them for about an hour.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 474.43,
+      "words": [
+        {
+          "start": 474.43,
+          "confidence": 0.967,
+          "end": 474.47,
+          "word": "I",
+          "punct": "I",
+          "index": 0
+        },
+        {
+          "start": 474.47,
+          "confidence": 0.852,
+          "end": 474.64,
+          "word": "did",
+          "punct": "did",
+          "index": 1
+        },
+        {
+          "start": 474.64,
+          "confidence": 0.685,
+          "end": 474.69,
+          "word": "a",
+          "punct": "a",
+          "index": 2
+        },
+        {
+          "start": 474.69,
+          "confidence": 0.993,
+          "end": 475.14,
+          "word": "workshop",
+          "punct": "workshop",
+          "index": 3
+        },
+        {
+          "start": 475.14,
+          "confidence": 1,
+          "end": 475.28,
+          "word": "with",
+          "punct": "with",
+          "index": 4
+        },
+        {
+          "start": 475.28,
+          "confidence": 1,
+          "end": 475.37,
+          "word": "my",
+          "punct": "my",
+          "index": 5
+        },
+        {
+          "start": 475.37,
+          "confidence": 0.883,
+          "end": 475.68,
+          "word": "friend",
+          "punct": "friend",
+          "index": 6
+        },
+        {
+          "start": 475.68,
+          "confidence": 0.147,
+          "end": 476.01,
+          "word": "harness",
+          "punct": "harness",
+          "index": 7
+        },
+        {
+          "start": 476.01,
+          "confidence": 0.199,
+          "end": 476.48,
+          "word": "gossip",
+          "punct": "gossip",
+          "index": 8
+        },
+        {
+          "start": 476.88,
+          "confidence": 1,
+          "end": 477.25,
+          "word": "and",
+          "punct": "and",
+          "index": 9
+        },
+        {
+          "start": 477.54,
+          "confidence": 1,
+          "end": 477.68,
+          "word": "we",
+          "punct": "we",
+          "index": 10
+        },
+        {
+          "start": 477.68,
+          "confidence": 1,
+          "end": 477.86,
+          "word": "took",
+          "punct": "took",
+          "index": 11
+        },
+        {
+          "start": 477.86,
+          "confidence": 1,
+          "end": 478.24,
+          "word": "five",
+          "punct": "five",
+          "index": 12
+        },
+        {
+          "start": 478.24,
+          "confidence": 1,
+          "end": 478.35,
+          "word": "of",
+          "punct": "of",
+          "index": 13
+        },
+        {
+          "start": 478.35,
+          "confidence": 0.997,
+          "end": 478.63,
+          "word": "these",
+          "punct": "these",
+          "index": 14
+        },
+        {
+          "start": 478.63,
+          "confidence": 0.57,
+          "end": 478.89,
+          "word": "baby",
+          "punct": "baby",
+          "index": 15
+        },
+        {
+          "start": 478.89,
+          "confidence": 1,
+          "end": 479.31,
+          "word": "dinosaur",
+          "punct": "dinosaur",
+          "index": 16
+        },
+        {
+          "start": 479.31,
+          "confidence": 1,
+          "end": 479.75,
+          "word": "robots",
+          "punct": "robots",
+          "index": 17
+        },
+        {
+          "start": 479.75,
+          "confidence": 1,
+          "end": 479.9,
+          "word": "and",
+          "punct": "and",
+          "index": 18
+        },
+        {
+          "start": 479.9,
+          "confidence": 1,
+          "end": 479.99,
+          "word": "we",
+          "punct": "we",
+          "index": 19
+        },
+        {
+          "start": 479.99,
+          "confidence": 0.682,
+          "end": 480.19,
+          "word": "gave",
+          "punct": "gave",
+          "index": 20
+        },
+        {
+          "start": 480.19,
+          "confidence": 0.871,
+          "end": 480.31,
+          "word": "them",
+          "punct": "them",
+          "index": 21
+        },
+        {
+          "start": 480.31,
+          "confidence": 0.342,
+          "end": 480.4,
+          "word": "the",
+          "punct": "the",
+          "index": 22
+        },
+        {
+          "start": 480.4,
+          "confidence": 1,
+          "end": 480.74,
+          "word": "five",
+          "punct": "five",
+          "index": 23
+        },
+        {
+          "start": 480.74,
+          "confidence": 1,
+          "end": 481.07,
+          "word": "teams",
+          "punct": "teams",
+          "index": 24
+        },
+        {
+          "start": 481.07,
+          "confidence": 1,
+          "end": 481.16,
+          "word": "of",
+          "punct": "of",
+          "index": 25
+        },
+        {
+          "start": 481.16,
+          "confidence": 1,
+          "end": 481.71,
+          "word": "people",
+          "punct": "people",
+          "index": 26
+        },
+        {
+          "start": 482.28,
+          "confidence": 0.78,
+          "end": 482.39,
+          "word": "and",
+          "punct": "and",
+          "index": 27
+        },
+        {
+          "start": 482.39,
+          "confidence": 1,
+          "end": 482.47,
+          "word": "we",
+          "punct": "we",
+          "index": 28
+        },
+        {
+          "start": 482.47,
+          "confidence": 0.628,
+          "end": 482.68,
+          "word": "have",
+          "punct": "have",
+          "index": 29
+        },
+        {
+          "start": 482.68,
+          "confidence": 0.577,
+          "end": 482.81,
+          "word": "them",
+          "punct": "them",
+          "index": 30
+        },
+        {
+          "start": 482.81,
+          "confidence": 0.94,
+          "end": 483.18,
+          "word": "name",
+          "punct": "name",
+          "index": 31
+        },
+        {
+          "start": 483.18,
+          "confidence": 0.991,
+          "end": 483.65,
+          "word": "them",
+          "punct": "them",
+          "index": 32
+        },
+        {
+          "start": 483.98,
+          "confidence": 1,
+          "end": 484.15,
+          "word": "and",
+          "punct": "and",
+          "index": 33
+        },
+        {
+          "start": 484.15,
+          "confidence": 1,
+          "end": 484.42,
+          "word": "play",
+          "punct": "play",
+          "index": 34
+        },
+        {
+          "start": 484.42,
+          "confidence": 1,
+          "end": 484.59,
+          "word": "with",
+          "punct": "with",
+          "index": 35
+        },
+        {
+          "start": 484.59,
+          "confidence": 1,
+          "end": 485.1,
+          "word": "them",
+          "punct": "them",
+          "index": 36
+        },
+        {
+          "start": 485.13,
+          "confidence": 1,
+          "end": 485.27,
+          "word": "and",
+          "punct": "and",
+          "index": 37
+        },
+        {
+          "start": 485.27,
+          "confidence": 1,
+          "end": 485.78,
+          "word": "interact",
+          "punct": "interact",
+          "index": 38
+        },
+        {
+          "start": 485.78,
+          "confidence": 1,
+          "end": 485.91,
+          "word": "with",
+          "punct": "with",
+          "index": 39
+        },
+        {
+          "start": 485.91,
+          "confidence": 1,
+          "end": 486.26,
+          "word": "them",
+          "punct": "them",
+          "index": 40
+        },
+        {
+          "start": 486.26,
+          "confidence": 1,
+          "end": 486.7,
+          "word": "for",
+          "punct": "for",
+          "index": 41
+        },
+        {
+          "start": 486.82,
+          "confidence": 1,
+          "end": 487.15,
+          "word": "about",
+          "punct": "about",
+          "index": 42
+        },
+        {
+          "start": 487.15,
+          "confidence": 1,
+          "end": 487.26,
+          "word": "an",
+          "punct": "an",
+          "index": 43
+        },
+        {
+          "start": 487.26,
+          "confidence": 0.982,
+          "end": 487.71,
+          "word": "hour",
+          "punct": "hour.",
+          "index": 44
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 474.43,
+        "end": 474.47,
+        "confidence": 0.967,
+        "text": "I",
+        "offset": 0,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 474.47,
+        "end": 474.64,
+        "confidence": 0.852,
+        "text": "did",
+        "offset": 2,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 474.64,
+        "end": 474.69,
+        "confidence": 0.685,
+        "text": "a",
+        "offset": 6,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 474.69,
+        "end": 475.14,
+        "confidence": 0.993,
+        "text": "workshop",
+        "offset": 8,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 475.14,
+        "end": 475.28,
+        "confidence": 1,
+        "text": "with",
+        "offset": 17,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 475.28,
+        "end": 475.37,
+        "confidence": 1,
+        "text": "my",
+        "offset": 22,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 475.37,
+        "end": 475.68,
+        "confidence": 0.883,
+        "text": "friend",
+        "offset": 25,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 475.68,
+        "end": 476.01,
+        "confidence": 0.147,
+        "text": "harness",
+        "offset": 32,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 476.01,
+        "end": 476.48,
+        "confidence": 0.199,
+        "text": "gossip",
+        "offset": 40,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 476.88,
+        "end": 477.25,
+        "confidence": 1,
+        "text": "and",
+        "offset": 47,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 477.54,
+        "end": 477.68,
+        "confidence": 1,
+        "text": "we",
+        "offset": 51,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 477.68,
+        "end": 477.86,
+        "confidence": 1,
+        "text": "took",
+        "offset": 54,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 477.86,
+        "end": 478.24,
+        "confidence": 1,
+        "text": "five",
+        "offset": 59,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 478.24,
+        "end": 478.35,
+        "confidence": 1,
+        "text": "of",
+        "offset": 64,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 478.35,
+        "end": 478.63,
+        "confidence": 0.997,
+        "text": "these",
+        "offset": 67,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 478.63,
+        "end": 478.89,
+        "confidence": 0.57,
+        "text": "baby",
+        "offset": 73,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 478.89,
+        "end": 479.31,
+        "confidence": 1,
+        "text": "dinosaur",
+        "offset": 78,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 479.31,
+        "end": 479.75,
+        "confidence": 1,
+        "text": "robots",
+        "offset": 87,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 479.75,
+        "end": 479.9,
+        "confidence": 1,
+        "text": "and",
+        "offset": 94,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 479.9,
+        "end": 479.99,
+        "confidence": 1,
+        "text": "we",
+        "offset": 98,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 479.99,
+        "end": 480.19,
+        "confidence": 0.682,
+        "text": "gave",
+        "offset": 101,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 480.19,
+        "end": 480.31,
+        "confidence": 0.871,
+        "text": "them",
+        "offset": 106,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 480.31,
+        "end": 480.4,
+        "confidence": 0.342,
+        "text": "the",
+        "offset": 111,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 480.4,
+        "end": 480.74,
+        "confidence": 1,
+        "text": "five",
+        "offset": 115,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 480.74,
+        "end": 481.07,
+        "confidence": 1,
+        "text": "teams",
+        "offset": 120,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 481.07,
+        "end": 481.16,
+        "confidence": 1,
+        "text": "of",
+        "offset": 126,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 481.16,
+        "end": 481.71,
+        "confidence": 1,
+        "text": "people",
+        "offset": 129,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 482.28,
+        "end": 482.39,
+        "confidence": 0.78,
+        "text": "and",
+        "offset": 136,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 482.39,
+        "end": 482.47,
+        "confidence": 1,
+        "text": "we",
+        "offset": 140,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 482.47,
+        "end": 482.68,
+        "confidence": 0.628,
+        "text": "have",
+        "offset": 143,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 482.68,
+        "end": 482.81,
+        "confidence": 0.577,
+        "text": "them",
+        "offset": 148,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 482.81,
+        "end": 483.18,
+        "confidence": 0.94,
+        "text": "name",
+        "offset": 153,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 483.18,
+        "end": 483.65,
+        "confidence": 0.991,
+        "text": "them",
+        "offset": 158,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 483.98,
+        "end": 484.15,
+        "confidence": 1,
+        "text": "and",
+        "offset": 163,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 484.15,
+        "end": 484.42,
+        "confidence": 1,
+        "text": "play",
+        "offset": 167,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 484.42,
+        "end": 484.59,
+        "confidence": 1,
+        "text": "with",
+        "offset": 172,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 484.59,
+        "end": 485.1,
+        "confidence": 1,
+        "text": "them",
+        "offset": 177,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 485.13,
+        "end": 485.27,
+        "confidence": 1,
+        "text": "and",
+        "offset": 182,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 485.27,
+        "end": 485.78,
+        "confidence": 1,
+        "text": "interact",
+        "offset": 186,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 485.78,
+        "end": 485.91,
+        "confidence": 1,
+        "text": "with",
+        "offset": 195,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 485.91,
+        "end": 486.26,
+        "confidence": 1,
+        "text": "them",
+        "offset": 200,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 486.26,
+        "end": 486.7,
+        "confidence": 1,
+        "text": "for",
+        "offset": 205,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 486.82,
+        "end": 487.15,
+        "confidence": 1,
+        "text": "about",
+        "offset": 209,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 487.15,
+        "end": 487.26,
+        "confidence": 1,
+        "text": "an",
+        "offset": 215,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 487.26,
+        "end": 487.71,
+        "confidence": 0.982,
+        "text": "hour.",
+        "offset": 218,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And then we unveiled a hammer and hatchet and we told them to torture and kill the robots.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 488.69,
+      "words": [
+        {
+          "start": 488.69,
+          "confidence": 1,
+          "end": 488.89,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 488.89,
+          "confidence": 1,
+          "end": 489.05,
+          "word": "then",
+          "punct": "then",
+          "index": 1
+        },
+        {
+          "start": 489.05,
+          "confidence": 1,
+          "end": 489.16,
+          "word": "we",
+          "punct": "we",
+          "index": 2
+        },
+        {
+          "start": 489.16,
+          "confidence": 1,
+          "end": 489.69,
+          "word": "unveiled",
+          "punct": "unveiled",
+          "index": 3
+        },
+        {
+          "start": 489.72,
+          "confidence": 0.903,
+          "end": 489.81,
+          "word": "a",
+          "punct": "a",
+          "index": 4
+        },
+        {
+          "start": 489.81,
+          "confidence": 0.985,
+          "end": 490.19,
+          "word": "hammer",
+          "punct": "hammer",
+          "index": 5
+        },
+        {
+          "start": 490.19,
+          "confidence": 0.88,
+          "end": 490.32,
+          "word": "and",
+          "punct": "and",
+          "index": 6
+        },
+        {
+          "start": 490.32,
+          "confidence": 1,
+          "end": 490.9,
+          "word": "hatchet",
+          "punct": "hatchet",
+          "index": 7
+        },
+        {
+          "start": 490.93,
+          "confidence": 1,
+          "end": 491.04,
+          "word": "and",
+          "punct": "and",
+          "index": 8
+        },
+        {
+          "start": 491.04,
+          "confidence": 1,
+          "end": 491.14,
+          "word": "we",
+          "punct": "we",
+          "index": 9
+        },
+        {
+          "start": 491.14,
+          "confidence": 1,
+          "end": 491.38,
+          "word": "told",
+          "punct": "told",
+          "index": 10
+        },
+        {
+          "start": 491.38,
+          "confidence": 0.704,
+          "end": 491.49,
+          "word": "them",
+          "punct": "them",
+          "index": 11
+        },
+        {
+          "start": 491.49,
+          "confidence": 1,
+          "end": 491.59,
+          "word": "to",
+          "punct": "to",
+          "index": 12
+        },
+        {
+          "start": 491.59,
+          "confidence": 1,
+          "end": 492.01,
+          "word": "torture",
+          "punct": "torture",
+          "index": 13
+        },
+        {
+          "start": 492.01,
+          "confidence": 1,
+          "end": 492.12,
+          "word": "and",
+          "punct": "and",
+          "index": 14
+        },
+        {
+          "start": 492.12,
+          "confidence": 1,
+          "end": 492.41,
+          "word": "kill",
+          "punct": "kill",
+          "index": 15
+        },
+        {
+          "start": 492.41,
+          "confidence": 1,
+          "end": 492.51,
+          "word": "the",
+          "punct": "the",
+          "index": 16
+        },
+        {
+          "start": 492.51,
+          "confidence": 0.467,
+          "end": 493.17,
+          "word": "robots",
+          "punct": "robots.",
+          "index": 17
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 488.69,
+        "end": 488.89,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 488.89,
+        "end": 489.05,
+        "confidence": 1,
+        "text": "then",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 489.05,
+        "end": 489.16,
+        "confidence": 1,
+        "text": "we",
+        "offset": 9,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 489.16,
+        "end": 489.69,
+        "confidence": 1,
+        "text": "unveiled",
+        "offset": 12,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 489.72,
+        "end": 489.81,
+        "confidence": 0.903,
+        "text": "a",
+        "offset": 21,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 489.81,
+        "end": 490.19,
+        "confidence": 0.985,
+        "text": "hammer",
+        "offset": 23,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 490.19,
+        "end": 490.32,
+        "confidence": 0.88,
+        "text": "and",
+        "offset": 30,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 490.32,
+        "end": 490.9,
+        "confidence": 1,
+        "text": "hatchet",
+        "offset": 34,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 490.93,
+        "end": 491.04,
+        "confidence": 1,
+        "text": "and",
+        "offset": 42,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 491.04,
+        "end": 491.14,
+        "confidence": 1,
+        "text": "we",
+        "offset": 46,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 491.14,
+        "end": 491.38,
+        "confidence": 1,
+        "text": "told",
+        "offset": 49,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 491.38,
+        "end": 491.49,
+        "confidence": 0.704,
+        "text": "them",
+        "offset": 54,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 491.49,
+        "end": 491.59,
+        "confidence": 1,
+        "text": "to",
+        "offset": 59,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 491.59,
+        "end": 492.01,
+        "confidence": 1,
+        "text": "torture",
+        "offset": 62,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 492.01,
+        "end": 492.12,
+        "confidence": 1,
+        "text": "and",
+        "offset": 70,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 492.12,
+        "end": 492.41,
+        "confidence": 1,
+        "text": "kill",
+        "offset": 74,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 492.41,
+        "end": 492.51,
+        "confidence": 1,
+        "text": "the",
+        "offset": 79,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 492.51,
+        "end": 493.17,
+        "confidence": 0.467,
+        "text": "robots.",
+        "offset": 83,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And this turned out to be a little more dramatic than we expected it to be because none of the participants would even so much a strike these baby dinosaur robots so we had to improvise a little and at some point he said okay.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 496.84,
+      "words": [
+        {
+          "start": 496.84,
+          "confidence": 0.614,
+          "end": 497.07,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 497.17,
+          "confidence": 0.966,
+          "end": 497.4,
+          "word": "this",
+          "punct": "this",
+          "index": 1
+        },
+        {
+          "start": 497.4,
+          "confidence": 1,
+          "end": 497.64,
+          "word": "turned",
+          "punct": "turned",
+          "index": 2
+        },
+        {
+          "start": 497.64,
+          "confidence": 1,
+          "end": 497.78,
+          "word": "out",
+          "punct": "out",
+          "index": 3
+        },
+        {
+          "start": 497.78,
+          "confidence": 1,
+          "end": 497.91,
+          "word": "to",
+          "punct": "to",
+          "index": 4
+        },
+        {
+          "start": 497.91,
+          "confidence": 1,
+          "end": 498.02,
+          "word": "be",
+          "punct": "be",
+          "index": 5
+        },
+        {
+          "start": 498.02,
+          "confidence": 1,
+          "end": 498.09,
+          "word": "a",
+          "punct": "a",
+          "index": 6
+        },
+        {
+          "start": 498.09,
+          "confidence": 1,
+          "end": 498.28,
+          "word": "little",
+          "punct": "little",
+          "index": 7
+        },
+        {
+          "start": 498.28,
+          "confidence": 1,
+          "end": 498.44,
+          "word": "more",
+          "punct": "more",
+          "index": 8
+        },
+        {
+          "start": 498.44,
+          "confidence": 1,
+          "end": 498.97,
+          "word": "dramatic",
+          "punct": "dramatic",
+          "index": 9
+        },
+        {
+          "start": 498.97,
+          "confidence": 1,
+          "end": 499.12,
+          "word": "than",
+          "punct": "than",
+          "index": 10
+        },
+        {
+          "start": 499.12,
+          "confidence": 0.614,
+          "end": 499.22,
+          "word": "we",
+          "punct": "we",
+          "index": 11
+        },
+        {
+          "start": 499.22,
+          "confidence": 0.993,
+          "end": 499.9,
+          "word": "expected",
+          "punct": "expected",
+          "index": 12
+        },
+        {
+          "start": 499.9,
+          "confidence": 1,
+          "end": 500,
+          "word": "it",
+          "punct": "it",
+          "index": 13
+        },
+        {
+          "start": 500,
+          "confidence": 1,
+          "end": 500.11,
+          "word": "to",
+          "punct": "to",
+          "index": 14
+        },
+        {
+          "start": 500.11,
+          "confidence": 1,
+          "end": 500.29,
+          "word": "be",
+          "punct": "be",
+          "index": 15
+        },
+        {
+          "start": 500.29,
+          "confidence": 1,
+          "end": 500.57,
+          "word": "because",
+          "punct": "because",
+          "index": 16
+        },
+        {
+          "start": 500.57,
+          "confidence": 1,
+          "end": 500.89,
+          "word": "none",
+          "punct": "none",
+          "index": 17
+        },
+        {
+          "start": 500.89,
+          "confidence": 1,
+          "end": 501,
+          "word": "of",
+          "punct": "of",
+          "index": 18
+        },
+        {
+          "start": 501,
+          "confidence": 1,
+          "end": 501.09,
+          "word": "the",
+          "punct": "the",
+          "index": 19
+        },
+        {
+          "start": 501.09,
+          "confidence": 1,
+          "end": 501.84,
+          "word": "participants",
+          "punct": "participants",
+          "index": 20
+        },
+        {
+          "start": 501.84,
+          "confidence": 0.562,
+          "end": 502.09,
+          "word": "would",
+          "punct": "would",
+          "index": 21
+        },
+        {
+          "start": 502.44,
+          "confidence": 1,
+          "end": 502.7,
+          "word": "even",
+          "punct": "even",
+          "index": 22
+        },
+        {
+          "start": 502.7,
+          "confidence": 1,
+          "end": 502.83,
+          "word": "so",
+          "punct": "so",
+          "index": 23
+        },
+        {
+          "start": 502.83,
+          "confidence": 1,
+          "end": 502.99,
+          "word": "much",
+          "punct": "much",
+          "index": 24
+        },
+        {
+          "start": 502.99,
+          "confidence": 0.507,
+          "end": 503.07,
+          "word": "a",
+          "punct": "a",
+          "index": 25
+        },
+        {
+          "start": 503.07,
+          "confidence": 0.964,
+          "end": 503.54,
+          "word": "strike",
+          "punct": "strike",
+          "index": 26
+        },
+        {
+          "start": 503.54,
+          "confidence": 0.982,
+          "end": 503.76,
+          "word": "these",
+          "punct": "these",
+          "index": 27
+        },
+        {
+          "start": 503.76,
+          "confidence": 0.396,
+          "end": 503.96,
+          "word": "baby",
+          "punct": "baby",
+          "index": 28
+        },
+        {
+          "start": 503.96,
+          "confidence": 1,
+          "end": 504.33,
+          "word": "dinosaur",
+          "punct": "dinosaur",
+          "index": 29
+        },
+        {
+          "start": 504.33,
+          "confidence": 0.688,
+          "end": 504.76,
+          "word": "robots",
+          "punct": "robots",
+          "index": 30
+        },
+        {
+          "start": 504.76,
+          "confidence": 0.97,
+          "end": 505.12,
+          "word": "so",
+          "punct": "so",
+          "index": 31
+        },
+        {
+          "start": 505.36,
+          "confidence": 1,
+          "end": 505.54,
+          "word": "we",
+          "punct": "we",
+          "index": 32
+        },
+        {
+          "start": 505.54,
+          "confidence": 0.734,
+          "end": 505.64,
+          "word": "had",
+          "punct": "had",
+          "index": 33
+        },
+        {
+          "start": 505.64,
+          "confidence": 1,
+          "end": 505.72,
+          "word": "to",
+          "punct": "to",
+          "index": 34
+        },
+        {
+          "start": 505.72,
+          "confidence": 1,
+          "end": 506.2,
+          "word": "improvise",
+          "punct": "improvise",
+          "index": 35
+        },
+        {
+          "start": 506.2,
+          "confidence": 1,
+          "end": 506.26,
+          "word": "a",
+          "punct": "a",
+          "index": 36
+        },
+        {
+          "start": 506.26,
+          "confidence": 1,
+          "end": 506.71,
+          "word": "little",
+          "punct": "little",
+          "index": 37
+        },
+        {
+          "start": 507.35,
+          "confidence": 0.451,
+          "end": 507.75,
+          "word": "and",
+          "punct": "and",
+          "index": 38
+        },
+        {
+          "start": 507.79,
+          "confidence": 1,
+          "end": 507.98,
+          "word": "at",
+          "punct": "at",
+          "index": 39
+        },
+        {
+          "start": 507.98,
+          "confidence": 1,
+          "end": 508.13,
+          "word": "some",
+          "punct": "some",
+          "index": 40
+        },
+        {
+          "start": 508.13,
+          "confidence": 0.98,
+          "end": 508.32,
+          "word": "point",
+          "punct": "point",
+          "index": 41
+        },
+        {
+          "start": 508.32,
+          "confidence": 0.406,
+          "end": 508.4,
+          "word": "he",
+          "punct": "he",
+          "index": 42
+        },
+        {
+          "start": 508.4,
+          "confidence": 0.996,
+          "end": 508.71,
+          "word": "said",
+          "punct": "said",
+          "index": 43
+        },
+        {
+          "start": 508.71,
+          "confidence": 0.981,
+          "end": 509.34,
+          "word": "okay",
+          "punct": "okay.",
+          "index": 44
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 496.84,
+        "end": 497.07,
+        "confidence": 0.614,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 497.17,
+        "end": 497.4,
+        "confidence": 0.966,
+        "text": "this",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 497.4,
+        "end": 497.64,
+        "confidence": 1,
+        "text": "turned",
+        "offset": 9,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 497.64,
+        "end": 497.78,
+        "confidence": 1,
+        "text": "out",
+        "offset": 16,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 497.78,
+        "end": 497.91,
+        "confidence": 1,
+        "text": "to",
+        "offset": 20,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 497.91,
+        "end": 498.02,
+        "confidence": 1,
+        "text": "be",
+        "offset": 23,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 498.02,
+        "end": 498.09,
+        "confidence": 1,
+        "text": "a",
+        "offset": 26,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 498.09,
+        "end": 498.28,
+        "confidence": 1,
+        "text": "little",
+        "offset": 28,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 498.28,
+        "end": 498.44,
+        "confidence": 1,
+        "text": "more",
+        "offset": 35,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 498.44,
+        "end": 498.97,
+        "confidence": 1,
+        "text": "dramatic",
+        "offset": 40,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 498.97,
+        "end": 499.12,
+        "confidence": 1,
+        "text": "than",
+        "offset": 49,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 499.12,
+        "end": 499.22,
+        "confidence": 0.614,
+        "text": "we",
+        "offset": 54,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 499.22,
+        "end": 499.9,
+        "confidence": 0.993,
+        "text": "expected",
+        "offset": 57,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 499.9,
+        "end": 500,
+        "confidence": 1,
+        "text": "it",
+        "offset": 66,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 500,
+        "end": 500.11,
+        "confidence": 1,
+        "text": "to",
+        "offset": 69,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 500.11,
+        "end": 500.29,
+        "confidence": 1,
+        "text": "be",
+        "offset": 72,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 500.29,
+        "end": 500.57,
+        "confidence": 1,
+        "text": "because",
+        "offset": 75,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 500.57,
+        "end": 500.89,
+        "confidence": 1,
+        "text": "none",
+        "offset": 83,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 500.89,
+        "end": 501,
+        "confidence": 1,
+        "text": "of",
+        "offset": 88,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 501,
+        "end": 501.09,
+        "confidence": 1,
+        "text": "the",
+        "offset": 91,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 501.09,
+        "end": 501.84,
+        "confidence": 1,
+        "text": "participants",
+        "offset": 95,
+        "length": 12,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 501.84,
+        "end": 502.09,
+        "confidence": 0.562,
+        "text": "would",
+        "offset": 108,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 502.44,
+        "end": 502.7,
+        "confidence": 1,
+        "text": "even",
+        "offset": 114,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 502.7,
+        "end": 502.83,
+        "confidence": 1,
+        "text": "so",
+        "offset": 119,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 502.83,
+        "end": 502.99,
+        "confidence": 1,
+        "text": "much",
+        "offset": 122,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 502.99,
+        "end": 503.07,
+        "confidence": 0.507,
+        "text": "a",
+        "offset": 127,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 503.07,
+        "end": 503.54,
+        "confidence": 0.964,
+        "text": "strike",
+        "offset": 129,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 503.54,
+        "end": 503.76,
+        "confidence": 0.982,
+        "text": "these",
+        "offset": 136,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 503.76,
+        "end": 503.96,
+        "confidence": 0.396,
+        "text": "baby",
+        "offset": 142,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 503.96,
+        "end": 504.33,
+        "confidence": 1,
+        "text": "dinosaur",
+        "offset": 147,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 504.33,
+        "end": 504.76,
+        "confidence": 0.688,
+        "text": "robots",
+        "offset": 156,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 504.76,
+        "end": 505.12,
+        "confidence": 0.97,
+        "text": "so",
+        "offset": 163,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 505.36,
+        "end": 505.54,
+        "confidence": 1,
+        "text": "we",
+        "offset": 166,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 505.54,
+        "end": 505.64,
+        "confidence": 0.734,
+        "text": "had",
+        "offset": 169,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 505.64,
+        "end": 505.72,
+        "confidence": 1,
+        "text": "to",
+        "offset": 173,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 505.72,
+        "end": 506.2,
+        "confidence": 1,
+        "text": "improvise",
+        "offset": 176,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 506.2,
+        "end": 506.26,
+        "confidence": 1,
+        "text": "a",
+        "offset": 186,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 506.26,
+        "end": 506.71,
+        "confidence": 1,
+        "text": "little",
+        "offset": 188,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 507.35,
+        "end": 507.75,
+        "confidence": 0.451,
+        "text": "and",
+        "offset": 195,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 507.79,
+        "end": 507.98,
+        "confidence": 1,
+        "text": "at",
+        "offset": 199,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 507.98,
+        "end": 508.13,
+        "confidence": 1,
+        "text": "some",
+        "offset": 202,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 508.13,
+        "end": 508.32,
+        "confidence": 0.98,
+        "text": "point",
+        "offset": 207,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 508.32,
+        "end": 508.4,
+        "confidence": 0.406,
+        "text": "he",
+        "offset": 213,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 508.4,
+        "end": 508.71,
+        "confidence": 0.996,
+        "text": "said",
+        "offset": 216,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 508.71,
+        "end": 509.34,
+        "confidence": 0.981,
+        "text": "okay.",
+        "offset": 221,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "You can save your team's robot if you destroy another team's robot.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 510.06,
+      "words": [
+        {
+          "start": 510.06,
+          "confidence": 1,
+          "end": 510.33,
+          "word": "you",
+          "punct": "You",
+          "index": 0
+        },
+        {
+          "start": 510.33,
+          "confidence": 0.783,
+          "end": 510.49,
+          "word": "can",
+          "punct": "can",
+          "index": 1
+        },
+        {
+          "start": 510.49,
+          "confidence": 0.979,
+          "end": 510.8,
+          "word": "save",
+          "punct": "save",
+          "index": 2
+        },
+        {
+          "start": 510.8,
+          "confidence": 1,
+          "end": 511.13,
+          "word": "your",
+          "punct": "your",
+          "index": 3
+        },
+        {
+          "start": 511.13,
+          "confidence": 0.686,
+          "end": 511.59,
+          "word": "team's",
+          "punct": "team's",
+          "index": 4
+        },
+        {
+          "start": 511.59,
+          "confidence": 0.917,
+          "end": 512.08,
+          "word": "robot",
+          "punct": "robot",
+          "index": 5
+        },
+        {
+          "start": 512.11,
+          "confidence": 1,
+          "end": 512.3,
+          "word": "if",
+          "punct": "if",
+          "index": 6
+        },
+        {
+          "start": 512.3,
+          "confidence": 1,
+          "end": 512.44,
+          "word": "you",
+          "punct": "you",
+          "index": 7
+        },
+        {
+          "start": 512.44,
+          "confidence": 0.97,
+          "end": 513.01,
+          "word": "destroy",
+          "punct": "destroy",
+          "index": 8
+        },
+        {
+          "start": 513.04,
+          "confidence": 0.894,
+          "end": 513.6,
+          "word": "another",
+          "punct": "another",
+          "index": 9
+        },
+        {
+          "start": 513.6,
+          "confidence": 0.624,
+          "end": 514.01,
+          "word": "team's",
+          "punct": "team's",
+          "index": 10
+        },
+        {
+          "start": 514.01,
+          "confidence": 0.335,
+          "end": 514.56,
+          "word": "robot",
+          "punct": "robot.",
+          "index": 11
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 510.06,
+        "end": 510.33,
+        "confidence": 1,
+        "text": "You",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 510.33,
+        "end": 510.49,
+        "confidence": 0.783,
+        "text": "can",
+        "offset": 4,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 510.49,
+        "end": 510.8,
+        "confidence": 0.979,
+        "text": "save",
+        "offset": 8,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 510.8,
+        "end": 511.13,
+        "confidence": 1,
+        "text": "your",
+        "offset": 13,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 511.13,
+        "end": 511.59,
+        "confidence": 0.686,
+        "text": "team's",
+        "offset": 18,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 511.59,
+        "end": 512.08,
+        "confidence": 0.917,
+        "text": "robot",
+        "offset": 25,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 512.11,
+        "end": 512.3,
+        "confidence": 1,
+        "text": "if",
+        "offset": 31,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 512.3,
+        "end": 512.44,
+        "confidence": 1,
+        "text": "you",
+        "offset": 34,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 512.44,
+        "end": 513.01,
+        "confidence": 0.97,
+        "text": "destroy",
+        "offset": 38,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 513.04,
+        "end": 513.6,
+        "confidence": 0.894,
+        "text": "another",
+        "offset": 46,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 513.6,
+        "end": 514.01,
+        "confidence": 0.624,
+        "text": "team's",
+        "offset": 54,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 514.01,
+        "end": 514.56,
+        "confidence": 0.335,
+        "text": "robot.",
+        "offset": 61,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And even that didn't work they couldn't do it so finally we said we're going to destroy all of the robots unless someone takes a hatchet to one of them.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 516.82,
+      "words": [
+        {
+          "start": 516.82,
+          "confidence": 0.84,
+          "end": 516.99,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 516.99,
+          "confidence": 0.975,
+          "end": 517.18,
+          "word": "even",
+          "punct": "even",
+          "index": 1
+        },
+        {
+          "start": 517.18,
+          "confidence": 1,
+          "end": 517.33,
+          "word": "that",
+          "punct": "that",
+          "index": 2
+        },
+        {
+          "start": 517.33,
+          "confidence": 1,
+          "end": 517.58,
+          "word": "didn't",
+          "punct": "didn't",
+          "index": 3
+        },
+        {
+          "start": 517.58,
+          "confidence": 1,
+          "end": 517.82,
+          "word": "work",
+          "punct": "work",
+          "index": 4
+        },
+        {
+          "start": 517.82,
+          "confidence": 0.721,
+          "end": 517.93,
+          "word": "they",
+          "punct": "they",
+          "index": 5
+        },
+        {
+          "start": 517.93,
+          "confidence": 0.985,
+          "end": 518.22,
+          "word": "couldn't",
+          "punct": "couldn't",
+          "index": 6
+        },
+        {
+          "start": 518.22,
+          "confidence": 1,
+          "end": 518.33,
+          "word": "do",
+          "punct": "do",
+          "index": 7
+        },
+        {
+          "start": 518.33,
+          "confidence": 0.989,
+          "end": 518.53,
+          "word": "it",
+          "punct": "it",
+          "index": 8
+        },
+        {
+          "start": 518.64,
+          "confidence": 1,
+          "end": 518.82,
+          "word": "so",
+          "punct": "so",
+          "index": 9
+        },
+        {
+          "start": 518.82,
+          "confidence": 1,
+          "end": 519.24,
+          "word": "finally",
+          "punct": "finally",
+          "index": 10
+        },
+        {
+          "start": 519.24,
+          "confidence": 0.304,
+          "end": 519.33,
+          "word": "we",
+          "punct": "we",
+          "index": 11
+        },
+        {
+          "start": 519.33,
+          "confidence": 1,
+          "end": 519.75,
+          "word": "said",
+          "punct": "said",
+          "index": 12
+        },
+        {
+          "start": 519.99,
+          "confidence": 1,
+          "end": 520.22,
+          "word": "we're",
+          "punct": "we're",
+          "index": 13
+        },
+        {
+          "start": 520.22,
+          "confidence": 0.471,
+          "end": 520.34,
+          "word": "going",
+          "punct": "going",
+          "index": 14
+        },
+        {
+          "start": 520.34,
+          "confidence": 0.471,
+          "end": 520.4,
+          "word": "to",
+          "punct": "to",
+          "index": 15
+        },
+        {
+          "start": 520.4,
+          "confidence": 0.886,
+          "end": 520.88,
+          "word": "destroy",
+          "punct": "destroy",
+          "index": 16
+        },
+        {
+          "start": 520.91,
+          "confidence": 1,
+          "end": 521.17,
+          "word": "all",
+          "punct": "all",
+          "index": 17
+        },
+        {
+          "start": 521.17,
+          "confidence": 1,
+          "end": 521.27,
+          "word": "of",
+          "punct": "of",
+          "index": 18
+        },
+        {
+          "start": 521.27,
+          "confidence": 1,
+          "end": 521.37,
+          "word": "the",
+          "punct": "the",
+          "index": 19
+        },
+        {
+          "start": 521.37,
+          "confidence": 0.78,
+          "end": 521.91,
+          "word": "robots",
+          "punct": "robots",
+          "index": 20
+        },
+        {
+          "start": 521.94,
+          "confidence": 1,
+          "end": 522.22,
+          "word": "unless",
+          "punct": "unless",
+          "index": 21
+        },
+        {
+          "start": 522.22,
+          "confidence": 1,
+          "end": 522.49,
+          "word": "someone",
+          "punct": "someone",
+          "index": 22
+        },
+        {
+          "start": 522.49,
+          "confidence": 0.821,
+          "end": 522.69,
+          "word": "takes",
+          "punct": "takes",
+          "index": 23
+        },
+        {
+          "start": 522.69,
+          "confidence": 0.572,
+          "end": 522.76,
+          "word": "a",
+          "punct": "a",
+          "index": 24
+        },
+        {
+          "start": 522.76,
+          "confidence": 0.67,
+          "end": 523.23,
+          "word": "hatchet",
+          "punct": "hatchet",
+          "index": 25
+        },
+        {
+          "start": 523.23,
+          "confidence": 1,
+          "end": 523.35,
+          "word": "to",
+          "punct": "to",
+          "index": 26
+        },
+        {
+          "start": 523.35,
+          "confidence": 1,
+          "end": 523.55,
+          "word": "one",
+          "punct": "one",
+          "index": 27
+        },
+        {
+          "start": 523.55,
+          "confidence": 1,
+          "end": 523.68,
+          "word": "of",
+          "punct": "of",
+          "index": 28
+        },
+        {
+          "start": 523.68,
+          "confidence": 0.992,
+          "end": 524.01,
+          "word": "them",
+          "punct": "them.",
+          "index": 29
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 516.82,
+        "end": 516.99,
+        "confidence": 0.84,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 516.99,
+        "end": 517.18,
+        "confidence": 0.975,
+        "text": "even",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 517.18,
+        "end": 517.33,
+        "confidence": 1,
+        "text": "that",
+        "offset": 9,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 517.33,
+        "end": 517.58,
+        "confidence": 1,
+        "text": "didn't",
+        "offset": 14,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 517.58,
+        "end": 517.82,
+        "confidence": 1,
+        "text": "work",
+        "offset": 21,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 517.82,
+        "end": 517.93,
+        "confidence": 0.721,
+        "text": "they",
+        "offset": 26,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 517.93,
+        "end": 518.22,
+        "confidence": 0.985,
+        "text": "couldn't",
+        "offset": 31,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 518.22,
+        "end": 518.33,
+        "confidence": 1,
+        "text": "do",
+        "offset": 40,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 518.33,
+        "end": 518.53,
+        "confidence": 0.989,
+        "text": "it",
+        "offset": 43,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 518.64,
+        "end": 518.82,
+        "confidence": 1,
+        "text": "so",
+        "offset": 46,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 518.82,
+        "end": 519.24,
+        "confidence": 1,
+        "text": "finally",
+        "offset": 49,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 519.24,
+        "end": 519.33,
+        "confidence": 0.304,
+        "text": "we",
+        "offset": 57,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 519.33,
+        "end": 519.75,
+        "confidence": 1,
+        "text": "said",
+        "offset": 60,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 519.99,
+        "end": 520.22,
+        "confidence": 1,
+        "text": "we're",
+        "offset": 65,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 520.22,
+        "end": 520.34,
+        "confidence": 0.471,
+        "text": "going",
+        "offset": 71,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 520.34,
+        "end": 520.4,
+        "confidence": 0.471,
+        "text": "to",
+        "offset": 77,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 520.4,
+        "end": 520.88,
+        "confidence": 0.886,
+        "text": "destroy",
+        "offset": 80,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 520.91,
+        "end": 521.17,
+        "confidence": 1,
+        "text": "all",
+        "offset": 88,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 521.17,
+        "end": 521.27,
+        "confidence": 1,
+        "text": "of",
+        "offset": 92,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 521.27,
+        "end": 521.37,
+        "confidence": 1,
+        "text": "the",
+        "offset": 95,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 521.37,
+        "end": 521.91,
+        "confidence": 0.78,
+        "text": "robots",
+        "offset": 99,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 521.94,
+        "end": 522.22,
+        "confidence": 1,
+        "text": "unless",
+        "offset": 106,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 522.22,
+        "end": 522.49,
+        "confidence": 1,
+        "text": "someone",
+        "offset": 113,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 522.49,
+        "end": 522.69,
+        "confidence": 0.821,
+        "text": "takes",
+        "offset": 121,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 522.69,
+        "end": 522.76,
+        "confidence": 0.572,
+        "text": "a",
+        "offset": 127,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 522.76,
+        "end": 523.23,
+        "confidence": 0.67,
+        "text": "hatchet",
+        "offset": 129,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 523.23,
+        "end": 523.35,
+        "confidence": 1,
+        "text": "to",
+        "offset": 137,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 523.35,
+        "end": 523.55,
+        "confidence": 1,
+        "text": "one",
+        "offset": 140,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 523.55,
+        "end": 523.68,
+        "confidence": 1,
+        "text": "of",
+        "offset": 144,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 523.68,
+        "end": 524.01,
+        "confidence": 0.992,
+        "text": "them.",
+        "offset": 147,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And this guy stood up and he took the hatchet.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 525.56,
+      "words": [
+        {
+          "start": 525.56,
+          "confidence": 0.301,
+          "end": 525.78,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 525.78,
+          "confidence": 1,
+          "end": 525.96,
+          "word": "this",
+          "punct": "this",
+          "index": 1
+        },
+        {
+          "start": 525.96,
+          "confidence": 0.803,
+          "end": 526.2,
+          "word": "guy",
+          "punct": "guy",
+          "index": 2
+        },
+        {
+          "start": 526.2,
+          "confidence": 0.859,
+          "end": 526.48,
+          "word": "stood",
+          "punct": "stood",
+          "index": 3
+        },
+        {
+          "start": 526.48,
+          "confidence": 1,
+          "end": 526.75,
+          "word": "up",
+          "punct": "up",
+          "index": 4
+        },
+        {
+          "start": 526.78,
+          "confidence": 1,
+          "end": 527.06,
+          "word": "and",
+          "punct": "and",
+          "index": 5
+        },
+        {
+          "start": 527.06,
+          "confidence": 1,
+          "end": 527.28,
+          "word": "he",
+          "punct": "he",
+          "index": 6
+        },
+        {
+          "start": 527.28,
+          "confidence": 1,
+          "end": 527.61,
+          "word": "took",
+          "punct": "took",
+          "index": 7
+        },
+        {
+          "start": 527.61,
+          "confidence": 1,
+          "end": 527.71,
+          "word": "the",
+          "punct": "the",
+          "index": 8
+        },
+        {
+          "start": 527.71,
+          "confidence": 0.765,
+          "end": 528.33,
+          "word": "hatchet",
+          "punct": "hatchet.",
+          "index": 9
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 525.56,
+        "end": 525.78,
+        "confidence": 0.301,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 525.78,
+        "end": 525.96,
+        "confidence": 1,
+        "text": "this",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 525.96,
+        "end": 526.2,
+        "confidence": 0.803,
+        "text": "guy",
+        "offset": 9,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 526.2,
+        "end": 526.48,
+        "confidence": 0.859,
+        "text": "stood",
+        "offset": 13,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 526.48,
+        "end": 526.75,
+        "confidence": 1,
+        "text": "up",
+        "offset": 19,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 526.78,
+        "end": 527.06,
+        "confidence": 1,
+        "text": "and",
+        "offset": 22,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 527.06,
+        "end": 527.28,
+        "confidence": 1,
+        "text": "he",
+        "offset": 26,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 527.28,
+        "end": 527.61,
+        "confidence": 1,
+        "text": "took",
+        "offset": 29,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 527.61,
+        "end": 527.71,
+        "confidence": 1,
+        "text": "the",
+        "offset": 34,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 527.71,
+        "end": 528.33,
+        "confidence": 0.765,
+        "text": "hatchet.",
+        "offset": 38,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And the whole room winced as he brought the hatchet down on the robots neck and there was this half joking half serious moment of silence in the room for this fallen robot.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 529.18,
+      "words": [
+        {
+          "start": 529.18,
+          "confidence": 1,
+          "end": 529.37,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 529.37,
+          "confidence": 0.932,
+          "end": 529.44,
+          "word": "the",
+          "punct": "the",
+          "index": 1
+        },
+        {
+          "start": 529.44,
+          "confidence": 1,
+          "end": 529.7,
+          "word": "whole",
+          "punct": "whole",
+          "index": 2
+        },
+        {
+          "start": 529.7,
+          "confidence": 0.927,
+          "end": 530.06,
+          "word": "room",
+          "punct": "room",
+          "index": 3
+        },
+        {
+          "start": 530.06,
+          "confidence": 0.866,
+          "end": 530.56,
+          "word": "winced",
+          "punct": "winced",
+          "index": 4
+        },
+        {
+          "start": 530.56,
+          "confidence": 1,
+          "end": 530.66,
+          "word": "as",
+          "punct": "as",
+          "index": 5
+        },
+        {
+          "start": 530.66,
+          "confidence": 0.936,
+          "end": 530.76,
+          "word": "he",
+          "punct": "he",
+          "index": 6
+        },
+        {
+          "start": 530.76,
+          "confidence": 1,
+          "end": 531,
+          "word": "brought",
+          "punct": "brought",
+          "index": 7
+        },
+        {
+          "start": 531,
+          "confidence": 0.967,
+          "end": 531.08,
+          "word": "the",
+          "punct": "the",
+          "index": 8
+        },
+        {
+          "start": 531.08,
+          "confidence": 0.421,
+          "end": 531.47,
+          "word": "hatchet",
+          "punct": "hatchet",
+          "index": 9
+        },
+        {
+          "start": 531.47,
+          "confidence": 1,
+          "end": 531.73,
+          "word": "down",
+          "punct": "down",
+          "index": 10
+        },
+        {
+          "start": 531.73,
+          "confidence": 0.536,
+          "end": 531.82,
+          "word": "on",
+          "punct": "on",
+          "index": 11
+        },
+        {
+          "start": 531.82,
+          "confidence": 0.962,
+          "end": 531.93,
+          "word": "the",
+          "punct": "the",
+          "index": 12
+        },
+        {
+          "start": 531.93,
+          "confidence": 0.521,
+          "end": 532.4,
+          "word": "robots",
+          "punct": "robots",
+          "index": 13
+        },
+        {
+          "start": 532.4,
+          "confidence": 0.369,
+          "end": 533.02,
+          "word": "neck",
+          "punct": "neck",
+          "index": 14
+        },
+        {
+          "start": 533.68,
+          "confidence": 1,
+          "end": 534.06,
+          "word": "and",
+          "punct": "and",
+          "index": 15
+        },
+        {
+          "start": 534.09,
+          "confidence": 1,
+          "end": 534.33,
+          "word": "there",
+          "punct": "there",
+          "index": 16
+        },
+        {
+          "start": 534.33,
+          "confidence": 1,
+          "end": 534.5,
+          "word": "was",
+          "punct": "was",
+          "index": 17
+        },
+        {
+          "start": 534.5,
+          "confidence": 1,
+          "end": 534.65,
+          "word": "this",
+          "punct": "this",
+          "index": 18
+        },
+        {
+          "start": 534.65,
+          "confidence": 1,
+          "end": 535.11,
+          "word": "half",
+          "punct": "half",
+          "index": 19
+        },
+        {
+          "start": 535.11,
+          "confidence": 0.997,
+          "end": 535.83,
+          "word": "joking",
+          "punct": "joking",
+          "index": 20
+        },
+        {
+          "start": 536,
+          "confidence": 1,
+          "end": 536.65,
+          "word": "half",
+          "punct": "half",
+          "index": 21
+        },
+        {
+          "start": 536.68,
+          "confidence": 0.563,
+          "end": 537.4,
+          "word": "serious",
+          "punct": "serious",
+          "index": 22
+        },
+        {
+          "start": 537.4,
+          "confidence": 0.836,
+          "end": 537.8,
+          "word": "moment",
+          "punct": "moment",
+          "index": 23
+        },
+        {
+          "start": 537.8,
+          "confidence": 1,
+          "end": 537.87,
+          "word": "of",
+          "punct": "of",
+          "index": 24
+        },
+        {
+          "start": 537.87,
+          "confidence": 1,
+          "end": 538.54,
+          "word": "silence",
+          "punct": "silence",
+          "index": 25
+        },
+        {
+          "start": 538.54,
+          "confidence": 1,
+          "end": 538.79,
+          "word": "in",
+          "punct": "in",
+          "index": 26
+        },
+        {
+          "start": 538.79,
+          "confidence": 1,
+          "end": 538.89,
+          "word": "the",
+          "punct": "the",
+          "index": 27
+        },
+        {
+          "start": 538.89,
+          "confidence": 0.999,
+          "end": 539.52,
+          "word": "room",
+          "punct": "room",
+          "index": 28
+        },
+        {
+          "start": 540.02,
+          "confidence": 1,
+          "end": 540.26,
+          "word": "for",
+          "punct": "for",
+          "index": 29
+        },
+        {
+          "start": 540.26,
+          "confidence": 1,
+          "end": 540.45,
+          "word": "this",
+          "punct": "this",
+          "index": 30
+        },
+        {
+          "start": 540.45,
+          "confidence": 0.6,
+          "end": 540.96,
+          "word": "fallen",
+          "punct": "fallen",
+          "index": 31
+        },
+        {
+          "start": 540.96,
+          "confidence": 0.876,
+          "end": 541.57,
+          "word": "robot",
+          "punct": "robot.",
+          "index": 32
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 529.18,
+        "end": 529.37,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 529.37,
+        "end": 529.44,
+        "confidence": 0.932,
+        "text": "the",
+        "offset": 4,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 529.44,
+        "end": 529.7,
+        "confidence": 1,
+        "text": "whole",
+        "offset": 8,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 529.7,
+        "end": 530.06,
+        "confidence": 0.927,
+        "text": "room",
+        "offset": 14,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 530.06,
+        "end": 530.56,
+        "confidence": 0.866,
+        "text": "winced",
+        "offset": 19,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 530.56,
+        "end": 530.66,
+        "confidence": 1,
+        "text": "as",
+        "offset": 26,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 530.66,
+        "end": 530.76,
+        "confidence": 0.936,
+        "text": "he",
+        "offset": 29,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 530.76,
+        "end": 531,
+        "confidence": 1,
+        "text": "brought",
+        "offset": 32,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 531,
+        "end": 531.08,
+        "confidence": 0.967,
+        "text": "the",
+        "offset": 40,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 531.08,
+        "end": 531.47,
+        "confidence": 0.421,
+        "text": "hatchet",
+        "offset": 44,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 531.47,
+        "end": 531.73,
+        "confidence": 1,
+        "text": "down",
+        "offset": 52,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 531.73,
+        "end": 531.82,
+        "confidence": 0.536,
+        "text": "on",
+        "offset": 57,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 531.82,
+        "end": 531.93,
+        "confidence": 0.962,
+        "text": "the",
+        "offset": 60,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 531.93,
+        "end": 532.4,
+        "confidence": 0.521,
+        "text": "robots",
+        "offset": 64,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 532.4,
+        "end": 533.02,
+        "confidence": 0.369,
+        "text": "neck",
+        "offset": 71,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 533.68,
+        "end": 534.06,
+        "confidence": 1,
+        "text": "and",
+        "offset": 76,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 534.09,
+        "end": 534.33,
+        "confidence": 1,
+        "text": "there",
+        "offset": 80,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 534.33,
+        "end": 534.5,
+        "confidence": 1,
+        "text": "was",
+        "offset": 86,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 534.5,
+        "end": 534.65,
+        "confidence": 1,
+        "text": "this",
+        "offset": 90,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 534.65,
+        "end": 535.11,
+        "confidence": 1,
+        "text": "half",
+        "offset": 95,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 535.11,
+        "end": 535.83,
+        "confidence": 0.997,
+        "text": "joking",
+        "offset": 100,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 536,
+        "end": 536.65,
+        "confidence": 1,
+        "text": "half",
+        "offset": 107,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 536.68,
+        "end": 537.4,
+        "confidence": 0.563,
+        "text": "serious",
+        "offset": 112,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 537.4,
+        "end": 537.8,
+        "confidence": 0.836,
+        "text": "moment",
+        "offset": 120,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 537.8,
+        "end": 537.87,
+        "confidence": 1,
+        "text": "of",
+        "offset": 127,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 537.87,
+        "end": 538.54,
+        "confidence": 1,
+        "text": "silence",
+        "offset": 130,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 538.54,
+        "end": 538.79,
+        "confidence": 1,
+        "text": "in",
+        "offset": 138,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 538.79,
+        "end": 538.89,
+        "confidence": 1,
+        "text": "the",
+        "offset": 141,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 538.89,
+        "end": 539.52,
+        "confidence": 0.999,
+        "text": "room",
+        "offset": 145,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 540.02,
+        "end": 540.26,
+        "confidence": 1,
+        "text": "for",
+        "offset": 150,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 540.26,
+        "end": 540.45,
+        "confidence": 1,
+        "text": "this",
+        "offset": 154,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 540.45,
+        "end": 540.96,
+        "confidence": 0.6,
+        "text": "fallen",
+        "offset": 159,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 540.96,
+        "end": 541.57,
+        "confidence": 0.876,
+        "text": "robot.",
+        "offset": 166,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "So that was a really interesting experience no it wasn't a controlled study obviously but it did lead to some later research that I did it on my T. with plush non Dian Cynthia Brazil where we had people come into the lab and smash these hex bugs that move around in a really life like way like insects so instead of choosing something cute the people are drawn to which was something more basic and what we found was that high embassy people would hesitate more to hit the hex Bucks.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 543.2,
+      "words": [
+        {
+          "start": 543.2,
+          "confidence": 0.503,
+          "end": 543.53,
+          "word": "so",
+          "punct": "So",
+          "index": 0
+        },
+        {
+          "start": 543.63,
+          "confidence": 0.89,
+          "end": 543.83,
+          "word": "that",
+          "punct": "that",
+          "index": 1
+        },
+        {
+          "start": 543.83,
+          "confidence": 1,
+          "end": 544.03,
+          "word": "was",
+          "punct": "was",
+          "index": 2
+        },
+        {
+          "start": 544.03,
+          "confidence": 0.774,
+          "end": 544.12,
+          "word": "a",
+          "punct": "a",
+          "index": 3
+        },
+        {
+          "start": 544.12,
+          "confidence": 0.955,
+          "end": 544.52,
+          "word": "really",
+          "punct": "really",
+          "index": 4
+        },
+        {
+          "start": 544.55,
+          "confidence": 1,
+          "end": 545.36,
+          "word": "interesting",
+          "punct": "interesting",
+          "index": 5
+        },
+        {
+          "start": 545.36,
+          "confidence": 0.997,
+          "end": 546.52,
+          "word": "experience",
+          "punct": "experience",
+          "index": 6
+        },
+        {
+          "start": 546.9,
+          "confidence": 0.685,
+          "end": 547.08,
+          "word": "no",
+          "punct": "no",
+          "index": 7
+        },
+        {
+          "start": 547.08,
+          "confidence": 1,
+          "end": 547.25,
+          "word": "it",
+          "punct": "it",
+          "index": 8
+        },
+        {
+          "start": 547.25,
+          "confidence": 1,
+          "end": 547.53,
+          "word": "wasn't",
+          "punct": "wasn't",
+          "index": 9
+        },
+        {
+          "start": 547.53,
+          "confidence": 1,
+          "end": 547.58,
+          "word": "a",
+          "punct": "a",
+          "index": 10
+        },
+        {
+          "start": 547.58,
+          "confidence": 1,
+          "end": 548.25,
+          "word": "controlled",
+          "punct": "controlled",
+          "index": 11
+        },
+        {
+          "start": 548.25,
+          "confidence": 1,
+          "end": 548.7,
+          "word": "study",
+          "punct": "study",
+          "index": 12
+        },
+        {
+          "start": 548.7,
+          "confidence": 1,
+          "end": 549.33,
+          "word": "obviously",
+          "punct": "obviously",
+          "index": 13
+        },
+        {
+          "start": 549.33,
+          "confidence": 1,
+          "end": 549.56,
+          "word": "but",
+          "punct": "but",
+          "index": 14
+        },
+        {
+          "start": 549.56,
+          "confidence": 1,
+          "end": 549.7,
+          "word": "it",
+          "punct": "it",
+          "index": 15
+        },
+        {
+          "start": 549.7,
+          "confidence": 0.821,
+          "end": 549.92,
+          "word": "did",
+          "punct": "did",
+          "index": 16
+        },
+        {
+          "start": 549.92,
+          "confidence": 0.974,
+          "end": 550.13,
+          "word": "lead",
+          "punct": "lead",
+          "index": 17
+        },
+        {
+          "start": 550.13,
+          "confidence": 1,
+          "end": 550.21,
+          "word": "to",
+          "punct": "to",
+          "index": 18
+        },
+        {
+          "start": 550.21,
+          "confidence": 1,
+          "end": 550.41,
+          "word": "some",
+          "punct": "some",
+          "index": 19
+        },
+        {
+          "start": 550.41,
+          "confidence": 0.81,
+          "end": 550.7,
+          "word": "later",
+          "punct": "later",
+          "index": 20
+        },
+        {
+          "start": 550.7,
+          "confidence": 1,
+          "end": 551.16,
+          "word": "research",
+          "punct": "research",
+          "index": 21
+        },
+        {
+          "start": 551.16,
+          "confidence": 1,
+          "end": 551.33,
+          "word": "that",
+          "punct": "that",
+          "index": 22
+        },
+        {
+          "start": 551.33,
+          "confidence": 1,
+          "end": 551.4,
+          "word": "I",
+          "punct": "I",
+          "index": 23
+        },
+        {
+          "start": 551.4,
+          "confidence": 0.993,
+          "end": 551.68,
+          "word": "did",
+          "punct": "did",
+          "index": 24
+        },
+        {
+          "start": 551.68,
+          "confidence": 0.484,
+          "end": 551.78,
+          "word": "it",
+          "punct": "it",
+          "index": 25
+        },
+        {
+          "start": 551.78,
+          "confidence": 0.194,
+          "end": 551.88,
+          "word": "on",
+          "punct": "on",
+          "index": 26
+        },
+        {
+          "start": 551.88,
+          "confidence": 0.608,
+          "end": 551.98,
+          "word": "my",
+          "punct": "my",
+          "index": 27
+        },
+        {
+          "start": 551.98,
+          "confidence": 0.935,
+          "end": 552.25,
+          "word": "T.",
+          "punct": "T.",
+          "index": 28
+        },
+        {
+          "start": 552.25,
+          "confidence": 0.968,
+          "end": 552.42,
+          "word": "with",
+          "punct": "with",
+          "index": 29
+        },
+        {
+          "start": 552.42,
+          "confidence": 0.255,
+          "end": 552.82,
+          "word": "plush",
+          "punct": "plush",
+          "index": 30
+        },
+        {
+          "start": 552.82,
+          "confidence": 0.468,
+          "end": 553.06,
+          "word": "non",
+          "punct": "non",
+          "index": 31
+        },
+        {
+          "start": 553.06,
+          "confidence": 0.332,
+          "end": 553.25,
+          "word": "Dian",
+          "punct": "Dian",
+          "index": 32
+        },
+        {
+          "start": 553.25,
+          "confidence": 0.186,
+          "end": 553.62,
+          "word": "Cynthia",
+          "punct": "Cynthia",
+          "index": 33
+        },
+        {
+          "start": 553.62,
+          "confidence": 0.548,
+          "end": 554.24,
+          "word": "Brazil",
+          "punct": "Brazil",
+          "index": 34
+        },
+        {
+          "start": 554.41,
+          "confidence": 1,
+          "end": 554.82,
+          "word": "where",
+          "punct": "where",
+          "index": 35
+        },
+        {
+          "start": 554.82,
+          "confidence": 1,
+          "end": 554.95,
+          "word": "we",
+          "punct": "we",
+          "index": 36
+        },
+        {
+          "start": 554.95,
+          "confidence": 0.641,
+          "end": 555.1,
+          "word": "had",
+          "punct": "had",
+          "index": 37
+        },
+        {
+          "start": 555.1,
+          "confidence": 1,
+          "end": 555.32,
+          "word": "people",
+          "punct": "people",
+          "index": 38
+        },
+        {
+          "start": 555.32,
+          "confidence": 0.799,
+          "end": 555.5,
+          "word": "come",
+          "punct": "come",
+          "index": 39
+        },
+        {
+          "start": 555.5,
+          "confidence": 0.361,
+          "end": 555.7,
+          "word": "into",
+          "punct": "into",
+          "index": 40
+        },
+        {
+          "start": 555.7,
+          "confidence": 1,
+          "end": 555.8,
+          "word": "the",
+          "punct": "the",
+          "index": 41
+        },
+        {
+          "start": 555.8,
+          "confidence": 1,
+          "end": 556.3,
+          "word": "lab",
+          "punct": "lab",
+          "index": 42
+        },
+        {
+          "start": 556.64,
+          "confidence": 1,
+          "end": 556.88,
+          "word": "and",
+          "punct": "and",
+          "index": 43
+        },
+        {
+          "start": 556.88,
+          "confidence": 0.592,
+          "end": 557.21,
+          "word": "smash",
+          "punct": "smash",
+          "index": 44
+        },
+        {
+          "start": 557.21,
+          "confidence": 0.914,
+          "end": 557.42,
+          "word": "these",
+          "punct": "these",
+          "index": 45
+        },
+        {
+          "start": 557.42,
+          "confidence": 0.657,
+          "end": 557.83,
+          "word": "hex",
+          "punct": "hex",
+          "index": 46
+        },
+        {
+          "start": 557.83,
+          "confidence": 0.996,
+          "end": 558.19,
+          "word": "bugs",
+          "punct": "bugs",
+          "index": 47
+        },
+        {
+          "start": 558.19,
+          "confidence": 0.577,
+          "end": 558.31,
+          "word": "that",
+          "punct": "that",
+          "index": 48
+        },
+        {
+          "start": 558.31,
+          "confidence": 0.549,
+          "end": 558.61,
+          "word": "move",
+          "punct": "move",
+          "index": 49
+        },
+        {
+          "start": 558.61,
+          "confidence": 1,
+          "end": 559.1,
+          "word": "around",
+          "punct": "around",
+          "index": 50
+        },
+        {
+          "start": 559.1,
+          "confidence": 0.59,
+          "end": 559.21,
+          "word": "in",
+          "punct": "in",
+          "index": 51
+        },
+        {
+          "start": 559.21,
+          "confidence": 0.505,
+          "end": 559.27,
+          "word": "a",
+          "punct": "a",
+          "index": 52
+        },
+        {
+          "start": 559.27,
+          "confidence": 1,
+          "end": 559.49,
+          "word": "really",
+          "punct": "really",
+          "index": 53
+        },
+        {
+          "start": 559.49,
+          "confidence": 0.76,
+          "end": 559.74,
+          "word": "life",
+          "punct": "life",
+          "index": 54
+        },
+        {
+          "start": 559.74,
+          "confidence": 0.792,
+          "end": 559.91,
+          "word": "like",
+          "punct": "like",
+          "index": 55
+        },
+        {
+          "start": 559.91,
+          "confidence": 0.809,
+          "end": 560.08,
+          "word": "way",
+          "punct": "way",
+          "index": 56
+        },
+        {
+          "start": 560.08,
+          "confidence": 0.985,
+          "end": 560.29,
+          "word": "like",
+          "punct": "like",
+          "index": 57
+        },
+        {
+          "start": 560.29,
+          "confidence": 0.798,
+          "end": 561.16,
+          "word": "insects",
+          "punct": "insects",
+          "index": 58
+        },
+        {
+          "start": 561.31,
+          "confidence": 1,
+          "end": 561.47,
+          "word": "so",
+          "punct": "so",
+          "index": 59
+        },
+        {
+          "start": 561.47,
+          "confidence": 1,
+          "end": 561.7,
+          "word": "instead",
+          "punct": "instead",
+          "index": 60
+        },
+        {
+          "start": 561.7,
+          "confidence": 1,
+          "end": 561.79,
+          "word": "of",
+          "punct": "of",
+          "index": 61
+        },
+        {
+          "start": 561.79,
+          "confidence": 1,
+          "end": 562.08,
+          "word": "choosing",
+          "punct": "choosing",
+          "index": 62
+        },
+        {
+          "start": 562.08,
+          "confidence": 0.515,
+          "end": 562.34,
+          "word": "something",
+          "punct": "something",
+          "index": 63
+        },
+        {
+          "start": 562.34,
+          "confidence": 0.487,
+          "end": 562.74,
+          "word": "cute",
+          "punct": "cute",
+          "index": 64
+        },
+        {
+          "start": 562.74,
+          "confidence": 0.381,
+          "end": 562.83,
+          "word": "the",
+          "punct": "the",
+          "index": 65
+        },
+        {
+          "start": 562.83,
+          "confidence": 0.98,
+          "end": 563.37,
+          "word": "people",
+          "punct": "people",
+          "index": 66
+        },
+        {
+          "start": 563.72,
+          "confidence": 1,
+          "end": 563.85,
+          "word": "are",
+          "punct": "are",
+          "index": 67
+        },
+        {
+          "start": 563.85,
+          "confidence": 0.94,
+          "end": 564.22,
+          "word": "drawn",
+          "punct": "drawn",
+          "index": 68
+        },
+        {
+          "start": 564.22,
+          "confidence": 0.848,
+          "end": 564.44,
+          "word": "to",
+          "punct": "to",
+          "index": 69
+        },
+        {
+          "start": 564.44,
+          "confidence": 0.523,
+          "end": 564.64,
+          "word": "which",
+          "punct": "which",
+          "index": 70
+        },
+        {
+          "start": 564.64,
+          "confidence": 0.261,
+          "end": 564.77,
+          "word": "was",
+          "punct": "was",
+          "index": 71
+        },
+        {
+          "start": 564.77,
+          "confidence": 1,
+          "end": 565.04,
+          "word": "something",
+          "punct": "something",
+          "index": 72
+        },
+        {
+          "start": 565.04,
+          "confidence": 1,
+          "end": 565.23,
+          "word": "more",
+          "punct": "more",
+          "index": 73
+        },
+        {
+          "start": 565.23,
+          "confidence": 1,
+          "end": 566.06,
+          "word": "basic",
+          "punct": "basic",
+          "index": 74
+        },
+        {
+          "start": 566.57,
+          "confidence": 1,
+          "end": 566.97,
+          "word": "and",
+          "punct": "and",
+          "index": 75
+        },
+        {
+          "start": 567.21,
+          "confidence": 1,
+          "end": 567.4,
+          "word": "what",
+          "punct": "what",
+          "index": 76
+        },
+        {
+          "start": 567.4,
+          "confidence": 1,
+          "end": 567.52,
+          "word": "we",
+          "punct": "we",
+          "index": 77
+        },
+        {
+          "start": 567.52,
+          "confidence": 1,
+          "end": 568.12,
+          "word": "found",
+          "punct": "found",
+          "index": 78
+        },
+        {
+          "start": 568.15,
+          "confidence": 1,
+          "end": 568.53,
+          "word": "was",
+          "punct": "was",
+          "index": 79
+        },
+        {
+          "start": 568.53,
+          "confidence": 1,
+          "end": 568.77,
+          "word": "that",
+          "punct": "that",
+          "index": 80
+        },
+        {
+          "start": 568.8,
+          "confidence": 0.986,
+          "end": 569.15,
+          "word": "high",
+          "punct": "high",
+          "index": 81
+        },
+        {
+          "start": 569.15,
+          "confidence": 0.288,
+          "end": 569.65,
+          "word": "embassy",
+          "punct": "embassy",
+          "index": 82
+        },
+        {
+          "start": 569.65,
+          "confidence": 1,
+          "end": 570.08,
+          "word": "people",
+          "punct": "people",
+          "index": 83
+        },
+        {
+          "start": 570.08,
+          "confidence": 0.756,
+          "end": 570.25,
+          "word": "would",
+          "punct": "would",
+          "index": 84
+        },
+        {
+          "start": 570.25,
+          "confidence": 1,
+          "end": 570.78,
+          "word": "hesitate",
+          "punct": "hesitate",
+          "index": 85
+        },
+        {
+          "start": 570.78,
+          "confidence": 1,
+          "end": 570.99,
+          "word": "more",
+          "punct": "more",
+          "index": 86
+        },
+        {
+          "start": 570.99,
+          "confidence": 0.872,
+          "end": 571.07,
+          "word": "to",
+          "punct": "to",
+          "index": 87
+        },
+        {
+          "start": 571.07,
+          "confidence": 0.819,
+          "end": 571.26,
+          "word": "hit",
+          "punct": "hit",
+          "index": 88
+        },
+        {
+          "start": 571.26,
+          "confidence": 0.92,
+          "end": 571.35,
+          "word": "the",
+          "punct": "the",
+          "index": 89
+        },
+        {
+          "start": 571.35,
+          "confidence": 0.868,
+          "end": 571.68,
+          "word": "hex",
+          "punct": "hex",
+          "index": 90
+        },
+        {
+          "start": 571.68,
+          "confidence": 0.478,
+          "end": 572.16,
+          "word": "Bucks",
+          "punct": "Bucks.",
+          "index": 91
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 543.2,
+        "end": 543.53,
+        "confidence": 0.503,
+        "text": "So",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 543.63,
+        "end": 543.83,
+        "confidence": 0.89,
+        "text": "that",
+        "offset": 3,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 543.83,
+        "end": 544.03,
+        "confidence": 1,
+        "text": "was",
+        "offset": 8,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 544.03,
+        "end": 544.12,
+        "confidence": 0.774,
+        "text": "a",
+        "offset": 12,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 544.12,
+        "end": 544.52,
+        "confidence": 0.955,
+        "text": "really",
+        "offset": 14,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 544.55,
+        "end": 545.36,
+        "confidence": 1,
+        "text": "interesting",
+        "offset": 21,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 545.36,
+        "end": 546.52,
+        "confidence": 0.997,
+        "text": "experience",
+        "offset": 33,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 546.9,
+        "end": 547.08,
+        "confidence": 0.685,
+        "text": "no",
+        "offset": 44,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 547.08,
+        "end": 547.25,
+        "confidence": 1,
+        "text": "it",
+        "offset": 47,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 547.25,
+        "end": 547.53,
+        "confidence": 1,
+        "text": "wasn't",
+        "offset": 50,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 547.53,
+        "end": 547.58,
+        "confidence": 1,
+        "text": "a",
+        "offset": 57,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 547.58,
+        "end": 548.25,
+        "confidence": 1,
+        "text": "controlled",
+        "offset": 59,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 548.25,
+        "end": 548.7,
+        "confidence": 1,
+        "text": "study",
+        "offset": 70,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 548.7,
+        "end": 549.33,
+        "confidence": 1,
+        "text": "obviously",
+        "offset": 76,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 549.33,
+        "end": 549.56,
+        "confidence": 1,
+        "text": "but",
+        "offset": 86,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 549.56,
+        "end": 549.7,
+        "confidence": 1,
+        "text": "it",
+        "offset": 90,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 549.7,
+        "end": 549.92,
+        "confidence": 0.821,
+        "text": "did",
+        "offset": 93,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 549.92,
+        "end": 550.13,
+        "confidence": 0.974,
+        "text": "lead",
+        "offset": 97,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 550.13,
+        "end": 550.21,
+        "confidence": 1,
+        "text": "to",
+        "offset": 102,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 550.21,
+        "end": 550.41,
+        "confidence": 1,
+        "text": "some",
+        "offset": 105,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 550.41,
+        "end": 550.7,
+        "confidence": 0.81,
+        "text": "later",
+        "offset": 110,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 550.7,
+        "end": 551.16,
+        "confidence": 1,
+        "text": "research",
+        "offset": 116,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 551.16,
+        "end": 551.33,
+        "confidence": 1,
+        "text": "that",
+        "offset": 125,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 551.33,
+        "end": 551.4,
+        "confidence": 1,
+        "text": "I",
+        "offset": 130,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 551.4,
+        "end": 551.68,
+        "confidence": 0.993,
+        "text": "did",
+        "offset": 132,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 551.68,
+        "end": 551.78,
+        "confidence": 0.484,
+        "text": "it",
+        "offset": 136,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 551.78,
+        "end": 551.88,
+        "confidence": 0.194,
+        "text": "on",
+        "offset": 139,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 551.88,
+        "end": 551.98,
+        "confidence": 0.608,
+        "text": "my",
+        "offset": 142,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 551.98,
+        "end": 552.25,
+        "confidence": 0.935,
+        "text": "T.",
+        "offset": 145,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 552.25,
+        "end": 552.42,
+        "confidence": 0.968,
+        "text": "with",
+        "offset": 148,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 552.42,
+        "end": 552.82,
+        "confidence": 0.255,
+        "text": "plush",
+        "offset": 153,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 552.82,
+        "end": 553.06,
+        "confidence": 0.468,
+        "text": "non",
+        "offset": 159,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 553.06,
+        "end": 553.25,
+        "confidence": 0.332,
+        "text": "Dian",
+        "offset": 163,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 553.25,
+        "end": 553.62,
+        "confidence": 0.186,
+        "text": "Cynthia",
+        "offset": 168,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 553.62,
+        "end": 554.24,
+        "confidence": 0.548,
+        "text": "Brazil",
+        "offset": 176,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 554.41,
+        "end": 554.82,
+        "confidence": 1,
+        "text": "where",
+        "offset": 183,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 554.82,
+        "end": 554.95,
+        "confidence": 1,
+        "text": "we",
+        "offset": 189,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 554.95,
+        "end": 555.1,
+        "confidence": 0.641,
+        "text": "had",
+        "offset": 192,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 555.1,
+        "end": 555.32,
+        "confidence": 1,
+        "text": "people",
+        "offset": 196,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 555.32,
+        "end": 555.5,
+        "confidence": 0.799,
+        "text": "come",
+        "offset": 203,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 555.5,
+        "end": 555.7,
+        "confidence": 0.361,
+        "text": "into",
+        "offset": 208,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 555.7,
+        "end": 555.8,
+        "confidence": 1,
+        "text": "the",
+        "offset": 213,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 555.8,
+        "end": 556.3,
+        "confidence": 1,
+        "text": "lab",
+        "offset": 217,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 556.64,
+        "end": 556.88,
+        "confidence": 1,
+        "text": "and",
+        "offset": 221,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 556.88,
+        "end": 557.21,
+        "confidence": 0.592,
+        "text": "smash",
+        "offset": 225,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 557.21,
+        "end": 557.42,
+        "confidence": 0.914,
+        "text": "these",
+        "offset": 231,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 557.42,
+        "end": 557.83,
+        "confidence": 0.657,
+        "text": "hex",
+        "offset": 237,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 557.83,
+        "end": 558.19,
+        "confidence": 0.996,
+        "text": "bugs",
+        "offset": 241,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 558.19,
+        "end": 558.31,
+        "confidence": 0.577,
+        "text": "that",
+        "offset": 246,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 558.31,
+        "end": 558.61,
+        "confidence": 0.549,
+        "text": "move",
+        "offset": 251,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 558.61,
+        "end": 559.1,
+        "confidence": 1,
+        "text": "around",
+        "offset": 256,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 559.1,
+        "end": 559.21,
+        "confidence": 0.59,
+        "text": "in",
+        "offset": 263,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 559.21,
+        "end": 559.27,
+        "confidence": 0.505,
+        "text": "a",
+        "offset": 266,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 559.27,
+        "end": 559.49,
+        "confidence": 1,
+        "text": "really",
+        "offset": 268,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 559.49,
+        "end": 559.74,
+        "confidence": 0.76,
+        "text": "life",
+        "offset": 275,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 559.74,
+        "end": 559.91,
+        "confidence": 0.792,
+        "text": "like",
+        "offset": 280,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 559.91,
+        "end": 560.08,
+        "confidence": 0.809,
+        "text": "way",
+        "offset": 285,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 560.08,
+        "end": 560.29,
+        "confidence": 0.985,
+        "text": "like",
+        "offset": 289,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 560.29,
+        "end": 561.16,
+        "confidence": 0.798,
+        "text": "insects",
+        "offset": 294,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 561.31,
+        "end": 561.47,
+        "confidence": 1,
+        "text": "so",
+        "offset": 302,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 561.47,
+        "end": 561.7,
+        "confidence": 1,
+        "text": "instead",
+        "offset": 305,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 561.7,
+        "end": 561.79,
+        "confidence": 1,
+        "text": "of",
+        "offset": 313,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 561.79,
+        "end": 562.08,
+        "confidence": 1,
+        "text": "choosing",
+        "offset": 316,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 562.08,
+        "end": 562.34,
+        "confidence": 0.515,
+        "text": "something",
+        "offset": 325,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 562.34,
+        "end": 562.74,
+        "confidence": 0.487,
+        "text": "cute",
+        "offset": 335,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 562.74,
+        "end": 562.83,
+        "confidence": 0.381,
+        "text": "the",
+        "offset": 340,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 562.83,
+        "end": 563.37,
+        "confidence": 0.98,
+        "text": "people",
+        "offset": 344,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 563.72,
+        "end": 563.85,
+        "confidence": 1,
+        "text": "are",
+        "offset": 351,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 563.85,
+        "end": 564.22,
+        "confidence": 0.94,
+        "text": "drawn",
+        "offset": 355,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 564.22,
+        "end": 564.44,
+        "confidence": 0.848,
+        "text": "to",
+        "offset": 361,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 564.44,
+        "end": 564.64,
+        "confidence": 0.523,
+        "text": "which",
+        "offset": 364,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 564.64,
+        "end": 564.77,
+        "confidence": 0.261,
+        "text": "was",
+        "offset": 370,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 564.77,
+        "end": 565.04,
+        "confidence": 1,
+        "text": "something",
+        "offset": 374,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 565.04,
+        "end": 565.23,
+        "confidence": 1,
+        "text": "more",
+        "offset": 384,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 565.23,
+        "end": 566.06,
+        "confidence": 1,
+        "text": "basic",
+        "offset": 389,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 566.57,
+        "end": 566.97,
+        "confidence": 1,
+        "text": "and",
+        "offset": 395,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 567.21,
+        "end": 567.4,
+        "confidence": 1,
+        "text": "what",
+        "offset": 399,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 567.4,
+        "end": 567.52,
+        "confidence": 1,
+        "text": "we",
+        "offset": 404,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 567.52,
+        "end": 568.12,
+        "confidence": 1,
+        "text": "found",
+        "offset": 407,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 568.15,
+        "end": 568.53,
+        "confidence": 1,
+        "text": "was",
+        "offset": 413,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 568.53,
+        "end": 568.77,
+        "confidence": 1,
+        "text": "that",
+        "offset": 417,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 568.8,
+        "end": 569.15,
+        "confidence": 0.986,
+        "text": "high",
+        "offset": 422,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 569.15,
+        "end": 569.65,
+        "confidence": 0.288,
+        "text": "embassy",
+        "offset": 427,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 569.65,
+        "end": 570.08,
+        "confidence": 1,
+        "text": "people",
+        "offset": 435,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 570.08,
+        "end": 570.25,
+        "confidence": 0.756,
+        "text": "would",
+        "offset": 442,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 570.25,
+        "end": 570.78,
+        "confidence": 1,
+        "text": "hesitate",
+        "offset": 448,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 570.78,
+        "end": 570.99,
+        "confidence": 1,
+        "text": "more",
+        "offset": 457,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 570.99,
+        "end": 571.07,
+        "confidence": 0.872,
+        "text": "to",
+        "offset": 462,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 571.07,
+        "end": 571.26,
+        "confidence": 0.819,
+        "text": "hit",
+        "offset": 465,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 571.26,
+        "end": 571.35,
+        "confidence": 0.92,
+        "text": "the",
+        "offset": 469,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 571.35,
+        "end": 571.68,
+        "confidence": 0.868,
+        "text": "hex",
+        "offset": 473,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 571.68,
+        "end": 572.16,
+        "confidence": 0.478,
+        "text": "Bucks.",
+        "offset": 477,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "I was just a little study but it's part of a larger body of research that is starting to indicate that there may be a connection between people's tendencies for empathy and their behavior around robots.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 573.58,
+      "words": [
+        {
+          "start": 573.58,
+          "confidence": 0.189,
+          "end": 573.66,
+          "word": "I",
+          "punct": "I",
+          "index": 0
+        },
+        {
+          "start": 573.66,
+          "confidence": 0.155,
+          "end": 573.92,
+          "word": "was",
+          "punct": "was",
+          "index": 1
+        },
+        {
+          "start": 573.92,
+          "confidence": 1,
+          "end": 574.1,
+          "word": "just",
+          "punct": "just",
+          "index": 2
+        },
+        {
+          "start": 574.1,
+          "confidence": 1,
+          "end": 574.16,
+          "word": "a",
+          "punct": "a",
+          "index": 3
+        },
+        {
+          "start": 574.16,
+          "confidence": 0.981,
+          "end": 574.39,
+          "word": "little",
+          "punct": "little",
+          "index": 4
+        },
+        {
+          "start": 574.39,
+          "confidence": 0.383,
+          "end": 574.89,
+          "word": "study",
+          "punct": "study",
+          "index": 5
+        },
+        {
+          "start": 574.89,
+          "confidence": 1,
+          "end": 575.27,
+          "word": "but",
+          "punct": "but",
+          "index": 6
+        },
+        {
+          "start": 575.51,
+          "confidence": 1,
+          "end": 575.71,
+          "word": "it's",
+          "punct": "it's",
+          "index": 7
+        },
+        {
+          "start": 575.71,
+          "confidence": 1,
+          "end": 575.97,
+          "word": "part",
+          "punct": "part",
+          "index": 8
+        },
+        {
+          "start": 575.97,
+          "confidence": 1,
+          "end": 576.04,
+          "word": "of",
+          "punct": "of",
+          "index": 9
+        },
+        {
+          "start": 576.04,
+          "confidence": 1,
+          "end": 576.13,
+          "word": "a",
+          "punct": "a",
+          "index": 10
+        },
+        {
+          "start": 576.13,
+          "confidence": 0.614,
+          "end": 576.48,
+          "word": "larger",
+          "punct": "larger",
+          "index": 11
+        },
+        {
+          "start": 576.48,
+          "confidence": 1,
+          "end": 576.75,
+          "word": "body",
+          "punct": "body",
+          "index": 12
+        },
+        {
+          "start": 576.75,
+          "confidence": 1,
+          "end": 576.86,
+          "word": "of",
+          "punct": "of",
+          "index": 13
+        },
+        {
+          "start": 576.86,
+          "confidence": 1,
+          "end": 577.48,
+          "word": "research",
+          "punct": "research",
+          "index": 14
+        },
+        {
+          "start": 577.48,
+          "confidence": 1,
+          "end": 577.89,
+          "word": "that",
+          "punct": "that",
+          "index": 15
+        },
+        {
+          "start": 577.99,
+          "confidence": 0.761,
+          "end": 578.21,
+          "word": "is",
+          "punct": "is",
+          "index": 16
+        },
+        {
+          "start": 578.21,
+          "confidence": 0.994,
+          "end": 578.58,
+          "word": "starting",
+          "punct": "starting",
+          "index": 17
+        },
+        {
+          "start": 578.58,
+          "confidence": 1,
+          "end": 578.73,
+          "word": "to",
+          "punct": "to",
+          "index": 18
+        },
+        {
+          "start": 578.73,
+          "confidence": 1,
+          "end": 579.19,
+          "word": "indicate",
+          "punct": "indicate",
+          "index": 19
+        },
+        {
+          "start": 579.19,
+          "confidence": 1,
+          "end": 579.3,
+          "word": "that",
+          "punct": "that",
+          "index": 20
+        },
+        {
+          "start": 579.3,
+          "confidence": 1,
+          "end": 579.4,
+          "word": "there",
+          "punct": "there",
+          "index": 21
+        },
+        {
+          "start": 579.4,
+          "confidence": 1,
+          "end": 579.6,
+          "word": "may",
+          "punct": "may",
+          "index": 22
+        },
+        {
+          "start": 579.6,
+          "confidence": 1,
+          "end": 579.82,
+          "word": "be",
+          "punct": "be",
+          "index": 23
+        },
+        {
+          "start": 579.82,
+          "confidence": 0.896,
+          "end": 579.93,
+          "word": "a",
+          "punct": "a",
+          "index": 24
+        },
+        {
+          "start": 579.93,
+          "confidence": 1,
+          "end": 580.52,
+          "word": "connection",
+          "punct": "connection",
+          "index": 25
+        },
+        {
+          "start": 580.52,
+          "confidence": 1,
+          "end": 580.85,
+          "word": "between",
+          "punct": "between",
+          "index": 26
+        },
+        {
+          "start": 580.85,
+          "confidence": 0.948,
+          "end": 581.27,
+          "word": "people's",
+          "punct": "people's",
+          "index": 27
+        },
+        {
+          "start": 581.27,
+          "confidence": 0.749,
+          "end": 581.78,
+          "word": "tendencies",
+          "punct": "tendencies",
+          "index": 28
+        },
+        {
+          "start": 581.78,
+          "confidence": 1,
+          "end": 581.9,
+          "word": "for",
+          "punct": "for",
+          "index": 29
+        },
+        {
+          "start": 581.9,
+          "confidence": 1,
+          "end": 582.62,
+          "word": "empathy",
+          "punct": "empathy",
+          "index": 30
+        },
+        {
+          "start": 582.89,
+          "confidence": 1,
+          "end": 583.04,
+          "word": "and",
+          "punct": "and",
+          "index": 31
+        },
+        {
+          "start": 583.04,
+          "confidence": 0.852,
+          "end": 583.15,
+          "word": "their",
+          "punct": "their",
+          "index": 32
+        },
+        {
+          "start": 583.15,
+          "confidence": 0.996,
+          "end": 583.83,
+          "word": "behavior",
+          "punct": "behavior",
+          "index": 33
+        },
+        {
+          "start": 583.83,
+          "confidence": 0.994,
+          "end": 584.18,
+          "word": "around",
+          "punct": "around",
+          "index": 34
+        },
+        {
+          "start": 584.18,
+          "confidence": 0.6,
+          "end": 584.86,
+          "word": "robots",
+          "punct": "robots.",
+          "index": 35
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 573.58,
+        "end": 573.66,
+        "confidence": 0.189,
+        "text": "I",
+        "offset": 0,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 573.66,
+        "end": 573.92,
+        "confidence": 0.155,
+        "text": "was",
+        "offset": 2,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 573.92,
+        "end": 574.1,
+        "confidence": 1,
+        "text": "just",
+        "offset": 6,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 574.1,
+        "end": 574.16,
+        "confidence": 1,
+        "text": "a",
+        "offset": 11,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 574.16,
+        "end": 574.39,
+        "confidence": 0.981,
+        "text": "little",
+        "offset": 13,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 574.39,
+        "end": 574.89,
+        "confidence": 0.383,
+        "text": "study",
+        "offset": 20,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 574.89,
+        "end": 575.27,
+        "confidence": 1,
+        "text": "but",
+        "offset": 26,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 575.51,
+        "end": 575.71,
+        "confidence": 1,
+        "text": "it's",
+        "offset": 30,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 575.71,
+        "end": 575.97,
+        "confidence": 1,
+        "text": "part",
+        "offset": 35,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 575.97,
+        "end": 576.04,
+        "confidence": 1,
+        "text": "of",
+        "offset": 40,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 576.04,
+        "end": 576.13,
+        "confidence": 1,
+        "text": "a",
+        "offset": 43,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 576.13,
+        "end": 576.48,
+        "confidence": 0.614,
+        "text": "larger",
+        "offset": 45,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 576.48,
+        "end": 576.75,
+        "confidence": 1,
+        "text": "body",
+        "offset": 52,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 576.75,
+        "end": 576.86,
+        "confidence": 1,
+        "text": "of",
+        "offset": 57,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 576.86,
+        "end": 577.48,
+        "confidence": 1,
+        "text": "research",
+        "offset": 60,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 577.48,
+        "end": 577.89,
+        "confidence": 1,
+        "text": "that",
+        "offset": 69,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 577.99,
+        "end": 578.21,
+        "confidence": 0.761,
+        "text": "is",
+        "offset": 74,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 578.21,
+        "end": 578.58,
+        "confidence": 0.994,
+        "text": "starting",
+        "offset": 77,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 578.58,
+        "end": 578.73,
+        "confidence": 1,
+        "text": "to",
+        "offset": 86,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 578.73,
+        "end": 579.19,
+        "confidence": 1,
+        "text": "indicate",
+        "offset": 89,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 579.19,
+        "end": 579.3,
+        "confidence": 1,
+        "text": "that",
+        "offset": 98,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 579.3,
+        "end": 579.4,
+        "confidence": 1,
+        "text": "there",
+        "offset": 103,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 579.4,
+        "end": 579.6,
+        "confidence": 1,
+        "text": "may",
+        "offset": 109,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 579.6,
+        "end": 579.82,
+        "confidence": 1,
+        "text": "be",
+        "offset": 113,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 579.82,
+        "end": 579.93,
+        "confidence": 0.896,
+        "text": "a",
+        "offset": 116,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 579.93,
+        "end": 580.52,
+        "confidence": 1,
+        "text": "connection",
+        "offset": 118,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 580.52,
+        "end": 580.85,
+        "confidence": 1,
+        "text": "between",
+        "offset": 129,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 580.85,
+        "end": 581.27,
+        "confidence": 0.948,
+        "text": "people's",
+        "offset": 137,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 581.27,
+        "end": 581.78,
+        "confidence": 0.749,
+        "text": "tendencies",
+        "offset": 146,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 581.78,
+        "end": 581.9,
+        "confidence": 1,
+        "text": "for",
+        "offset": 157,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 581.9,
+        "end": 582.62,
+        "confidence": 1,
+        "text": "empathy",
+        "offset": 161,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 582.89,
+        "end": 583.04,
+        "confidence": 1,
+        "text": "and",
+        "offset": 169,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 583.04,
+        "end": 583.15,
+        "confidence": 0.852,
+        "text": "their",
+        "offset": 173,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 583.15,
+        "end": 583.83,
+        "confidence": 0.996,
+        "text": "behavior",
+        "offset": 179,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 583.83,
+        "end": 584.18,
+        "confidence": 0.994,
+        "text": "around",
+        "offset": 188,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 584.18,
+        "end": 584.86,
+        "confidence": 0.6,
+        "text": "robots.",
+        "offset": 195,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "But my question for the coming era of human robot interaction is not do we empathize with robots.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 585.7,
+      "words": [
+        {
+          "start": 585.7,
+          "confidence": 0.67,
+          "end": 585.84,
+          "word": "but",
+          "punct": "But",
+          "index": 0
+        },
+        {
+          "start": 585.84,
+          "confidence": 0.963,
+          "end": 586.08,
+          "word": "my",
+          "punct": "my",
+          "index": 1
+        },
+        {
+          "start": 586.08,
+          "confidence": 0.818,
+          "end": 586.83,
+          "word": "question",
+          "punct": "question",
+          "index": 2
+        },
+        {
+          "start": 586.86,
+          "confidence": 0.858,
+          "end": 587,
+          "word": "for",
+          "punct": "for",
+          "index": 3
+        },
+        {
+          "start": 587,
+          "confidence": 1,
+          "end": 587.09,
+          "word": "the",
+          "punct": "the",
+          "index": 4
+        },
+        {
+          "start": 587.09,
+          "confidence": 1,
+          "end": 587.5,
+          "word": "coming",
+          "punct": "coming",
+          "index": 5
+        },
+        {
+          "start": 587.5,
+          "confidence": 1,
+          "end": 587.95,
+          "word": "era",
+          "punct": "era",
+          "index": 6
+        },
+        {
+          "start": 587.95,
+          "confidence": 1,
+          "end": 588.07,
+          "word": "of",
+          "punct": "of",
+          "index": 7
+        },
+        {
+          "start": 588.07,
+          "confidence": 1,
+          "end": 588.37,
+          "word": "human",
+          "punct": "human",
+          "index": 8
+        },
+        {
+          "start": 588.37,
+          "confidence": 1,
+          "end": 588.68,
+          "word": "robot",
+          "punct": "robot",
+          "index": 9
+        },
+        {
+          "start": 588.68,
+          "confidence": 0.988,
+          "end": 589.36,
+          "word": "interaction",
+          "punct": "interaction",
+          "index": 10
+        },
+        {
+          "start": 589.36,
+          "confidence": 0.796,
+          "end": 589.53,
+          "word": "is",
+          "punct": "is",
+          "index": 11
+        },
+        {
+          "start": 589.53,
+          "confidence": 1,
+          "end": 589.99,
+          "word": "not",
+          "punct": "not",
+          "index": 12
+        },
+        {
+          "start": 590.45,
+          "confidence": 0.726,
+          "end": 590.57,
+          "word": "do",
+          "punct": "do",
+          "index": 13
+        },
+        {
+          "start": 590.57,
+          "confidence": 0.974,
+          "end": 590.73,
+          "word": "we",
+          "punct": "we",
+          "index": 14
+        },
+        {
+          "start": 590.73,
+          "confidence": 1,
+          "end": 591.4,
+          "word": "empathize",
+          "punct": "empathize",
+          "index": 15
+        },
+        {
+          "start": 591.4,
+          "confidence": 1,
+          "end": 591.58,
+          "word": "with",
+          "punct": "with",
+          "index": 16
+        },
+        {
+          "start": 591.58,
+          "confidence": 0.999,
+          "end": 592.32,
+          "word": "robots",
+          "punct": "robots.",
+          "index": 17
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 585.7,
+        "end": 585.84,
+        "confidence": 0.67,
+        "text": "But",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 585.84,
+        "end": 586.08,
+        "confidence": 0.963,
+        "text": "my",
+        "offset": 4,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 586.08,
+        "end": 586.83,
+        "confidence": 0.818,
+        "text": "question",
+        "offset": 7,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 586.86,
+        "end": 587,
+        "confidence": 0.858,
+        "text": "for",
+        "offset": 16,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 587,
+        "end": 587.09,
+        "confidence": 1,
+        "text": "the",
+        "offset": 20,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 587.09,
+        "end": 587.5,
+        "confidence": 1,
+        "text": "coming",
+        "offset": 24,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 587.5,
+        "end": 587.95,
+        "confidence": 1,
+        "text": "era",
+        "offset": 31,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 587.95,
+        "end": 588.07,
+        "confidence": 1,
+        "text": "of",
+        "offset": 35,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 588.07,
+        "end": 588.37,
+        "confidence": 1,
+        "text": "human",
+        "offset": 38,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 588.37,
+        "end": 588.68,
+        "confidence": 1,
+        "text": "robot",
+        "offset": 44,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 588.68,
+        "end": 589.36,
+        "confidence": 0.988,
+        "text": "interaction",
+        "offset": 50,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 589.36,
+        "end": 589.53,
+        "confidence": 0.796,
+        "text": "is",
+        "offset": 62,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 589.53,
+        "end": 589.99,
+        "confidence": 1,
+        "text": "not",
+        "offset": 65,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 590.45,
+        "end": 590.57,
+        "confidence": 0.726,
+        "text": "do",
+        "offset": 69,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 590.57,
+        "end": 590.73,
+        "confidence": 0.974,
+        "text": "we",
+        "offset": 72,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 590.73,
+        "end": 591.4,
+        "confidence": 1,
+        "text": "empathize",
+        "offset": 75,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 591.4,
+        "end": 591.58,
+        "confidence": 1,
+        "text": "with",
+        "offset": 85,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 591.58,
+        "end": 592.32,
+        "confidence": 0.999,
+        "text": "robots.",
+        "offset": 90,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "It's Karen robots change people's empathy.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 593.19,
+      "words": [
+        {
+          "start": 593.19,
+          "confidence": 0.949,
+          "end": 593.4,
+          "word": "it's",
+          "punct": "It's",
+          "index": 0
+        },
+        {
+          "start": 593.4,
+          "confidence": 0.322,
+          "end": 593.77,
+          "word": "Karen",
+          "punct": "Karen",
+          "index": 1
+        },
+        {
+          "start": 593.77,
+          "confidence": 0.503,
+          "end": 594.32,
+          "word": "robots",
+          "punct": "robots",
+          "index": 2
+        },
+        {
+          "start": 594.35,
+          "confidence": 0.826,
+          "end": 594.98,
+          "word": "change",
+          "punct": "change",
+          "index": 3
+        },
+        {
+          "start": 594.98,
+          "confidence": 0.978,
+          "end": 595.37,
+          "word": "people's",
+          "punct": "people's",
+          "index": 4
+        },
+        {
+          "start": 595.37,
+          "confidence": 0.931,
+          "end": 595.99,
+          "word": "empathy",
+          "punct": "empathy.",
+          "index": 5
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 593.19,
+        "end": 593.4,
+        "confidence": 0.949,
+        "text": "It's",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 593.4,
+        "end": 593.77,
+        "confidence": 0.322,
+        "text": "Karen",
+        "offset": 5,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 593.77,
+        "end": 594.32,
+        "confidence": 0.503,
+        "text": "robots",
+        "offset": 11,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 594.35,
+        "end": 594.98,
+        "confidence": 0.826,
+        "text": "change",
+        "offset": 18,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 594.98,
+        "end": 595.37,
+        "confidence": 0.978,
+        "text": "people's",
+        "offset": 25,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 595.37,
+        "end": 595.99,
+        "confidence": 0.931,
+        "text": "empathy.",
+        "offset": 34,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Is there reason to for example prevent your child from kicking a robotic doc.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 597.46,
+      "words": [
+        {
+          "start": 597.46,
+          "confidence": 0.831,
+          "end": 597.67,
+          "word": "is",
+          "punct": "Is",
+          "index": 0
+        },
+        {
+          "start": 597.67,
+          "confidence": 0.862,
+          "end": 597.85,
+          "word": "there",
+          "punct": "there",
+          "index": 1
+        },
+        {
+          "start": 597.85,
+          "confidence": 1,
+          "end": 598.25,
+          "word": "reason",
+          "punct": "reason",
+          "index": 2
+        },
+        {
+          "start": 598.25,
+          "confidence": 0.951,
+          "end": 598.46,
+          "word": "to",
+          "punct": "to",
+          "index": 3
+        },
+        {
+          "start": 598.46,
+          "confidence": 1,
+          "end": 598.65,
+          "word": "for",
+          "punct": "for",
+          "index": 4
+        },
+        {
+          "start": 598.65,
+          "confidence": 1,
+          "end": 599.48,
+          "word": "example",
+          "punct": "example",
+          "index": 5
+        },
+        {
+          "start": 599.77,
+          "confidence": 1,
+          "end": 600.12,
+          "word": "prevent",
+          "punct": "prevent",
+          "index": 6
+        },
+        {
+          "start": 600.12,
+          "confidence": 1,
+          "end": 600.23,
+          "word": "your",
+          "punct": "your",
+          "index": 7
+        },
+        {
+          "start": 600.23,
+          "confidence": 1,
+          "end": 600.69,
+          "word": "child",
+          "punct": "child",
+          "index": 8
+        },
+        {
+          "start": 600.69,
+          "confidence": 1,
+          "end": 600.83,
+          "word": "from",
+          "punct": "from",
+          "index": 9
+        },
+        {
+          "start": 600.83,
+          "confidence": 0.748,
+          "end": 601.22,
+          "word": "kicking",
+          "punct": "kicking",
+          "index": 10
+        },
+        {
+          "start": 601.22,
+          "confidence": 0.784,
+          "end": 601.29,
+          "word": "a",
+          "punct": "a",
+          "index": 11
+        },
+        {
+          "start": 601.29,
+          "confidence": 1,
+          "end": 601.69,
+          "word": "robotic",
+          "punct": "robotic",
+          "index": 12
+        },
+        {
+          "start": 601.69,
+          "confidence": 0.329,
+          "end": 602.07,
+          "word": "doc",
+          "punct": "doc.",
+          "index": 13
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 597.46,
+        "end": 597.67,
+        "confidence": 0.831,
+        "text": "Is",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 597.67,
+        "end": 597.85,
+        "confidence": 0.862,
+        "text": "there",
+        "offset": 3,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 597.85,
+        "end": 598.25,
+        "confidence": 1,
+        "text": "reason",
+        "offset": 9,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 598.25,
+        "end": 598.46,
+        "confidence": 0.951,
+        "text": "to",
+        "offset": 16,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 598.46,
+        "end": 598.65,
+        "confidence": 1,
+        "text": "for",
+        "offset": 19,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 598.65,
+        "end": 599.48,
+        "confidence": 1,
+        "text": "example",
+        "offset": 23,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 599.77,
+        "end": 600.12,
+        "confidence": 1,
+        "text": "prevent",
+        "offset": 31,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 600.12,
+        "end": 600.23,
+        "confidence": 1,
+        "text": "your",
+        "offset": 39,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 600.23,
+        "end": 600.69,
+        "confidence": 1,
+        "text": "child",
+        "offset": 44,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 600.69,
+        "end": 600.83,
+        "confidence": 1,
+        "text": "from",
+        "offset": 50,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 600.83,
+        "end": 601.22,
+        "confidence": 0.748,
+        "text": "kicking",
+        "offset": 55,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 601.22,
+        "end": 601.29,
+        "confidence": 0.784,
+        "text": "a",
+        "offset": 63,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 601.29,
+        "end": 601.69,
+        "confidence": 1,
+        "text": "robotic",
+        "offset": 65,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 601.69,
+        "end": 602.07,
+        "confidence": 0.329,
+        "text": "doc.",
+        "offset": 73,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Not just out of respect for property but because the child might be more likely to kick a real doc.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 603.19,
+      "words": [
+        {
+          "start": 603.19,
+          "confidence": 1,
+          "end": 603.51,
+          "word": "not",
+          "punct": "Not",
+          "index": 0
+        },
+        {
+          "start": 603.54,
+          "confidence": 1,
+          "end": 603.96,
+          "word": "just",
+          "punct": "just",
+          "index": 1
+        },
+        {
+          "start": 603.96,
+          "confidence": 1,
+          "end": 604.05,
+          "word": "out",
+          "punct": "out",
+          "index": 2
+        },
+        {
+          "start": 604.05,
+          "confidence": 1,
+          "end": 604.14,
+          "word": "of",
+          "punct": "of",
+          "index": 3
+        },
+        {
+          "start": 604.14,
+          "confidence": 1,
+          "end": 604.64,
+          "word": "respect",
+          "punct": "respect",
+          "index": 4
+        },
+        {
+          "start": 604.64,
+          "confidence": 1,
+          "end": 604.77,
+          "word": "for",
+          "punct": "for",
+          "index": 5
+        },
+        {
+          "start": 604.77,
+          "confidence": 1,
+          "end": 605.55,
+          "word": "property",
+          "punct": "property",
+          "index": 6
+        },
+        {
+          "start": 606.13,
+          "confidence": 0.479,
+          "end": 606.28,
+          "word": "but",
+          "punct": "but",
+          "index": 7
+        },
+        {
+          "start": 606.28,
+          "confidence": 1,
+          "end": 606.8,
+          "word": "because",
+          "punct": "because",
+          "index": 8
+        },
+        {
+          "start": 606.8,
+          "confidence": 0.88,
+          "end": 606.92,
+          "word": "the",
+          "punct": "the",
+          "index": 9
+        },
+        {
+          "start": 606.92,
+          "confidence": 0.696,
+          "end": 607.24,
+          "word": "child",
+          "punct": "child",
+          "index": 10
+        },
+        {
+          "start": 607.24,
+          "confidence": 0.54,
+          "end": 607.36,
+          "word": "might",
+          "punct": "might",
+          "index": 11
+        },
+        {
+          "start": 607.36,
+          "confidence": 1,
+          "end": 607.45,
+          "word": "be",
+          "punct": "be",
+          "index": 12
+        },
+        {
+          "start": 607.45,
+          "confidence": 1,
+          "end": 607.63,
+          "word": "more",
+          "punct": "more",
+          "index": 13
+        },
+        {
+          "start": 607.63,
+          "confidence": 1,
+          "end": 607.96,
+          "word": "likely",
+          "punct": "likely",
+          "index": 14
+        },
+        {
+          "start": 607.96,
+          "confidence": 0.992,
+          "end": 608.06,
+          "word": "to",
+          "punct": "to",
+          "index": 15
+        },
+        {
+          "start": 608.06,
+          "confidence": 0.358,
+          "end": 608.25,
+          "word": "kick",
+          "punct": "kick",
+          "index": 16
+        },
+        {
+          "start": 608.25,
+          "confidence": 1,
+          "end": 608.33,
+          "word": "a",
+          "punct": "a",
+          "index": 17
+        },
+        {
+          "start": 608.33,
+          "confidence": 1,
+          "end": 608.54,
+          "word": "real",
+          "punct": "real",
+          "index": 18
+        },
+        {
+          "start": 608.54,
+          "confidence": 0.504,
+          "end": 609,
+          "word": "doc",
+          "punct": "doc.",
+          "index": 19
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 603.19,
+        "end": 603.51,
+        "confidence": 1,
+        "text": "Not",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 603.54,
+        "end": 603.96,
+        "confidence": 1,
+        "text": "just",
+        "offset": 4,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 603.96,
+        "end": 604.05,
+        "confidence": 1,
+        "text": "out",
+        "offset": 9,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 604.05,
+        "end": 604.14,
+        "confidence": 1,
+        "text": "of",
+        "offset": 13,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 604.14,
+        "end": 604.64,
+        "confidence": 1,
+        "text": "respect",
+        "offset": 16,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 604.64,
+        "end": 604.77,
+        "confidence": 1,
+        "text": "for",
+        "offset": 24,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 604.77,
+        "end": 605.55,
+        "confidence": 1,
+        "text": "property",
+        "offset": 28,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 606.13,
+        "end": 606.28,
+        "confidence": 0.479,
+        "text": "but",
+        "offset": 37,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 606.28,
+        "end": 606.8,
+        "confidence": 1,
+        "text": "because",
+        "offset": 41,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 606.8,
+        "end": 606.92,
+        "confidence": 0.88,
+        "text": "the",
+        "offset": 49,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 606.92,
+        "end": 607.24,
+        "confidence": 0.696,
+        "text": "child",
+        "offset": 53,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 607.24,
+        "end": 607.36,
+        "confidence": 0.54,
+        "text": "might",
+        "offset": 59,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 607.36,
+        "end": 607.45,
+        "confidence": 1,
+        "text": "be",
+        "offset": 65,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 607.45,
+        "end": 607.63,
+        "confidence": 1,
+        "text": "more",
+        "offset": 68,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 607.63,
+        "end": 607.96,
+        "confidence": 1,
+        "text": "likely",
+        "offset": 73,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 607.96,
+        "end": 608.06,
+        "confidence": 0.992,
+        "text": "to",
+        "offset": 80,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 608.06,
+        "end": 608.25,
+        "confidence": 0.358,
+        "text": "kick",
+        "offset": 83,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 608.25,
+        "end": 608.33,
+        "confidence": 1,
+        "text": "a",
+        "offset": 88,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 608.33,
+        "end": 608.54,
+        "confidence": 1,
+        "text": "real",
+        "offset": 90,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 608.54,
+        "end": 609,
+        "confidence": 0.504,
+        "text": "doc.",
+        "offset": 95,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And again it's not just kids.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 610.48,
+      "words": [
+        {
+          "start": 610.48,
+          "confidence": 1,
+          "end": 610.65,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 610.65,
+          "confidence": 1,
+          "end": 610.95,
+          "word": "again",
+          "punct": "again",
+          "index": 1
+        },
+        {
+          "start": 610.95,
+          "confidence": 1,
+          "end": 611.14,
+          "word": "it's",
+          "punct": "it's",
+          "index": 2
+        },
+        {
+          "start": 611.14,
+          "confidence": 1,
+          "end": 611.47,
+          "word": "not",
+          "punct": "not",
+          "index": 3
+        },
+        {
+          "start": 611.47,
+          "confidence": 0.974,
+          "end": 611.72,
+          "word": "just",
+          "punct": "just",
+          "index": 4
+        },
+        {
+          "start": 611.72,
+          "confidence": 0.997,
+          "end": 612.32,
+          "word": "kids",
+          "punct": "kids.",
+          "index": 5
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 610.48,
+        "end": 610.65,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 610.65,
+        "end": 610.95,
+        "confidence": 1,
+        "text": "again",
+        "offset": 4,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 610.95,
+        "end": 611.14,
+        "confidence": 1,
+        "text": "it's",
+        "offset": 10,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 611.14,
+        "end": 611.47,
+        "confidence": 1,
+        "text": "not",
+        "offset": 15,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 611.47,
+        "end": 611.72,
+        "confidence": 0.974,
+        "text": "just",
+        "offset": 19,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 611.72,
+        "end": 612.32,
+        "confidence": 0.997,
+        "text": "kids.",
+        "offset": 24,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "This is the violent video games question but it's on a completely new level because of this visceral physicality that we respond more intensely to into images on a screen.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 613.53,
+      "words": [
+        {
+          "start": 613.53,
+          "confidence": 1,
+          "end": 613.74,
+          "word": "this",
+          "punct": "This",
+          "index": 0
+        },
+        {
+          "start": 613.74,
+          "confidence": 1,
+          "end": 613.93,
+          "word": "is",
+          "punct": "is",
+          "index": 1
+        },
+        {
+          "start": 613.93,
+          "confidence": 1,
+          "end": 614.35,
+          "word": "the",
+          "punct": "the",
+          "index": 2
+        },
+        {
+          "start": 614.4,
+          "confidence": 1,
+          "end": 615.02,
+          "word": "violent",
+          "punct": "violent",
+          "index": 3
+        },
+        {
+          "start": 615.05,
+          "confidence": 0.635,
+          "end": 615.38,
+          "word": "video",
+          "punct": "video",
+          "index": 4
+        },
+        {
+          "start": 615.38,
+          "confidence": 0.635,
+          "end": 615.67,
+          "word": "games",
+          "punct": "games",
+          "index": 5
+        },
+        {
+          "start": 615.67,
+          "confidence": 0.707,
+          "end": 616.12,
+          "word": "question",
+          "punct": "question",
+          "index": 6
+        },
+        {
+          "start": 616.12,
+          "confidence": 0.948,
+          "end": 616.27,
+          "word": "but",
+          "punct": "but",
+          "index": 7
+        },
+        {
+          "start": 616.27,
+          "confidence": 0.992,
+          "end": 616.37,
+          "word": "it's",
+          "punct": "it's",
+          "index": 8
+        },
+        {
+          "start": 616.37,
+          "confidence": 0.8,
+          "end": 616.47,
+          "word": "on",
+          "punct": "on",
+          "index": 9
+        },
+        {
+          "start": 616.47,
+          "confidence": 1,
+          "end": 616.52,
+          "word": "a",
+          "punct": "a",
+          "index": 10
+        },
+        {
+          "start": 616.52,
+          "confidence": 0.992,
+          "end": 617.13,
+          "word": "completely",
+          "punct": "completely",
+          "index": 11
+        },
+        {
+          "start": 617.13,
+          "confidence": 1,
+          "end": 617.26,
+          "word": "new",
+          "punct": "new",
+          "index": 12
+        },
+        {
+          "start": 617.26,
+          "confidence": 1,
+          "end": 617.6,
+          "word": "level",
+          "punct": "level",
+          "index": 13
+        },
+        {
+          "start": 617.6,
+          "confidence": 1,
+          "end": 617.82,
+          "word": "because",
+          "punct": "because",
+          "index": 14
+        },
+        {
+          "start": 617.82,
+          "confidence": 1,
+          "end": 617.93,
+          "word": "of",
+          "punct": "of",
+          "index": 15
+        },
+        {
+          "start": 617.93,
+          "confidence": 0.997,
+          "end": 618.1,
+          "word": "this",
+          "punct": "this",
+          "index": 16
+        },
+        {
+          "start": 618.1,
+          "confidence": 0.974,
+          "end": 618.81,
+          "word": "visceral",
+          "punct": "visceral",
+          "index": 17
+        },
+        {
+          "start": 618.81,
+          "confidence": 1,
+          "end": 619.73,
+          "word": "physicality",
+          "punct": "physicality",
+          "index": 18
+        },
+        {
+          "start": 619.73,
+          "confidence": 1,
+          "end": 619.9,
+          "word": "that",
+          "punct": "that",
+          "index": 19
+        },
+        {
+          "start": 619.9,
+          "confidence": 0.891,
+          "end": 620.04,
+          "word": "we",
+          "punct": "we",
+          "index": 20
+        },
+        {
+          "start": 620.04,
+          "confidence": 0.993,
+          "end": 620.7,
+          "word": "respond",
+          "punct": "respond",
+          "index": 21
+        },
+        {
+          "start": 620.7,
+          "confidence": 0.987,
+          "end": 621.05,
+          "word": "more",
+          "punct": "more",
+          "index": 22
+        },
+        {
+          "start": 621.05,
+          "confidence": 1,
+          "end": 621.72,
+          "word": "intensely",
+          "punct": "intensely",
+          "index": 23
+        },
+        {
+          "start": 621.72,
+          "confidence": 0.978,
+          "end": 622.2,
+          "word": "to",
+          "punct": "to",
+          "index": 24
+        },
+        {
+          "start": 622.44,
+          "confidence": 0.327,
+          "end": 622.67,
+          "word": "into",
+          "punct": "into",
+          "index": 25
+        },
+        {
+          "start": 622.67,
+          "confidence": 0.956,
+          "end": 623.12,
+          "word": "images",
+          "punct": "images",
+          "index": 26
+        },
+        {
+          "start": 623.12,
+          "confidence": 0.982,
+          "end": 623.22,
+          "word": "on",
+          "punct": "on",
+          "index": 27
+        },
+        {
+          "start": 623.22,
+          "confidence": 0.82,
+          "end": 623.29,
+          "word": "a",
+          "punct": "a",
+          "index": 28
+        },
+        {
+          "start": 623.29,
+          "confidence": 0.939,
+          "end": 623.92,
+          "word": "screen",
+          "punct": "screen.",
+          "index": 29
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 613.53,
+        "end": 613.74,
+        "confidence": 1,
+        "text": "This",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 613.74,
+        "end": 613.93,
+        "confidence": 1,
+        "text": "is",
+        "offset": 5,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 613.93,
+        "end": 614.35,
+        "confidence": 1,
+        "text": "the",
+        "offset": 8,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 614.4,
+        "end": 615.02,
+        "confidence": 1,
+        "text": "violent",
+        "offset": 12,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 615.05,
+        "end": 615.38,
+        "confidence": 0.635,
+        "text": "video",
+        "offset": 20,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 615.38,
+        "end": 615.67,
+        "confidence": 0.635,
+        "text": "games",
+        "offset": 26,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 615.67,
+        "end": 616.12,
+        "confidence": 0.707,
+        "text": "question",
+        "offset": 32,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 616.12,
+        "end": 616.27,
+        "confidence": 0.948,
+        "text": "but",
+        "offset": 41,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 616.27,
+        "end": 616.37,
+        "confidence": 0.992,
+        "text": "it's",
+        "offset": 45,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 616.37,
+        "end": 616.47,
+        "confidence": 0.8,
+        "text": "on",
+        "offset": 50,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 616.47,
+        "end": 616.52,
+        "confidence": 1,
+        "text": "a",
+        "offset": 53,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 616.52,
+        "end": 617.13,
+        "confidence": 0.992,
+        "text": "completely",
+        "offset": 55,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 617.13,
+        "end": 617.26,
+        "confidence": 1,
+        "text": "new",
+        "offset": 66,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 617.26,
+        "end": 617.6,
+        "confidence": 1,
+        "text": "level",
+        "offset": 70,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 617.6,
+        "end": 617.82,
+        "confidence": 1,
+        "text": "because",
+        "offset": 76,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 617.82,
+        "end": 617.93,
+        "confidence": 1,
+        "text": "of",
+        "offset": 84,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 617.93,
+        "end": 618.1,
+        "confidence": 0.997,
+        "text": "this",
+        "offset": 87,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 618.1,
+        "end": 618.81,
+        "confidence": 0.974,
+        "text": "visceral",
+        "offset": 92,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 618.81,
+        "end": 619.73,
+        "confidence": 1,
+        "text": "physicality",
+        "offset": 101,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 619.73,
+        "end": 619.9,
+        "confidence": 1,
+        "text": "that",
+        "offset": 113,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 619.9,
+        "end": 620.04,
+        "confidence": 0.891,
+        "text": "we",
+        "offset": 118,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 620.04,
+        "end": 620.7,
+        "confidence": 0.993,
+        "text": "respond",
+        "offset": 121,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 620.7,
+        "end": 621.05,
+        "confidence": 0.987,
+        "text": "more",
+        "offset": 129,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 621.05,
+        "end": 621.72,
+        "confidence": 1,
+        "text": "intensely",
+        "offset": 134,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 621.72,
+        "end": 622.2,
+        "confidence": 0.978,
+        "text": "to",
+        "offset": 144,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 622.44,
+        "end": 622.67,
+        "confidence": 0.327,
+        "text": "into",
+        "offset": 147,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 622.67,
+        "end": 623.12,
+        "confidence": 0.956,
+        "text": "images",
+        "offset": 152,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 623.12,
+        "end": 623.22,
+        "confidence": 0.982,
+        "text": "on",
+        "offset": 159,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 623.22,
+        "end": 623.29,
+        "confidence": 0.82,
+        "text": "a",
+        "offset": 162,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 623.29,
+        "end": 623.92,
+        "confidence": 0.939,
+        "text": "screen.",
+        "offset": 164,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "When we behave violently towards robots specifically robots that are designed to mimic life is that healthy outlet for violent behavior?",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 625.62,
+      "words": [
+        {
+          "start": 625.62,
+          "confidence": 1,
+          "end": 625.84,
+          "word": "when",
+          "punct": "When",
+          "index": 0
+        },
+        {
+          "start": 625.84,
+          "confidence": 0.553,
+          "end": 625.95,
+          "word": "we",
+          "punct": "we",
+          "index": 1
+        },
+        {
+          "start": 625.95,
+          "confidence": 0.84,
+          "end": 626.27,
+          "word": "behave",
+          "punct": "behave",
+          "index": 2
+        },
+        {
+          "start": 626.27,
+          "confidence": 1,
+          "end": 626.88,
+          "word": "violently",
+          "punct": "violently",
+          "index": 3
+        },
+        {
+          "start": 626.88,
+          "confidence": 1,
+          "end": 627.4,
+          "word": "towards",
+          "punct": "towards",
+          "index": 4
+        },
+        {
+          "start": 627.4,
+          "confidence": 0.997,
+          "end": 628.07,
+          "word": "robots",
+          "punct": "robots",
+          "index": 5
+        },
+        {
+          "start": 628.1,
+          "confidence": 0.993,
+          "end": 628.82,
+          "word": "specifically",
+          "punct": "specifically",
+          "index": 6
+        },
+        {
+          "start": 628.82,
+          "confidence": 1,
+          "end": 629.2,
+          "word": "robots",
+          "punct": "robots",
+          "index": 7
+        },
+        {
+          "start": 629.2,
+          "confidence": 1,
+          "end": 629.35,
+          "word": "that",
+          "punct": "that",
+          "index": 8
+        },
+        {
+          "start": 629.35,
+          "confidence": 1,
+          "end": 629.43,
+          "word": "are",
+          "punct": "are",
+          "index": 9
+        },
+        {
+          "start": 629.43,
+          "confidence": 1,
+          "end": 629.94,
+          "word": "designed",
+          "punct": "designed",
+          "index": 10
+        },
+        {
+          "start": 629.94,
+          "confidence": 1,
+          "end": 630.07,
+          "word": "to",
+          "punct": "to",
+          "index": 11
+        },
+        {
+          "start": 630.07,
+          "confidence": 0.821,
+          "end": 630.39,
+          "word": "mimic",
+          "punct": "mimic",
+          "index": 12
+        },
+        {
+          "start": 630.39,
+          "confidence": 0.987,
+          "end": 630.94,
+          "word": "life",
+          "punct": "life",
+          "index": 13
+        },
+        {
+          "start": 631.37,
+          "confidence": 1,
+          "end": 631.55,
+          "word": "is",
+          "punct": "is",
+          "index": 14
+        },
+        {
+          "start": 631.55,
+          "confidence": 1,
+          "end": 631.88,
+          "word": "that",
+          "punct": "that",
+          "index": 15
+        },
+        {
+          "start": 632.54,
+          "confidence": 0.917,
+          "end": 633,
+          "word": "healthy",
+          "punct": "healthy",
+          "index": 16
+        },
+        {
+          "start": 633,
+          "confidence": 1,
+          "end": 633.48,
+          "word": "outlet",
+          "punct": "outlet",
+          "index": 17
+        },
+        {
+          "start": 633.48,
+          "confidence": 1,
+          "end": 633.62,
+          "word": "for",
+          "punct": "for",
+          "index": 18
+        },
+        {
+          "start": 633.62,
+          "confidence": 0.714,
+          "end": 633.95,
+          "word": "violent",
+          "punct": "violent",
+          "index": 19
+        },
+        {
+          "start": 633.95,
+          "confidence": 0.99,
+          "end": 634.53,
+          "word": "behavior",
+          "punct": "behavior?",
+          "index": 20
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 625.62,
+        "end": 625.84,
+        "confidence": 1,
+        "text": "When",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 625.84,
+        "end": 625.95,
+        "confidence": 0.553,
+        "text": "we",
+        "offset": 5,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 625.95,
+        "end": 626.27,
+        "confidence": 0.84,
+        "text": "behave",
+        "offset": 8,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 626.27,
+        "end": 626.88,
+        "confidence": 1,
+        "text": "violently",
+        "offset": 15,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 626.88,
+        "end": 627.4,
+        "confidence": 1,
+        "text": "towards",
+        "offset": 25,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 627.4,
+        "end": 628.07,
+        "confidence": 0.997,
+        "text": "robots",
+        "offset": 33,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 628.1,
+        "end": 628.82,
+        "confidence": 0.993,
+        "text": "specifically",
+        "offset": 40,
+        "length": 12,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 628.82,
+        "end": 629.2,
+        "confidence": 1,
+        "text": "robots",
+        "offset": 53,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 629.2,
+        "end": 629.35,
+        "confidence": 1,
+        "text": "that",
+        "offset": 60,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 629.35,
+        "end": 629.43,
+        "confidence": 1,
+        "text": "are",
+        "offset": 65,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 629.43,
+        "end": 629.94,
+        "confidence": 1,
+        "text": "designed",
+        "offset": 69,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 629.94,
+        "end": 630.07,
+        "confidence": 1,
+        "text": "to",
+        "offset": 78,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 630.07,
+        "end": 630.39,
+        "confidence": 0.821,
+        "text": "mimic",
+        "offset": 81,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 630.39,
+        "end": 630.94,
+        "confidence": 0.987,
+        "text": "life",
+        "offset": 87,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 631.37,
+        "end": 631.55,
+        "confidence": 1,
+        "text": "is",
+        "offset": 92,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 631.55,
+        "end": 631.88,
+        "confidence": 1,
+        "text": "that",
+        "offset": 95,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 632.54,
+        "end": 633,
+        "confidence": 0.917,
+        "text": "healthy",
+        "offset": 100,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 633,
+        "end": 633.48,
+        "confidence": 1,
+        "text": "outlet",
+        "offset": 108,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 633.48,
+        "end": 633.62,
+        "confidence": 1,
+        "text": "for",
+        "offset": 115,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 633.62,
+        "end": 633.95,
+        "confidence": 0.714,
+        "text": "violent",
+        "offset": 119,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 633.95,
+        "end": 634.53,
+        "confidence": 0.99,
+        "text": "behavior?",
+        "offset": 127,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Or is that training or cruelty muscles.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 635.37,
+      "words": [
+        {
+          "start": 635.37,
+          "confidence": 0.566,
+          "end": 635.46,
+          "word": "or",
+          "punct": "Or",
+          "index": 0
+        },
+        {
+          "start": 635.46,
+          "confidence": 0.948,
+          "end": 635.59,
+          "word": "is",
+          "punct": "is",
+          "index": 1
+        },
+        {
+          "start": 635.59,
+          "confidence": 1,
+          "end": 635.83,
+          "word": "that",
+          "punct": "that",
+          "index": 2
+        },
+        {
+          "start": 635.92,
+          "confidence": 1,
+          "end": 636.38,
+          "word": "training",
+          "punct": "training",
+          "index": 3
+        },
+        {
+          "start": 636.38,
+          "confidence": 0.415,
+          "end": 636.51,
+          "word": "or",
+          "punct": "or",
+          "index": 4
+        },
+        {
+          "start": 636.51,
+          "confidence": 0.24,
+          "end": 637,
+          "word": "cruelty",
+          "punct": "cruelty",
+          "index": 5
+        },
+        {
+          "start": 637,
+          "confidence": 0.956,
+          "end": 637.7,
+          "word": "muscles",
+          "punct": "muscles.",
+          "index": 6
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 635.37,
+        "end": 635.46,
+        "confidence": 0.566,
+        "text": "Or",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 635.46,
+        "end": 635.59,
+        "confidence": 0.948,
+        "text": "is",
+        "offset": 3,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 635.59,
+        "end": 635.83,
+        "confidence": 1,
+        "text": "that",
+        "offset": 6,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 635.92,
+        "end": 636.38,
+        "confidence": 1,
+        "text": "training",
+        "offset": 11,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 636.38,
+        "end": 636.51,
+        "confidence": 0.415,
+        "text": "or",
+        "offset": 20,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 636.51,
+        "end": 637,
+        "confidence": 0.24,
+        "text": "cruelty",
+        "offset": 23,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 637,
+        "end": 637.7,
+        "confidence": 0.956,
+        "text": "muscles.",
+        "offset": 31,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "We don't know.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 639.48,
+      "words": [
+        {
+          "start": 639.48,
+          "confidence": 1,
+          "end": 639.64,
+          "word": "we",
+          "punct": "We",
+          "index": 0
+        },
+        {
+          "start": 639.64,
+          "confidence": 1,
+          "end": 639.84,
+          "word": "don't",
+          "punct": "don't",
+          "index": 1
+        },
+        {
+          "start": 639.84,
+          "confidence": 0.735,
+          "end": 640.14,
+          "word": "know",
+          "punct": "know.",
+          "index": 2
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 639.48,
+        "end": 639.64,
+        "confidence": 1,
+        "text": "We",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 639.64,
+        "end": 639.84,
+        "confidence": 1,
+        "text": "don't",
+        "offset": 3,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 639.84,
+        "end": 640.14,
+        "confidence": 0.735,
+        "text": "know.",
+        "offset": 9,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "But the answer this question has the potential to impact human behavior has the potential to impact social norms it has the potential to inspire rules around what we can and can't do with certain robots similar to our animal cruelty laws.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 642.59,
+      "words": [
+        {
+          "start": 642.59,
+          "confidence": 0.839,
+          "end": 642.73,
+          "word": "but",
+          "punct": "But",
+          "index": 0
+        },
+        {
+          "start": 642.73,
+          "confidence": 1,
+          "end": 642.86,
+          "word": "the",
+          "punct": "the",
+          "index": 1
+        },
+        {
+          "start": 642.86,
+          "confidence": 1,
+          "end": 643.26,
+          "word": "answer",
+          "punct": "answer",
+          "index": 2
+        },
+        {
+          "start": 643.26,
+          "confidence": 0.741,
+          "end": 643.47,
+          "word": "this",
+          "punct": "this",
+          "index": 3
+        },
+        {
+          "start": 643.47,
+          "confidence": 1,
+          "end": 644.08,
+          "word": "question",
+          "punct": "question",
+          "index": 4
+        },
+        {
+          "start": 644.08,
+          "confidence": 0.649,
+          "end": 644.32,
+          "word": "has",
+          "punct": "has",
+          "index": 5
+        },
+        {
+          "start": 644.32,
+          "confidence": 0.857,
+          "end": 644.41,
+          "word": "the",
+          "punct": "the",
+          "index": 6
+        },
+        {
+          "start": 644.41,
+          "confidence": 1,
+          "end": 644.89,
+          "word": "potential",
+          "punct": "potential",
+          "index": 7
+        },
+        {
+          "start": 644.89,
+          "confidence": 1,
+          "end": 644.99,
+          "word": "to",
+          "punct": "to",
+          "index": 8
+        },
+        {
+          "start": 644.99,
+          "confidence": 1,
+          "end": 645.44,
+          "word": "impact",
+          "punct": "impact",
+          "index": 9
+        },
+        {
+          "start": 645.44,
+          "confidence": 1,
+          "end": 645.71,
+          "word": "human",
+          "punct": "human",
+          "index": 10
+        },
+        {
+          "start": 645.71,
+          "confidence": 0.999,
+          "end": 646.44,
+          "word": "behavior",
+          "punct": "behavior",
+          "index": 11
+        },
+        {
+          "start": 646.56,
+          "confidence": 0.817,
+          "end": 646.88,
+          "word": "has",
+          "punct": "has",
+          "index": 12
+        },
+        {
+          "start": 646.88,
+          "confidence": 1,
+          "end": 646.98,
+          "word": "the",
+          "punct": "the",
+          "index": 13
+        },
+        {
+          "start": 646.98,
+          "confidence": 1,
+          "end": 647.42,
+          "word": "potential",
+          "punct": "potential",
+          "index": 14
+        },
+        {
+          "start": 647.42,
+          "confidence": 0.789,
+          "end": 647.52,
+          "word": "to",
+          "punct": "to",
+          "index": 15
+        },
+        {
+          "start": 647.52,
+          "confidence": 0.822,
+          "end": 647.92,
+          "word": "impact",
+          "punct": "impact",
+          "index": 16
+        },
+        {
+          "start": 647.92,
+          "confidence": 0.979,
+          "end": 648.3,
+          "word": "social",
+          "punct": "social",
+          "index": 17
+        },
+        {
+          "start": 648.3,
+          "confidence": 1,
+          "end": 648.93,
+          "word": "norms",
+          "punct": "norms",
+          "index": 18
+        },
+        {
+          "start": 649.34,
+          "confidence": 0.957,
+          "end": 649.48,
+          "word": "it",
+          "punct": "it",
+          "index": 19
+        },
+        {
+          "start": 649.48,
+          "confidence": 1,
+          "end": 649.66,
+          "word": "has",
+          "punct": "has",
+          "index": 20
+        },
+        {
+          "start": 649.66,
+          "confidence": 1,
+          "end": 649.76,
+          "word": "the",
+          "punct": "the",
+          "index": 21
+        },
+        {
+          "start": 649.76,
+          "confidence": 1,
+          "end": 650.22,
+          "word": "potential",
+          "punct": "potential",
+          "index": 22
+        },
+        {
+          "start": 650.22,
+          "confidence": 1,
+          "end": 650.35,
+          "word": "to",
+          "punct": "to",
+          "index": 23
+        },
+        {
+          "start": 650.35,
+          "confidence": 1,
+          "end": 650.83,
+          "word": "inspire",
+          "punct": "inspire",
+          "index": 24
+        },
+        {
+          "start": 650.83,
+          "confidence": 0.993,
+          "end": 651.4,
+          "word": "rules",
+          "punct": "rules",
+          "index": 25
+        },
+        {
+          "start": 651.4,
+          "confidence": 0.98,
+          "end": 651.78,
+          "word": "around",
+          "punct": "around",
+          "index": 26
+        },
+        {
+          "start": 651.78,
+          "confidence": 1,
+          "end": 651.92,
+          "word": "what",
+          "punct": "what",
+          "index": 27
+        },
+        {
+          "start": 651.92,
+          "confidence": 1,
+          "end": 652.19,
+          "word": "we",
+          "punct": "we",
+          "index": 28
+        },
+        {
+          "start": 652.3,
+          "confidence": 1,
+          "end": 652.63,
+          "word": "can",
+          "punct": "can",
+          "index": 29
+        },
+        {
+          "start": 652.63,
+          "confidence": 1,
+          "end": 652.74,
+          "word": "and",
+          "punct": "and",
+          "index": 30
+        },
+        {
+          "start": 652.74,
+          "confidence": 1,
+          "end": 653.03,
+          "word": "can't",
+          "punct": "can't",
+          "index": 31
+        },
+        {
+          "start": 653.03,
+          "confidence": 1,
+          "end": 653.19,
+          "word": "do",
+          "punct": "do",
+          "index": 32
+        },
+        {
+          "start": 653.19,
+          "confidence": 0.574,
+          "end": 653.34,
+          "word": "with",
+          "punct": "with",
+          "index": 33
+        },
+        {
+          "start": 653.34,
+          "confidence": 1,
+          "end": 653.59,
+          "word": "certain",
+          "punct": "certain",
+          "index": 34
+        },
+        {
+          "start": 653.59,
+          "confidence": 1,
+          "end": 654.21,
+          "word": "robots",
+          "punct": "robots",
+          "index": 35
+        },
+        {
+          "start": 654.24,
+          "confidence": 1,
+          "end": 654.67,
+          "word": "similar",
+          "punct": "similar",
+          "index": 36
+        },
+        {
+          "start": 654.67,
+          "confidence": 0.857,
+          "end": 654.77,
+          "word": "to",
+          "punct": "to",
+          "index": 37
+        },
+        {
+          "start": 654.77,
+          "confidence": 0.34,
+          "end": 654.94,
+          "word": "our",
+          "punct": "our",
+          "index": 38
+        },
+        {
+          "start": 654.97,
+          "confidence": 1,
+          "end": 655.31,
+          "word": "animal",
+          "punct": "animal",
+          "index": 39
+        },
+        {
+          "start": 655.31,
+          "confidence": 0.999,
+          "end": 655.71,
+          "word": "cruelty",
+          "punct": "cruelty",
+          "index": 40
+        },
+        {
+          "start": 655.71,
+          "confidence": 0.559,
+          "end": 656.25,
+          "word": "laws",
+          "punct": "laws.",
+          "index": 41
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 642.59,
+        "end": 642.73,
+        "confidence": 0.839,
+        "text": "But",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 642.73,
+        "end": 642.86,
+        "confidence": 1,
+        "text": "the",
+        "offset": 4,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 642.86,
+        "end": 643.26,
+        "confidence": 1,
+        "text": "answer",
+        "offset": 8,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 643.26,
+        "end": 643.47,
+        "confidence": 0.741,
+        "text": "this",
+        "offset": 15,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 643.47,
+        "end": 644.08,
+        "confidence": 1,
+        "text": "question",
+        "offset": 20,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 644.08,
+        "end": 644.32,
+        "confidence": 0.649,
+        "text": "has",
+        "offset": 29,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 644.32,
+        "end": 644.41,
+        "confidence": 0.857,
+        "text": "the",
+        "offset": 33,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 644.41,
+        "end": 644.89,
+        "confidence": 1,
+        "text": "potential",
+        "offset": 37,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 644.89,
+        "end": 644.99,
+        "confidence": 1,
+        "text": "to",
+        "offset": 47,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 644.99,
+        "end": 645.44,
+        "confidence": 1,
+        "text": "impact",
+        "offset": 50,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 645.44,
+        "end": 645.71,
+        "confidence": 1,
+        "text": "human",
+        "offset": 57,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 645.71,
+        "end": 646.44,
+        "confidence": 0.999,
+        "text": "behavior",
+        "offset": 63,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 646.56,
+        "end": 646.88,
+        "confidence": 0.817,
+        "text": "has",
+        "offset": 72,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 646.88,
+        "end": 646.98,
+        "confidence": 1,
+        "text": "the",
+        "offset": 76,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 646.98,
+        "end": 647.42,
+        "confidence": 1,
+        "text": "potential",
+        "offset": 80,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 647.42,
+        "end": 647.52,
+        "confidence": 0.789,
+        "text": "to",
+        "offset": 90,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 647.52,
+        "end": 647.92,
+        "confidence": 0.822,
+        "text": "impact",
+        "offset": 93,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 647.92,
+        "end": 648.3,
+        "confidence": 0.979,
+        "text": "social",
+        "offset": 100,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 648.3,
+        "end": 648.93,
+        "confidence": 1,
+        "text": "norms",
+        "offset": 107,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 649.34,
+        "end": 649.48,
+        "confidence": 0.957,
+        "text": "it",
+        "offset": 113,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 649.48,
+        "end": 649.66,
+        "confidence": 1,
+        "text": "has",
+        "offset": 116,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 649.66,
+        "end": 649.76,
+        "confidence": 1,
+        "text": "the",
+        "offset": 120,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 649.76,
+        "end": 650.22,
+        "confidence": 1,
+        "text": "potential",
+        "offset": 124,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 650.22,
+        "end": 650.35,
+        "confidence": 1,
+        "text": "to",
+        "offset": 134,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 650.35,
+        "end": 650.83,
+        "confidence": 1,
+        "text": "inspire",
+        "offset": 137,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 650.83,
+        "end": 651.4,
+        "confidence": 0.993,
+        "text": "rules",
+        "offset": 145,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 651.4,
+        "end": 651.78,
+        "confidence": 0.98,
+        "text": "around",
+        "offset": 151,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 651.78,
+        "end": 651.92,
+        "confidence": 1,
+        "text": "what",
+        "offset": 158,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 651.92,
+        "end": 652.19,
+        "confidence": 1,
+        "text": "we",
+        "offset": 163,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 652.3,
+        "end": 652.63,
+        "confidence": 1,
+        "text": "can",
+        "offset": 166,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 652.63,
+        "end": 652.74,
+        "confidence": 1,
+        "text": "and",
+        "offset": 170,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 652.74,
+        "end": 653.03,
+        "confidence": 1,
+        "text": "can't",
+        "offset": 174,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 653.03,
+        "end": 653.19,
+        "confidence": 1,
+        "text": "do",
+        "offset": 180,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 653.19,
+        "end": 653.34,
+        "confidence": 0.574,
+        "text": "with",
+        "offset": 183,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 653.34,
+        "end": 653.59,
+        "confidence": 1,
+        "text": "certain",
+        "offset": 188,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 653.59,
+        "end": 654.21,
+        "confidence": 1,
+        "text": "robots",
+        "offset": 196,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 654.24,
+        "end": 654.67,
+        "confidence": 1,
+        "text": "similar",
+        "offset": 203,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 654.67,
+        "end": 654.77,
+        "confidence": 0.857,
+        "text": "to",
+        "offset": 211,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 654.77,
+        "end": 654.94,
+        "confidence": 0.34,
+        "text": "our",
+        "offset": 214,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 654.97,
+        "end": 655.31,
+        "confidence": 1,
+        "text": "animal",
+        "offset": 218,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 655.31,
+        "end": 655.71,
+        "confidence": 0.999,
+        "text": "cruelty",
+        "offset": 225,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 655.71,
+        "end": 656.25,
+        "confidence": 0.559,
+        "text": "laws.",
+        "offset": 233,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Because even if robots can't feel our behavior towards them might matter for us.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 657.2,
+      "words": [
+        {
+          "start": 657.2,
+          "confidence": 1,
+          "end": 657.51,
+          "word": "because",
+          "punct": "Because",
+          "index": 0
+        },
+        {
+          "start": 657.51,
+          "confidence": 1,
+          "end": 657.86,
+          "word": "even",
+          "punct": "even",
+          "index": 1
+        },
+        {
+          "start": 657.86,
+          "confidence": 1,
+          "end": 657.99,
+          "word": "if",
+          "punct": "if",
+          "index": 2
+        },
+        {
+          "start": 657.99,
+          "confidence": 1,
+          "end": 658.4,
+          "word": "robots",
+          "punct": "robots",
+          "index": 3
+        },
+        {
+          "start": 658.4,
+          "confidence": 0.989,
+          "end": 658.71,
+          "word": "can't",
+          "punct": "can't",
+          "index": 4
+        },
+        {
+          "start": 658.71,
+          "confidence": 0.929,
+          "end": 659.38,
+          "word": "feel",
+          "punct": "feel",
+          "index": 5
+        },
+        {
+          "start": 660.1,
+          "confidence": 0.68,
+          "end": 660.27,
+          "word": "our",
+          "punct": "our",
+          "index": 6
+        },
+        {
+          "start": 660.27,
+          "confidence": 1,
+          "end": 660.85,
+          "word": "behavior",
+          "punct": "behavior",
+          "index": 7
+        },
+        {
+          "start": 660.85,
+          "confidence": 0.96,
+          "end": 661.19,
+          "word": "towards",
+          "punct": "towards",
+          "index": 8
+        },
+        {
+          "start": 661.19,
+          "confidence": 0.359,
+          "end": 661.35,
+          "word": "them",
+          "punct": "them",
+          "index": 9
+        },
+        {
+          "start": 661.35,
+          "confidence": 0.858,
+          "end": 661.64,
+          "word": "might",
+          "punct": "might",
+          "index": 10
+        },
+        {
+          "start": 661.64,
+          "confidence": 1,
+          "end": 662.23,
+          "word": "matter",
+          "punct": "matter",
+          "index": 11
+        },
+        {
+          "start": 662.38,
+          "confidence": 1,
+          "end": 662.6,
+          "word": "for",
+          "punct": "for",
+          "index": 12
+        },
+        {
+          "start": 662.6,
+          "confidence": 0.996,
+          "end": 663.12,
+          "word": "us",
+          "punct": "us.",
+          "index": 13
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 657.2,
+        "end": 657.51,
+        "confidence": 1,
+        "text": "Because",
+        "offset": 0,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 657.51,
+        "end": 657.86,
+        "confidence": 1,
+        "text": "even",
+        "offset": 8,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 657.86,
+        "end": 657.99,
+        "confidence": 1,
+        "text": "if",
+        "offset": 13,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 657.99,
+        "end": 658.4,
+        "confidence": 1,
+        "text": "robots",
+        "offset": 16,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 658.4,
+        "end": 658.71,
+        "confidence": 0.989,
+        "text": "can't",
+        "offset": 23,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 658.71,
+        "end": 659.38,
+        "confidence": 0.929,
+        "text": "feel",
+        "offset": 29,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 660.1,
+        "end": 660.27,
+        "confidence": 0.68,
+        "text": "our",
+        "offset": 34,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 660.27,
+        "end": 660.85,
+        "confidence": 1,
+        "text": "behavior",
+        "offset": 38,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 660.85,
+        "end": 661.19,
+        "confidence": 0.96,
+        "text": "towards",
+        "offset": 47,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 661.19,
+        "end": 661.35,
+        "confidence": 0.359,
+        "text": "them",
+        "offset": 55,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 661.35,
+        "end": 661.64,
+        "confidence": 0.858,
+        "text": "might",
+        "offset": 60,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 661.64,
+        "end": 662.23,
+        "confidence": 1,
+        "text": "matter",
+        "offset": 66,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 662.38,
+        "end": 662.6,
+        "confidence": 1,
+        "text": "for",
+        "offset": 73,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 662.6,
+        "end": 663.12,
+        "confidence": 0.996,
+        "text": "us.",
+        "offset": 77,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "And regardless of whether we end up changing our rules.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 664.89,
+      "words": [
+        {
+          "start": 664.89,
+          "confidence": 1,
+          "end": 665.06,
+          "word": "and",
+          "punct": "And",
+          "index": 0
+        },
+        {
+          "start": 665.06,
+          "confidence": 1,
+          "end": 665.57,
+          "word": "regardless",
+          "punct": "regardless",
+          "index": 1
+        },
+        {
+          "start": 665.57,
+          "confidence": 1,
+          "end": 665.68,
+          "word": "of",
+          "punct": "of",
+          "index": 2
+        },
+        {
+          "start": 665.68,
+          "confidence": 1,
+          "end": 665.91,
+          "word": "whether",
+          "punct": "whether",
+          "index": 3
+        },
+        {
+          "start": 665.91,
+          "confidence": 1,
+          "end": 666.04,
+          "word": "we",
+          "punct": "we",
+          "index": 4
+        },
+        {
+          "start": 666.04,
+          "confidence": 0.978,
+          "end": 666.2,
+          "word": "end",
+          "punct": "end",
+          "index": 5
+        },
+        {
+          "start": 666.2,
+          "confidence": 0.656,
+          "end": 666.29,
+          "word": "up",
+          "punct": "up",
+          "index": 6
+        },
+        {
+          "start": 666.29,
+          "confidence": 0.991,
+          "end": 666.84,
+          "word": "changing",
+          "punct": "changing",
+          "index": 7
+        },
+        {
+          "start": 666.84,
+          "confidence": 0.627,
+          "end": 666.97,
+          "word": "our",
+          "punct": "our",
+          "index": 8
+        },
+        {
+          "start": 666.97,
+          "confidence": 0.822,
+          "end": 667.62,
+          "word": "rules",
+          "punct": "rules.",
+          "index": 9
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 664.89,
+        "end": 665.06,
+        "confidence": 1,
+        "text": "And",
+        "offset": 0,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 665.06,
+        "end": 665.57,
+        "confidence": 1,
+        "text": "regardless",
+        "offset": 4,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 665.57,
+        "end": 665.68,
+        "confidence": 1,
+        "text": "of",
+        "offset": 15,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 665.68,
+        "end": 665.91,
+        "confidence": 1,
+        "text": "whether",
+        "offset": 18,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 665.91,
+        "end": 666.04,
+        "confidence": 1,
+        "text": "we",
+        "offset": 26,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 666.04,
+        "end": 666.2,
+        "confidence": 0.978,
+        "text": "end",
+        "offset": 29,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 666.2,
+        "end": 666.29,
+        "confidence": 0.656,
+        "text": "up",
+        "offset": 33,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 666.29,
+        "end": 666.84,
+        "confidence": 0.991,
+        "text": "changing",
+        "offset": 36,
+        "length": 8,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 666.84,
+        "end": 666.97,
+        "confidence": 0.627,
+        "text": "our",
+        "offset": 45,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 666.97,
+        "end": 667.62,
+        "confidence": 0.822,
+        "text": "rules.",
+        "offset": 49,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Robots might be able to help us come to a new understanding of ourselves.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 668.88,
+      "words": [
+        {
+          "start": 668.88,
+          "confidence": 0.771,
+          "end": 669.32,
+          "word": "robots",
+          "punct": "Robots",
+          "index": 0
+        },
+        {
+          "start": 669.32,
+          "confidence": 0.76,
+          "end": 669.57,
+          "word": "might",
+          "punct": "might",
+          "index": 1
+        },
+        {
+          "start": 669.57,
+          "confidence": 1,
+          "end": 669.7,
+          "word": "be",
+          "punct": "be",
+          "index": 2
+        },
+        {
+          "start": 669.7,
+          "confidence": 1,
+          "end": 669.93,
+          "word": "able",
+          "punct": "able",
+          "index": 3
+        },
+        {
+          "start": 669.93,
+          "confidence": 1,
+          "end": 670.03,
+          "word": "to",
+          "punct": "to",
+          "index": 4
+        },
+        {
+          "start": 670.03,
+          "confidence": 0.986,
+          "end": 670.24,
+          "word": "help",
+          "punct": "help",
+          "index": 5
+        },
+        {
+          "start": 670.24,
+          "confidence": 0.711,
+          "end": 670.36,
+          "word": "us",
+          "punct": "us",
+          "index": 6
+        },
+        {
+          "start": 670.36,
+          "confidence": 0.992,
+          "end": 670.57,
+          "word": "come",
+          "punct": "come",
+          "index": 7
+        },
+        {
+          "start": 670.57,
+          "confidence": 1,
+          "end": 670.72,
+          "word": "to",
+          "punct": "to",
+          "index": 8
+        },
+        {
+          "start": 670.72,
+          "confidence": 1,
+          "end": 670.79,
+          "word": "a",
+          "punct": "a",
+          "index": 9
+        },
+        {
+          "start": 670.79,
+          "confidence": 1,
+          "end": 670.98,
+          "word": "new",
+          "punct": "new",
+          "index": 10
+        },
+        {
+          "start": 670.98,
+          "confidence": 1,
+          "end": 671.57,
+          "word": "understanding",
+          "punct": "understanding",
+          "index": 11
+        },
+        {
+          "start": 671.57,
+          "confidence": 1,
+          "end": 671.66,
+          "word": "of",
+          "punct": "of",
+          "index": 12
+        },
+        {
+          "start": 671.66,
+          "confidence": 0.458,
+          "end": 672.44,
+          "word": "ourselves",
+          "punct": "ourselves.",
+          "index": 13
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 668.88,
+        "end": 669.32,
+        "confidence": 0.771,
+        "text": "Robots",
+        "offset": 0,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 669.32,
+        "end": 669.57,
+        "confidence": 0.76,
+        "text": "might",
+        "offset": 7,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 669.57,
+        "end": 669.7,
+        "confidence": 1,
+        "text": "be",
+        "offset": 13,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 669.7,
+        "end": 669.93,
+        "confidence": 1,
+        "text": "able",
+        "offset": 16,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 669.93,
+        "end": 670.03,
+        "confidence": 1,
+        "text": "to",
+        "offset": 21,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 670.03,
+        "end": 670.24,
+        "confidence": 0.986,
+        "text": "help",
+        "offset": 24,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 670.24,
+        "end": 670.36,
+        "confidence": 0.711,
+        "text": "us",
+        "offset": 29,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 670.36,
+        "end": 670.57,
+        "confidence": 0.992,
+        "text": "come",
+        "offset": 32,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 670.57,
+        "end": 670.72,
+        "confidence": 1,
+        "text": "to",
+        "offset": 37,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 670.72,
+        "end": 670.79,
+        "confidence": 1,
+        "text": "a",
+        "offset": 40,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 670.79,
+        "end": 670.98,
+        "confidence": 1,
+        "text": "new",
+        "offset": 42,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 670.98,
+        "end": 671.57,
+        "confidence": 1,
+        "text": "understanding",
+        "offset": 46,
+        "length": 13,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 671.57,
+        "end": 671.66,
+        "confidence": 1,
+        "text": "of",
+        "offset": 60,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 671.66,
+        "end": 672.44,
+        "confidence": 0.458,
+        "text": "ourselves.",
+        "offset": 63,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Most of what I've learned over the past ten years have not been about technology at all.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 674.22,
+      "words": [
+        {
+          "start": 674.22,
+          "confidence": 0.903,
+          "end": 674.48,
+          "word": "most",
+          "punct": "Most",
+          "index": 0
+        },
+        {
+          "start": 674.48,
+          "confidence": 0.78,
+          "end": 674.54,
+          "word": "of",
+          "punct": "of",
+          "index": 1
+        },
+        {
+          "start": 674.54,
+          "confidence": 0.815,
+          "end": 674.66,
+          "word": "what",
+          "punct": "what",
+          "index": 2
+        },
+        {
+          "start": 674.66,
+          "confidence": 0.815,
+          "end": 674.76,
+          "word": "I've",
+          "punct": "I've",
+          "index": 3
+        },
+        {
+          "start": 674.76,
+          "confidence": 1,
+          "end": 675.05,
+          "word": "learned",
+          "punct": "learned",
+          "index": 4
+        },
+        {
+          "start": 675.05,
+          "confidence": 1,
+          "end": 675.16,
+          "word": "over",
+          "punct": "over",
+          "index": 5
+        },
+        {
+          "start": 675.16,
+          "confidence": 1,
+          "end": 675.23,
+          "word": "the",
+          "punct": "the",
+          "index": 6
+        },
+        {
+          "start": 675.23,
+          "confidence": 1,
+          "end": 675.53,
+          "word": "past",
+          "punct": "past",
+          "index": 7
+        },
+        {
+          "start": 675.53,
+          "confidence": 1,
+          "end": 675.69,
+          "word": "ten",
+          "punct": "ten",
+          "index": 8
+        },
+        {
+          "start": 675.69,
+          "confidence": 0.998,
+          "end": 676.29,
+          "word": "years",
+          "punct": "years",
+          "index": 9
+        },
+        {
+          "start": 676.44,
+          "confidence": 0.46,
+          "end": 676.62,
+          "word": "have",
+          "punct": "have",
+          "index": 10
+        },
+        {
+          "start": 676.62,
+          "confidence": 0.989,
+          "end": 676.86,
+          "word": "not",
+          "punct": "not",
+          "index": 11
+        },
+        {
+          "start": 676.86,
+          "confidence": 1,
+          "end": 676.97,
+          "word": "been",
+          "punct": "been",
+          "index": 12
+        },
+        {
+          "start": 676.97,
+          "confidence": 1,
+          "end": 677.2,
+          "word": "about",
+          "punct": "about",
+          "index": 13
+        },
+        {
+          "start": 677.2,
+          "confidence": 1,
+          "end": 677.72,
+          "word": "technology",
+          "punct": "technology",
+          "index": 14
+        },
+        {
+          "start": 677.72,
+          "confidence": 0.613,
+          "end": 677.8,
+          "word": "at",
+          "punct": "at",
+          "index": 15
+        },
+        {
+          "start": 677.8,
+          "confidence": 0.992,
+          "end": 678.12,
+          "word": "all",
+          "punct": "all.",
+          "index": 16
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 674.22,
+        "end": 674.48,
+        "confidence": 0.903,
+        "text": "Most",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 674.48,
+        "end": 674.54,
+        "confidence": 0.78,
+        "text": "of",
+        "offset": 5,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 674.54,
+        "end": 674.66,
+        "confidence": 0.815,
+        "text": "what",
+        "offset": 8,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 674.66,
+        "end": 674.76,
+        "confidence": 0.815,
+        "text": "I've",
+        "offset": 13,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 674.76,
+        "end": 675.05,
+        "confidence": 1,
+        "text": "learned",
+        "offset": 18,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 675.05,
+        "end": 675.16,
+        "confidence": 1,
+        "text": "over",
+        "offset": 26,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 675.16,
+        "end": 675.23,
+        "confidence": 1,
+        "text": "the",
+        "offset": 31,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 675.23,
+        "end": 675.53,
+        "confidence": 1,
+        "text": "past",
+        "offset": 35,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 675.53,
+        "end": 675.69,
+        "confidence": 1,
+        "text": "ten",
+        "offset": 40,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 675.69,
+        "end": 676.29,
+        "confidence": 0.998,
+        "text": "years",
+        "offset": 44,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 676.44,
+        "end": 676.62,
+        "confidence": 0.46,
+        "text": "have",
+        "offset": 50,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 676.62,
+        "end": 676.86,
+        "confidence": 0.989,
+        "text": "not",
+        "offset": 55,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 676.86,
+        "end": 676.97,
+        "confidence": 1,
+        "text": "been",
+        "offset": 59,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 676.97,
+        "end": 677.2,
+        "confidence": 1,
+        "text": "about",
+        "offset": 64,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 677.2,
+        "end": 677.72,
+        "confidence": 1,
+        "text": "technology",
+        "offset": 70,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 677.72,
+        "end": 677.8,
+        "confidence": 0.613,
+        "text": "at",
+        "offset": 81,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 677.8,
+        "end": 678.12,
+        "confidence": 0.992,
+        "text": "all.",
+        "offset": 84,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "It's been about human psychology and empathy and how we relate to others.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 678.96,
+      "words": [
+        {
+          "start": 678.96,
+          "confidence": 1,
+          "end": 679.06,
+          "word": "it's",
+          "punct": "It's",
+          "index": 0
+        },
+        {
+          "start": 679.06,
+          "confidence": 1,
+          "end": 679.2,
+          "word": "been",
+          "punct": "been",
+          "index": 1
+        },
+        {
+          "start": 679.2,
+          "confidence": 1,
+          "end": 679.45,
+          "word": "about",
+          "punct": "about",
+          "index": 2
+        },
+        {
+          "start": 679.45,
+          "confidence": 1,
+          "end": 679.75,
+          "word": "human",
+          "punct": "human",
+          "index": 3
+        },
+        {
+          "start": 679.75,
+          "confidence": 1,
+          "end": 680.69,
+          "word": "psychology",
+          "punct": "psychology",
+          "index": 4
+        },
+        {
+          "start": 681.38,
+          "confidence": 0.732,
+          "end": 681.58,
+          "word": "and",
+          "punct": "and",
+          "index": 5
+        },
+        {
+          "start": 681.58,
+          "confidence": 1,
+          "end": 682.26,
+          "word": "empathy",
+          "punct": "empathy",
+          "index": 6
+        },
+        {
+          "start": 682.29,
+          "confidence": 0.759,
+          "end": 682.44,
+          "word": "and",
+          "punct": "and",
+          "index": 7
+        },
+        {
+          "start": 682.44,
+          "confidence": 1,
+          "end": 682.65,
+          "word": "how",
+          "punct": "how",
+          "index": 8
+        },
+        {
+          "start": 682.65,
+          "confidence": 1,
+          "end": 682.78,
+          "word": "we",
+          "punct": "we",
+          "index": 9
+        },
+        {
+          "start": 682.78,
+          "confidence": 1,
+          "end": 683.12,
+          "word": "relate",
+          "punct": "relate",
+          "index": 10
+        },
+        {
+          "start": 683.12,
+          "confidence": 1,
+          "end": 683.23,
+          "word": "to",
+          "punct": "to",
+          "index": 11
+        },
+        {
+          "start": 683.23,
+          "confidence": 0.995,
+          "end": 683.82,
+          "word": "others",
+          "punct": "others.",
+          "index": 12
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 678.96,
+        "end": 679.06,
+        "confidence": 1,
+        "text": "It's",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 679.06,
+        "end": 679.2,
+        "confidence": 1,
+        "text": "been",
+        "offset": 5,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 679.2,
+        "end": 679.45,
+        "confidence": 1,
+        "text": "about",
+        "offset": 10,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 679.45,
+        "end": 679.75,
+        "confidence": 1,
+        "text": "human",
+        "offset": 16,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 679.75,
+        "end": 680.69,
+        "confidence": 1,
+        "text": "psychology",
+        "offset": 22,
+        "length": 10,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 681.38,
+        "end": 681.58,
+        "confidence": 0.732,
+        "text": "and",
+        "offset": 33,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 681.58,
+        "end": 682.26,
+        "confidence": 1,
+        "text": "empathy",
+        "offset": 37,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 682.29,
+        "end": 682.44,
+        "confidence": 0.759,
+        "text": "and",
+        "offset": 45,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 682.44,
+        "end": 682.65,
+        "confidence": 1,
+        "text": "how",
+        "offset": 49,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 682.65,
+        "end": 682.78,
+        "confidence": 1,
+        "text": "we",
+        "offset": 53,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 682.78,
+        "end": 683.12,
+        "confidence": 1,
+        "text": "relate",
+        "offset": 56,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 683.12,
+        "end": 683.23,
+        "confidence": 1,
+        "text": "to",
+        "offset": 63,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 683.23,
+        "end": 683.82,
+        "confidence": 0.995,
+        "text": "others.",
+        "offset": 66,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Because when a child is kind to a room by a.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 685.48,
+      "words": [
+        {
+          "start": 685.48,
+          "confidence": 1,
+          "end": 685.82,
+          "word": "because",
+          "punct": "Because",
+          "index": 0
+        },
+        {
+          "start": 685.82,
+          "confidence": 0.951,
+          "end": 685.97,
+          "word": "when",
+          "punct": "when",
+          "index": 1
+        },
+        {
+          "start": 685.97,
+          "confidence": 0.748,
+          "end": 686.02,
+          "word": "a",
+          "punct": "a",
+          "index": 2
+        },
+        {
+          "start": 686.02,
+          "confidence": 0.999,
+          "end": 686.47,
+          "word": "child",
+          "punct": "child",
+          "index": 3
+        },
+        {
+          "start": 686.47,
+          "confidence": 0.962,
+          "end": 686.59,
+          "word": "is",
+          "punct": "is",
+          "index": 4
+        },
+        {
+          "start": 686.59,
+          "confidence": 0.9,
+          "end": 686.98,
+          "word": "kind",
+          "punct": "kind",
+          "index": 5
+        },
+        {
+          "start": 686.98,
+          "confidence": 1,
+          "end": 687.11,
+          "word": "to",
+          "punct": "to",
+          "index": 6
+        },
+        {
+          "start": 687.11,
+          "confidence": 0.235,
+          "end": 687.21,
+          "word": "a",
+          "punct": "a",
+          "index": 7
+        },
+        {
+          "start": 687.21,
+          "confidence": 0.967,
+          "end": 687.47,
+          "word": "room",
+          "punct": "room",
+          "index": 8
+        },
+        {
+          "start": 687.47,
+          "confidence": 0.388,
+          "end": 687.58,
+          "word": "by",
+          "punct": "by",
+          "index": 9
+        },
+        {
+          "start": 687.58,
+          "confidence": 0.413,
+          "end": 687.78,
+          "word": "a",
+          "punct": "a.",
+          "index": 10
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 685.48,
+        "end": 685.82,
+        "confidence": 1,
+        "text": "Because",
+        "offset": 0,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 685.82,
+        "end": 685.97,
+        "confidence": 0.951,
+        "text": "when",
+        "offset": 8,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 685.97,
+        "end": 686.02,
+        "confidence": 0.748,
+        "text": "a",
+        "offset": 13,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 686.02,
+        "end": 686.47,
+        "confidence": 0.999,
+        "text": "child",
+        "offset": 15,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 686.47,
+        "end": 686.59,
+        "confidence": 0.962,
+        "text": "is",
+        "offset": 21,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 686.59,
+        "end": 686.98,
+        "confidence": 0.9,
+        "text": "kind",
+        "offset": 24,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 686.98,
+        "end": 687.11,
+        "confidence": 1,
+        "text": "to",
+        "offset": 29,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 687.11,
+        "end": 687.21,
+        "confidence": 0.235,
+        "text": "a",
+        "offset": 32,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 687.21,
+        "end": 687.47,
+        "confidence": 0.967,
+        "text": "room",
+        "offset": 34,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 687.47,
+        "end": 687.58,
+        "confidence": 0.388,
+        "text": "by",
+        "offset": 39,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 687.58,
+        "end": 687.78,
+        "confidence": 0.413,
+        "text": "a.",
+        "offset": 42,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "When a soldier tries to save a robot on the battlefield?",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 689.23,
+      "words": [
+        {
+          "start": 689.23,
+          "confidence": 0.578,
+          "end": 689.4,
+          "word": "when",
+          "punct": "When",
+          "index": 0
+        },
+        {
+          "start": 689.4,
+          "confidence": 0.445,
+          "end": 689.48,
+          "word": "a",
+          "punct": "a",
+          "index": 1
+        },
+        {
+          "start": 689.48,
+          "confidence": 0.924,
+          "end": 689.95,
+          "word": "soldier",
+          "punct": "soldier",
+          "index": 2
+        },
+        {
+          "start": 689.95,
+          "confidence": 0.593,
+          "end": 690.33,
+          "word": "tries",
+          "punct": "tries",
+          "index": 3
+        },
+        {
+          "start": 690.33,
+          "confidence": 1,
+          "end": 690.44,
+          "word": "to",
+          "punct": "to",
+          "index": 4
+        },
+        {
+          "start": 690.44,
+          "confidence": 0.832,
+          "end": 690.77,
+          "word": "save",
+          "punct": "save",
+          "index": 5
+        },
+        {
+          "start": 690.77,
+          "confidence": 0.74,
+          "end": 690.85,
+          "word": "a",
+          "punct": "a",
+          "index": 6
+        },
+        {
+          "start": 690.85,
+          "confidence": 0.847,
+          "end": 691.21,
+          "word": "robot",
+          "punct": "robot",
+          "index": 7
+        },
+        {
+          "start": 691.21,
+          "confidence": 1,
+          "end": 691.34,
+          "word": "on",
+          "punct": "on",
+          "index": 8
+        },
+        {
+          "start": 691.34,
+          "confidence": 0.99,
+          "end": 691.43,
+          "word": "the",
+          "punct": "the",
+          "index": 9
+        },
+        {
+          "start": 691.43,
+          "confidence": 0.411,
+          "end": 692.22,
+          "word": "battlefield",
+          "punct": "battlefield?",
+          "index": 10
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 689.23,
+        "end": 689.4,
+        "confidence": 0.578,
+        "text": "When",
+        "offset": 0,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 689.4,
+        "end": 689.48,
+        "confidence": 0.445,
+        "text": "a",
+        "offset": 5,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 689.48,
+        "end": 689.95,
+        "confidence": 0.924,
+        "text": "soldier",
+        "offset": 7,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 689.95,
+        "end": 690.33,
+        "confidence": 0.593,
+        "text": "tries",
+        "offset": 15,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 690.33,
+        "end": 690.44,
+        "confidence": 1,
+        "text": "to",
+        "offset": 21,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 690.44,
+        "end": 690.77,
+        "confidence": 0.832,
+        "text": "save",
+        "offset": 24,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 690.77,
+        "end": 690.85,
+        "confidence": 0.74,
+        "text": "a",
+        "offset": 29,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 690.85,
+        "end": 691.21,
+        "confidence": 0.847,
+        "text": "robot",
+        "offset": 31,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 691.21,
+        "end": 691.34,
+        "confidence": 1,
+        "text": "on",
+        "offset": 37,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 691.34,
+        "end": 691.43,
+        "confidence": 0.99,
+        "text": "the",
+        "offset": 40,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 691.43,
+        "end": 692.22,
+        "confidence": 0.411,
+        "text": "battlefield?",
+        "offset": 44,
+        "length": 12,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Or when a group of people refuses to harm a robotic baby dinosaur.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 693.26,
+      "words": [
+        {
+          "start": 693.26,
+          "confidence": 0.419,
+          "end": 693.42,
+          "word": "or",
+          "punct": "Or",
+          "index": 0
+        },
+        {
+          "start": 693.42,
+          "confidence": 1,
+          "end": 693.55,
+          "word": "when",
+          "punct": "when",
+          "index": 1
+        },
+        {
+          "start": 693.55,
+          "confidence": 1,
+          "end": 693.61,
+          "word": "a",
+          "punct": "a",
+          "index": 2
+        },
+        {
+          "start": 693.61,
+          "confidence": 1,
+          "end": 693.82,
+          "word": "group",
+          "punct": "group",
+          "index": 3
+        },
+        {
+          "start": 693.82,
+          "confidence": 1,
+          "end": 693.94,
+          "word": "of",
+          "punct": "of",
+          "index": 4
+        },
+        {
+          "start": 693.94,
+          "confidence": 1,
+          "end": 694.32,
+          "word": "people",
+          "punct": "people",
+          "index": 5
+        },
+        {
+          "start": 694.32,
+          "confidence": 1,
+          "end": 694.87,
+          "word": "refuses",
+          "punct": "refuses",
+          "index": 6
+        },
+        {
+          "start": 694.87,
+          "confidence": 1,
+          "end": 694.98,
+          "word": "to",
+          "punct": "to",
+          "index": 7
+        },
+        {
+          "start": 694.98,
+          "confidence": 0.894,
+          "end": 695.43,
+          "word": "harm",
+          "punct": "harm",
+          "index": 8
+        },
+        {
+          "start": 695.43,
+          "confidence": 0.654,
+          "end": 695.51,
+          "word": "a",
+          "punct": "a",
+          "index": 9
+        },
+        {
+          "start": 695.51,
+          "confidence": 1,
+          "end": 695.9,
+          "word": "robotic",
+          "punct": "robotic",
+          "index": 10
+        },
+        {
+          "start": 695.9,
+          "confidence": 0.51,
+          "end": 696.13,
+          "word": "baby",
+          "punct": "baby",
+          "index": 11
+        },
+        {
+          "start": 696.13,
+          "confidence": 0.985,
+          "end": 696.88,
+          "word": "dinosaur",
+          "punct": "dinosaur.",
+          "index": 12
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 693.26,
+        "end": 693.42,
+        "confidence": 0.419,
+        "text": "Or",
+        "offset": 0,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 693.42,
+        "end": 693.55,
+        "confidence": 1,
+        "text": "when",
+        "offset": 3,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 693.55,
+        "end": 693.61,
+        "confidence": 1,
+        "text": "a",
+        "offset": 8,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 693.61,
+        "end": 693.82,
+        "confidence": 1,
+        "text": "group",
+        "offset": 10,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 693.82,
+        "end": 693.94,
+        "confidence": 1,
+        "text": "of",
+        "offset": 16,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 693.94,
+        "end": 694.32,
+        "confidence": 1,
+        "text": "people",
+        "offset": 19,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 694.32,
+        "end": 694.87,
+        "confidence": 1,
+        "text": "refuses",
+        "offset": 26,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 694.87,
+        "end": 694.98,
+        "confidence": 1,
+        "text": "to",
+        "offset": 34,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 694.98,
+        "end": 695.43,
+        "confidence": 0.894,
+        "text": "harm",
+        "offset": 37,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 695.43,
+        "end": 695.51,
+        "confidence": 0.654,
+        "text": "a",
+        "offset": 42,
+        "length": 1,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 695.51,
+        "end": 695.9,
+        "confidence": 1,
+        "text": "robotic",
+        "offset": 44,
+        "length": 7,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 695.9,
+        "end": 696.13,
+        "confidence": 0.51,
+        "text": "baby",
+        "offset": 52,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 696.13,
+        "end": 696.88,
+        "confidence": 0.985,
+        "text": "dinosaur.",
+        "offset": 57,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Those robots arches motors in years and algorithms.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 698.21,
+      "words": [
+        {
+          "start": 698.21,
+          "confidence": 0.844,
+          "end": 698.43,
+          "word": "those",
+          "punct": "Those",
+          "index": 0
+        },
+        {
+          "start": 698.43,
+          "confidence": 0.951,
+          "end": 698.83,
+          "word": "robots",
+          "punct": "robots",
+          "index": 1
+        },
+        {
+          "start": 698.83,
+          "confidence": 0.396,
+          "end": 699.4,
+          "word": "arches",
+          "punct": "arches",
+          "index": 2
+        },
+        {
+          "start": 699.44,
+          "confidence": 1,
+          "end": 699.91,
+          "word": "motors",
+          "punct": "motors",
+          "index": 3
+        },
+        {
+          "start": 699.91,
+          "confidence": 0.506,
+          "end": 700.01,
+          "word": "in",
+          "punct": "in",
+          "index": 4
+        },
+        {
+          "start": 700.01,
+          "confidence": 0.362,
+          "end": 700.34,
+          "word": "years",
+          "punct": "years",
+          "index": 5
+        },
+        {
+          "start": 700.34,
+          "confidence": 0.553,
+          "end": 700.45,
+          "word": "and",
+          "punct": "and",
+          "index": 6
+        },
+        {
+          "start": 700.45,
+          "confidence": 0.998,
+          "end": 701.39,
+          "word": "algorithms",
+          "punct": "algorithms.",
+          "index": 7
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 698.21,
+        "end": 698.43,
+        "confidence": 0.844,
+        "text": "Those",
+        "offset": 0,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 698.43,
+        "end": 698.83,
+        "confidence": 0.951,
+        "text": "robots",
+        "offset": 6,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 698.83,
+        "end": 699.4,
+        "confidence": 0.396,
+        "text": "arches",
+        "offset": 13,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 699.44,
+        "end": 699.91,
+        "confidence": 1,
+        "text": "motors",
+        "offset": 20,
+        "length": 6,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 699.91,
+        "end": 700.01,
+        "confidence": 0.506,
+        "text": "in",
+        "offset": 27,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 700.01,
+        "end": 700.34,
+        "confidence": 0.362,
+        "text": "years",
+        "offset": 30,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 700.34,
+        "end": 700.45,
+        "confidence": 0.553,
+        "text": "and",
+        "offset": 36,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 700.45,
+        "end": 701.39,
+        "confidence": 0.998,
+        "text": "algorithms.",
+        "offset": 40,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Their reflections of our own humanity.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 702.48,
+      "words": [
+        {
+          "start": 702.48,
+          "confidence": 0.726,
+          "end": 702.65,
+          "word": "their",
+          "punct": "Their",
+          "index": 0
+        },
+        {
+          "start": 702.65,
+          "confidence": 1,
+          "end": 703.24,
+          "word": "reflections",
+          "punct": "reflections",
+          "index": 1
+        },
+        {
+          "start": 703.24,
+          "confidence": 1,
+          "end": 703.33,
+          "word": "of",
+          "punct": "of",
+          "index": 2
+        },
+        {
+          "start": 703.33,
+          "confidence": 1,
+          "end": 703.44,
+          "word": "our",
+          "punct": "our",
+          "index": 3
+        },
+        {
+          "start": 703.44,
+          "confidence": 1,
+          "end": 703.62,
+          "word": "own",
+          "punct": "own",
+          "index": 4
+        },
+        {
+          "start": 703.62,
+          "confidence": 0.998,
+          "end": 704.32,
+          "word": "humanity",
+          "punct": "humanity.",
+          "index": 5
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 702.48,
+        "end": 702.65,
+        "confidence": 0.726,
+        "text": "Their",
+        "offset": 0,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 702.65,
+        "end": 703.24,
+        "confidence": 1,
+        "text": "reflections",
+        "offset": 6,
+        "length": 11,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 703.24,
+        "end": 703.33,
+        "confidence": 1,
+        "text": "of",
+        "offset": 18,
+        "length": 2,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 703.33,
+        "end": 703.44,
+        "confidence": 1,
+        "text": "our",
+        "offset": 21,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 703.44,
+        "end": 703.62,
+        "confidence": 1,
+        "text": "own",
+        "offset": 25,
+        "length": 3,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 703.62,
+        "end": 704.32,
+        "confidence": 0.998,
+        "text": "humanity.",
+        "offset": 29,
+        "length": 9,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  },
+  {
+    "text": "Thank you.",
+    "type": "paragraph",
+    "data": {
+      "speaker": "TBC 1",
+      "start": 705.5,
+      "words": [
+        {
+          "start": 705.5,
+          "confidence": 1,
+          "end": 705.77,
+          "word": "thank",
+          "punct": "Thank",
+          "index": 0
+        },
+        {
+          "start": 705.77,
+          "confidence": 0.995,
+          "end": 705.94,
+          "word": "you",
+          "punct": "you.",
+          "index": 1
+        }
+      ]
+    },
+    "entityRanges": [
+      {
+        "start": 705.5,
+        "end": 705.77,
+        "confidence": 1,
+        "text": "Thank",
+        "offset": 0,
+        "length": 5,
+        "key": expect.any(String)//"ss8pm4p"
+      },
+      {
+        "start": 705.77,
+        "end": 705.94,
+        "confidence": 0.995,
+        "text": "you.",
+        "offset": 6,
+        "length": 4,
+        "key": expect.any(String)//"ss8pm4p"
+      }
+    ]
+  }
+];
+export default draftTranscriptExample;

--- a/src/lib/Util/adapters/index.js
+++ b/src/lib/Util/adapters/index.js
@@ -1,5 +1,6 @@
 import bbcKaldiToDraft from './bbc-kaldi/index';
 import autoEdit2ToDraft from './autoEdit2/index';
+import ibmToDraft from './ibm/index';
 /**
  * Adapters for STT conversion
  * @param {json} transcriptData - A json transcript with some word accurate timecode
@@ -38,11 +39,15 @@ const sttJsonAdapter = (transcriptData, sttJsonType) => {
     blocks = autoEdit2ToDraft(transcriptData);
 
     return { blocks, entityMap: createEntityMap(blocks) };
+  case 'ibm':
+    blocks = ibmToDraft(transcriptData);
+
+    return { blocks, entityMap: createEntityMap(blocks) };
   case 'draftjs':
     return transcriptData; // (typeof transcriptData === 'string')? JSON.parse(transcriptData): transcriptData;
   default:
     // code block
-    console.error('not recognised the stt enginge');
+    console.error('Did not recognize the stt engine.');
   }
 };
 

--- a/src/select-stt-json-type.js
+++ b/src/select-stt-json-type.js
@@ -8,7 +8,7 @@ const SttTypeSelect = props => (<select name={ props.name } value={ props.value 
   <option value="gentle-alignement" disabled>Gentle Alignement</option>
   <option value="iiif" disabled>IIIF</option>
   <option value="autoedit2">autoEdit 2</option>
-  <option value="ibm" disabled>IBM Watson STT</option>
+  <option value="ibm">IBM Watson STT</option>
   <option value="speechmatics" disabled>Speechmatics</option>
   <option value="assemblyai" disabled>AssemblyAI</option>
   <option value="rev" disabled>Rev</option>


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
No.

**Describe what the PR does**    
Adds initial support for IBM Watson TTS Json files. Working well in my limited tests, but a few things could probably be refactored for clarity. Creating EntityRanges is done from within the adapter itself, rather than being handed off to the common function for that purpose...


**State whether the PR is ready for review or whether it needs extra work**    
Ready to be reviewed.

**Additional context**    
N/A
