### PR TITLE
fixed single click fast forward/rewind

### DIFF
--- a/src/lib/TranscriptEditor/MediaPlayer/PlayerControls.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/PlayerControls.js
@@ -12,12 +12,14 @@ class PlayerControls extends React.Component {
   // backward or forward function
   // on mouseUp the interval is cleared
   setIntervalHelperBackward = () => {
+    this.props.skipBackward();
     this.interval = setInterval(() => {
       this.props.skipBackward();
     }, 300);
   }
 
   setIntervalHelperForward = () => {
+    this.props.skipForward();
     this.interval = setInterval(() => {
       this.props.skipForward();
     }, 300);


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      

addressing https://github.com/bbc/react-transcript-editor/issues/47 -Fast forward/rewind - single click bug 

> Expecting Fast forward/rewind button to work fast forwarding or rewinding even if user only click once.

**Describe what the PR does**    

Fixed single click fast forward/rewind, with previous bug it would only fast forward or rewind on single click, just fixed it so that it also works on single click

**State whether the PR is ready for review or whether it needs extra work**    

Ready for review

**Additional context**    

@jamesdools option to merge into `settings-panel-spike` directly or wait for  `settings-panel-spike` to be merged into `master` and merge to `master` afterwards. Whatever is easier.