### PR TITLE
help-box-spike: moved ToolTip next to settings icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3441,7 +3441,7 @@
         },
         "regjsparser": {
           "version": "0.1.5",
-          "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {

--- a/src/lib/TranscriptEditor/TimedTextEditor/index.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/index.js
@@ -1,9 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Tooltip from 'react-simple-tooltip';
-
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faQuestionCircle, faMousePointer, faICursor, faUserEdit, faKeyboard, faSave } from '@fortawesome/free-solid-svg-icons';
 
 import {
   Editor,
@@ -405,13 +401,6 @@ class TimedTextEditor extends React.Component {
   }
 
   render() {
-    const helpMessage = <div className={ style.helpMessage }>
-      <span><FontAwesomeIcon className={ style.icon } icon={ faMousePointer } />Double click on a word or timestamp to jump to that point in the video.</span>
-      <span><FontAwesomeIcon className={ style.icon } icon={ faICursor } />Start typing to edit text.</span>
-      <span><FontAwesomeIcon className={ style.icon } icon={ faUserEdit } />You can add and change names of speakers in your transcript.</span>
-      <span><FontAwesomeIcon className={ style.icon } icon={ faKeyboard } />Use keyboard shortcuts for quick control.</span>
-      <span><FontAwesomeIcon className={ style.icon } icon={ faSave } />Save & export to get a copy to your desktop.</span>
-    </div>;
 
     const currentWord = this.getCurrentWord();
     const highlightColour = '#69e3c2';
@@ -447,17 +436,6 @@ class TimedTextEditor extends React.Component {
 
     return (
       <section>
-        <Tooltip
-          className={ style.help }
-          content={ helpMessage }
-          fadeDuration={ 250 }
-          fadeEasing={ 'ease-in' }
-          placement={ 'bottom' }
-          radius={ 5 }>
-          <FontAwesomeIcon className={ style.icon } icon={ faQuestionCircle } />
-          How does this work?
-        </Tooltip>
-
         { this.props.transcriptData !== null ? editor : null }
       </section>
     );

--- a/src/lib/TranscriptEditor/TimedTextEditor/index.module.css
+++ b/src/lib/TranscriptEditor/TimedTextEditor/index.module.css
@@ -24,22 +24,3 @@ https://github.com/facebook/draft-js/issues/528
   }
 }
 
-.help {
-  cursor: pointer;
-  float: right;
-  padding-right: 0.5em;
-  padding-left: 11em;
-  margin: 0.5em 0;
-}
-
-.icon {
-  color: color-labs-red;
-  margin-right: 0.5em;
-}
-
-.helpMessage span {
-  display: block;
-  font-size: 0.8em;
-  font-weight: lighter;
-  margin-top: 1em;
-}

--- a/src/lib/TranscriptEditor/index.js
+++ b/src/lib/TranscriptEditor/index.js
@@ -2,7 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCog, faKeyboard } from '@fortawesome/free-solid-svg-icons';
+import { faCog, faKeyboard, faQuestionCircle, faMousePointer, faICursor, faUserEdit, faSave  } from '@fortawesome/free-solid-svg-icons';
+
+import Tooltip from 'react-simple-tooltip';
 
 import TimedTextEditor from './TimedTextEditor';
 import MediaPlayer from './MediaPlayer';
@@ -156,11 +158,35 @@ class TranscriptEditor extends React.Component {
       handleShortcutsToggle={ this.handleShortcutsToggle }
     />;
 
+    const helpMessage = <div className={ style.helpMessage }>
+      <span><FontAwesomeIcon className={ style.icon } icon={ faMousePointer } />Double click on a word or timestamp to jump to that point in the video.</span>
+      <span><FontAwesomeIcon className={ style.icon } icon={ faICursor } />Start typing to edit text.</span>
+      <span><FontAwesomeIcon className={ style.icon } icon={ faUserEdit } />You can add and change names of speakers in your transcript.</span>
+      <span><FontAwesomeIcon className={ style.icon } icon={ faKeyboard } />Use keyboard shortcuts for quick control.</span>
+      <span><FontAwesomeIcon className={ style.icon } icon={ faSave } />Save & export to get a copy to your desktop.</span>
+    </div>;
+
+    const tooltip = <Tooltip
+      className={ style.help }
+      content={ helpMessage }
+      fadeDuration={ 250 }
+      fadeEasing={ 'ease-in' }
+      placement={ 'bottom' }
+      radius={ 5 }
+      border={ '#ffffff' }
+      background={ '#f2f2f2' }
+      color={ '#000000' }
+    >
+      <FontAwesomeIcon className={ style.icon } icon={ faQuestionCircle } />
+    How does this work?
+    </Tooltip>;
+
     return (
       <div className={ style.container }>
         <header className={ style.header }>
           { this.state.showSettings ? settings : null }
           { this.state.showShortcuts ? shortcuts : null }
+          {tooltip}
         </header>
 
         <aside className={ style.aside }>{ this.props.mediaUrl ? mediaPlayer : null }</aside>

--- a/src/lib/TranscriptEditor/index.module.css
+++ b/src/lib/TranscriptEditor/index.module.css
@@ -70,3 +70,29 @@
 ::moz-selection {
   background: color-subt-green;
 }
+
+.help {
+  cursor: pointer;
+  float: right;
+  padding-right: 0.5em;
+  padding-left: 11em;
+  margin: 0.5em 0;
+  color: white;
+  display: block;
+  /* font-size: 0.8em; */
+  font-weight: lighter;
+  margin-top: 0.5em;
+  margin-right: 6em;
+}
+
+.icon {
+  color: color-labs-red;
+  margin-right: 0.5em;
+}
+
+.helpMessage span {
+  display: block;
+  /* font-size: 0.8em; */
+  font-weight: lighter;
+  margin-top: 1em; 
+}


### PR DESCRIPTION
I think https://github.com/bbc/react-transcript-editor/pull/65 look good, but thought it might had been easier to show my suggestions then describe it etc..

<img width="1228" alt="screen shot 2019-01-03 at 19 42 09" src="https://user-images.githubusercontent.com/4661975/50655313-07147800-0f90-11e9-8e05-dbed1cbf35d8.png">

- moved the `How Does this work` next to settings and keyboard shortcuts, this saves the extra line in `TimedTextEditor`.
- because after moving the tooltip the black background didn't quiet work with the background of the `MediaPlayer` / `PlayerControls` area, changed it to background colour of the keyboard shortcuts, better colour scheme match, readability, consistency etc..
- moved some of the CSS properties to the props of the component. 
- as refactor, to keep things tidy, I've noticed that the [`ToolTip` component has a list of CSS properties it takes as props](https://www.npmjs.com/package/react-simple-tooltip#props), might be good to make use of those as much as possible and add extras only when there might be shortcomings.

Let me know what you think