### PR TITLE
added picture in picture mode

### DIFF
--- a/src/lib/TranscriptEditor/MediaPlayer/PlayerControls.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/PlayerControls.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import VolumeControl from './VolumeControl';
 import Select from './Select';
 
@@ -43,6 +42,7 @@ class PlayerControls extends React.Component {
           onMouseDown={ this.setIntervalHelperBackward }
           onMouseUp={ this.clearIntervalHelper }>
           {'◀◀'}
+
         </button>
 
         <button
@@ -74,6 +74,13 @@ class PlayerControls extends React.Component {
           <span className={ style.duration }>{this.props.duration}</span>
         </div>
 
+        <button
+          className={ style.playerButton }
+          onClick={ this.props.pictureInPicture }
+        >
+          {'📺'}
+        </button>
+
         <VolumeControl
           handleMuteVolume={ this.props.handleMuteVolume }
         />
@@ -95,7 +102,8 @@ PlayerControls.propTypes = {
   skipForward: PropTypes.func,
   playbackRate: PropTypes.number,
   playbackRateOptions: PropTypes.array,
-  setPlayBackRate: PropTypes.func
+  setPlayBackRate: PropTypes.func,
+  pictureInPicture: PropTypes.func
 };
 
 export default PlayerControls;

--- a/src/lib/TranscriptEditor/MediaPlayer/index.js
+++ b/src/lib/TranscriptEditor/MediaPlayer/index.js
@@ -348,6 +348,25 @@ class MediaPlayer extends React.Component {
 
   }
 
+  handlePictureInPicture = () => {
+    if (this.videoRef.current !== null) {
+      // from https://developers.google.com/web/updates/2017/09/picture-in-picture
+      if (!document.pictureInPictureElement) {
+        this.videoRef.current.requestPictureInPicture()
+          .catch(error => {
+          // Video failed to enter Picture-in-Picture mode.
+            console.error('Video failed to enter Picture-in-Picture mode', error);
+          });
+      } else {
+        document.exitPictureInPicture()
+          .catch(error => {
+          // Video failed to leave Picture-in-Picture mode.
+            console.error('Video failed to leave Picture-in-Picture mode', error);
+          });
+      }
+    }
+  }
+
   render() {
     const player = <VideoPlayer
       mediaUrl={ this.props.mediaUrl }
@@ -379,6 +398,7 @@ class MediaPlayer extends React.Component {
           handleMuteVolume={ this.handleMuteVolume.bind(this) }
           setPlayBackRate={ this.handlePlayBackRateChange.bind(this) }
           playbackRateOptions={ this.state.playbackRateOptions }
+          pictureInPicture={ this.handlePictureInPicture }
         />
       </div>
     );


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      

Adding support for picture in picture, which means being able to have the video float as a resizable box above all other windows.

Addresses something that came out in user research, which is sometimes there is a need to read the burnt in time-codes on the video rushes being transcribed to double check they match the transcript once.

**Describe what the PR does**   
 
Enables picture in picture as a toggle

<img width="1446" alt="screen shot 2019-01-18 at 17 51 51" src="https://user-images.githubusercontent.com/4661975/51404129-62c33180-1b4a-11e9-972b-4e4f50acbd3f.png">

**State whether the PR is ready for review or whether it needs extra work**    

Ready for review / merge 

**Additional context**    

Background [docs on 'picture in pictrue'](https://developers.google.com/web/updates/2017/09/picture-in-picture)

- [ ] Needs a better icon, eg from Font Awesome, at the moment just using Tv emoji 📺 
- [ ] Needs adding picture in picture feature in QA docs (toggle on/off) and features list.