### PR TITLE
Moving cursor no longer puts focus on timestamp and speaker labels

### DIFF
--- a/src/lib/TranscriptEditor/TimedTextEditor/SpeakerLabel.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/SpeakerLabel.js
@@ -9,8 +9,7 @@ import style from './WrapperBlock.module.css';
 class SpeakerLabel extends PureComponent {
   render() {
     return (
-      <span className={ style.speaker }
-        contentEditable={ false }>
+      <span className={ style.speaker }>
         <span
           className={ style.EditLabel }
           onClick={ this.props.handleOnClickEdit }>

--- a/src/lib/TranscriptEditor/TimedTextEditor/SpeakerLabel.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/SpeakerLabel.js
@@ -9,7 +9,8 @@ import style from './WrapperBlock.module.css';
 class SpeakerLabel extends PureComponent {
   render() {
     return (
-      <span className={ style.speaker }>
+      <span className={ style.speaker }
+        contentEditable={ false }>
         <span
           className={ style.EditLabel }
           onClick={ this.props.handleOnClickEdit }>

--- a/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
@@ -93,16 +93,12 @@ class WrapperBlock extends React.Component {
       handleOnClickEdit={ this.handleOnClickEdit }
     />;
 
-    const timecodeElement = <span
-      contentEditable={ false }
-      className={ style.time }
-      onClick={ this.handleTimecodeClick }>
-      {shortTimecode(startTimecode)}
-    </span>;
+    const timecodeElement = <span className={ style.time } onClick={ this.handleTimecodeClick }>{shortTimecode(startTimecode)}</span>;
 
     return (
       <div className={ style.WrapperBlock }>
-        <div className={ style.markers }>
+        <div className={ style.markers }
+          contentEditable={ false }>
           {this.props.blockProps.showSpeakers ? speakerElement : ''}
           {this.props.blockProps.showTimecodes ? timecodeElement : ''}
         </div>

--- a/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
+++ b/src/lib/TranscriptEditor/TimedTextEditor/WrapperBlock.js
@@ -93,7 +93,12 @@ class WrapperBlock extends React.Component {
       handleOnClickEdit={ this.handleOnClickEdit }
     />;
 
-    const timecodeElement = <span className={ style.time } onClick={ this.handleTimecodeClick }>{shortTimecode(startTimecode)}</span>;
+    const timecodeElement = <span
+      contentEditable={ false }
+      className={ style.time }
+      onClick={ this.handleTimecodeClick }>
+      {shortTimecode(startTimecode)}
+    </span>;
 
     return (
       <div className={ style.WrapperBlock }>


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
This PR addresses #98.

**Describe what the PR does**    
Added `contentEditable={ false }` to speaker and timecode elements. This prevents the cursor from entering the timecode element. The cursor still selects speaker element when moving cursor out of the last character of a block, but not when switching between blocks directly.


**State whether the PR is ready for review or whether it needs extra work**    
Cursor still selects speaker element when moving cursor out of the last character of a block. This needs to be fixed before review.