### PR TITLE
Add amazontranscribe speaker detection support

### DIFF
--- a/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.js
+++ b/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.js
@@ -5,7 +5,7 @@ export const groupWordsBySpeaker = (words, speakerLabels) => {
     return groupWordsBySpeakerLabel(wordsWithSpeakers);
 }
 
-const groupWordsBySpeakerLabel = (words) => {
+export const groupWordsBySpeakerLabel = (words) => {
     const groupedWords = [];
     var currentSpeaker = "";
     words.forEach((word) => {
@@ -26,7 +26,7 @@ const addSpeakerLabelToWords = (words, segments) => {
     return words.map(w => Object.assign(w, {"speaker_label": findSpeakerForWord(w, segments)}));
 }
 
-const findSpeakerForWord = (word, segments)=> {
+export const findSpeakerForWord = (word, segments)=> {
     const startTime  = parseFloat(word.start_time);
     const endTime = parseFloat(word.end_time);
     const firstMatchingSegment = segments.find((seg) => {

--- a/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.js
+++ b/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.js
@@ -1,6 +1,6 @@
 export const groupWordsBySpeakerLabel = (words) => {
   const groupedWords = [];
-  var currentSpeaker = '';
+  let currentSpeaker = '';
   words.forEach((word) => {
     if (word.speaker_label === currentSpeaker) {
       groupedWords[groupedWords.length - 1].words.push(word);

--- a/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.js
+++ b/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.js
@@ -1,40 +1,40 @@
-
-export const groupWordsBySpeaker = (words, speakerLabels) => {
-    const wordsWithSpeakers = addSpeakerLabelToWords(words, speakerLabels.segments);
-
-    return groupWordsBySpeakerLabel(wordsWithSpeakers);
-}
-
 export const groupWordsBySpeakerLabel = (words) => {
-    const groupedWords = [];
-    var currentSpeaker = "";
-    words.forEach((word) => {
-        if (word.speaker_label === currentSpeaker) {
-            groupedWords[groupedWords.length-1].words.push(word);
-        } else {
-            currentSpeaker = word.speaker_label;
-            // start new speaker block
-            groupedWords.push({
-                speaker: word.speaker_label,
-                words: [word]});
-        }
-    });
-    return groupedWords;
-}
+  const groupedWords = [];
+  var currentSpeaker = '';
+  words.forEach((word) => {
+    if (word.speaker_label === currentSpeaker) {
+      groupedWords[groupedWords.length - 1].words.push(word);
+    } else {
+      currentSpeaker = word.speaker_label;
+      // start new speaker block
+      groupedWords.push({
+        speaker: word.speaker_label,
+        words: [ word ] });
+    }
+  });
+
+  return groupedWords;
+};
+
+export const findSpeakerForWord = (word, segments) => {
+  const startTime = parseFloat(word.start_time);
+  const endTime = parseFloat(word.end_time);
+  const firstMatchingSegment = segments.find((seg) => {
+    return startTime >= parseFloat(seg.start_time) && endTime <= parseFloat(seg.end_time);
+  });
+  if (firstMatchingSegment === undefined) {
+    return 'Speaker UKN';
+  } else {
+    return `Speaker ${ firstMatchingSegment.speaker_label.replace('spk_', '') }`;
+  }
+};
 
 const addSpeakerLabelToWords = (words, segments) => {
-    return words.map(w => Object.assign(w, {"speaker_label": findSpeakerForWord(w, segments)}));
-}
+  return words.map(w => Object.assign(w, { 'speaker_label': findSpeakerForWord(w, segments) }));
+};
 
-export const findSpeakerForWord = (word, segments)=> {
-    const startTime  = parseFloat(word.start_time);
-    const endTime = parseFloat(word.end_time);
-    const firstMatchingSegment = segments.find((seg) => {
-        return startTime >= parseFloat(seg.start_time) && endTime <= parseFloat(seg.end_time);
-    });
-    if (firstMatchingSegment === undefined) {
-        return "Speaker UKN";
-    } else {
-        return `Speaker ${firstMatchingSegment.speaker_label.replace("spk_", "")}`;
-    }
-}
+export const groupWordsBySpeaker = (words, speakerLabels) => {
+  const wordsWithSpeakers = addSpeakerLabelToWords(words, speakerLabels.segments);
+
+  return groupWordsBySpeakerLabel(wordsWithSpeakers);
+};

--- a/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.js
+++ b/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.js
@@ -1,0 +1,40 @@
+
+export const groupWordsBySpeaker = (words, speakerLabels) => {
+    const wordsWithSpeakers = addSpeakerLabelToWords(words, speakerLabels.segments);
+
+    return groupWordsBySpeakerLabel(wordsWithSpeakers);
+}
+
+const groupWordsBySpeakerLabel = (words) => {
+    const groupedWords = [];
+    var currentSpeaker = "";
+    words.forEach((word) => {
+        if (word.speaker_label === currentSpeaker) {
+            groupedWords[groupedWords.length-1].words.push(word);
+        } else {
+            currentSpeaker = word.speaker_label;
+            // start new speaker block
+            groupedWords.push({
+                speaker: word.speaker_label,
+                words: [word]});
+        }
+    });
+    return groupedWords;
+}
+
+const addSpeakerLabelToWords = (words, segments) => {
+    return words.map(w => Object.assign(w, {"speaker_label": findSpeakerForWord(w, segments)}));
+}
+
+const findSpeakerForWord = (word, segments)=> {
+    const startTime  = parseFloat(word.start_time);
+    const endTime = parseFloat(word.end_time);
+    const firstMatchingSegment = segments.find((seg) => {
+        return startTime >= parseFloat(seg.start_time) && endTime <= parseFloat(seg.end_time);
+    });
+    if (firstMatchingSegment === undefined) {
+        return "Speaker UKN";
+    } else {
+        return `Speaker ${firstMatchingSegment.speaker_label.replace("spk_", "")}`;
+    }
+}

--- a/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.test.js
+++ b/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.test.js
@@ -1,0 +1,53 @@
+import amazonTodayInFocusTranscript from './sample/todayinfocus.sample.json';
+import wordsWithSpeakers from './sample/todayinfocuswords.sample.json'
+
+import {groupWordsBySpeakerLabel, findSpeakerForWord, groupWordsBySpeaker} from './group-words-by-speakers';
+
+
+const words = amazonTodayInFocusTranscript.results.items;
+const speakerLabels = amazonTodayInFocusTranscript.results.speaker_labels;
+
+
+describe('groupWordsBySpeakerLabel', () => {
+    
+    it('Should group speakers correctly', ( ) => {
+        
+        const groups = groupWordsBySpeakerLabel(wordsWithSpeakers);
+        expect(groups[0].speaker).toBe("spk_0")
+        expect(groups[0].words.length).toBe(1);
+        expect(groups[1].speaker).toBe("spk_1");
+        expect(groups[1].words.length).toBe(2);
+    });
+});
+
+
+describe('findSpeakerForWord', () => {
+    
+    it('Should find correct speaker', ( ) => {
+        
+        const speaker = findSpeakerForWord({
+            "start_time": "8.65",
+            "end_time": "8.98",
+            "alternatives": [
+                {
+                    "confidence": "0.9999",
+                    "content": "one"
+                }
+            ],
+            "type": "pronunciation"
+        }, speakerLabels.segments)
+        
+        expect(speaker).toBe("Speaker 0")
+    });
+});
+
+describe('groupWordsBySpeaker', () => {
+    /** Hopefully the other unit tests suffice.
+    * this is a rather lazy one to check the full results
+    */
+    it('Should return expected number of groups', ( ) => {
+        
+        const groups = groupWordsBySpeaker(words, speakerLabels);
+        expect(groups.length).toBe(173)
+    });
+});

--- a/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.test.js
+++ b/src/lib/Util/adapters/amazon-transcribe/group-words-by-speakers.test.js
@@ -1,53 +1,50 @@
 import amazonTodayInFocusTranscript from './sample/todayinfocus.sample.json';
-import wordsWithSpeakers from './sample/todayinfocuswords.sample.json'
+import wordsWithSpeakers from './sample/todayinfocuswords.sample.json';
 
-import {groupWordsBySpeakerLabel, findSpeakerForWord, groupWordsBySpeaker} from './group-words-by-speakers';
-
+import { groupWordsBySpeakerLabel, findSpeakerForWord, groupWordsBySpeaker } from './group-words-by-speakers';
 
 const words = amazonTodayInFocusTranscript.results.items;
 const speakerLabels = amazonTodayInFocusTranscript.results.speaker_labels;
 
-
 describe('groupWordsBySpeakerLabel', () => {
-    
-    it('Should group speakers correctly', ( ) => {
-        
-        const groups = groupWordsBySpeakerLabel(wordsWithSpeakers);
-        expect(groups[0].speaker).toBe("spk_0")
-        expect(groups[0].words.length).toBe(1);
-        expect(groups[1].speaker).toBe("spk_1");
-        expect(groups[1].words.length).toBe(2);
-    });
+
+  it('Should group speakers correctly', ( ) => {
+
+    const groups = groupWordsBySpeakerLabel(wordsWithSpeakers);
+    expect(groups[0].speaker).toBe('spk_0');
+    expect(groups[0].words.length).toBe(1);
+    expect(groups[1].speaker).toBe('spk_1');
+    expect(groups[1].words.length).toBe(2);
+  });
 });
 
-
 describe('findSpeakerForWord', () => {
-    
-    it('Should find correct speaker', ( ) => {
-        
-        const speaker = findSpeakerForWord({
-            "start_time": "8.65",
-            "end_time": "8.98",
-            "alternatives": [
-                {
-                    "confidence": "0.9999",
-                    "content": "one"
-                }
-            ],
-            "type": "pronunciation"
-        }, speakerLabels.segments)
-        
-        expect(speaker).toBe("Speaker 0")
-    });
+
+  it('Should find correct speaker', ( ) => {
+
+    const speaker = findSpeakerForWord({
+      'start_time': '8.65',
+      'end_time': '8.98',
+      'alternatives': [
+        {
+          'confidence': '0.9999',
+          'content': 'one'
+        }
+      ],
+      'type': 'pronunciation'
+    }, speakerLabels.segments);
+
+    expect(speaker).toBe('Speaker 0');
+  });
 });
 
 describe('groupWordsBySpeaker', () => {
-    /** Hopefully the other unit tests suffice.
+  /** Hopefully the other unit tests suffice.
     * this is a rather lazy one to check the full results
     */
-    it('Should return expected number of groups', ( ) => {
-        
-        const groups = groupWordsBySpeaker(words, speakerLabels);
-        expect(groups.length).toBe(173)
-    });
+  it('Should return expected number of groups', ( ) => {
+
+    const groups = groupWordsBySpeaker(words, speakerLabels);
+    expect(groups.length).toBe(173);
+  });
 });

--- a/src/lib/Util/adapters/amazon-transcribe/index.js
+++ b/src/lib/Util/adapters/amazon-transcribe/index.js
@@ -4,6 +4,7 @@
  */
 
 import generateEntitiesRanges from '../generate-entities-ranges/index.js';
+import {groupWordsBySpeaker} from './group-words-by-speakers'
 
 export const stripLeadingSpace = word => {
   return word.replace(/^\s/, '');
@@ -106,19 +107,36 @@ const groupWordsInParagraphs = words => {
   return results;
 };
 
+const groupSpeakerWordsInParagraphs = (words, speakerLabels) => {
+  const wordsBySpeaker = groupWordsBySpeaker(words, speakerLabels)
+  return wordsBySpeaker.map((speakerGroup) => {
+    return {
+      words: speakerGroup.words.map(normalizeWord),
+      text: speakerGroup.words.map((w) => getBestAlternativeForWord(w).content),
+      speaker: speakerGroup.speaker
+    }
+  });
+}
+
 const amazonTranscribeToDraft = amazonTranscribeJson => {
   const results = [];
   const tmpWords = amazonTranscribeJson.results.items;
+  const speakerLabels = amazonTranscribeJson.results.speaker_labels;
   const wordsWithRemappedPunctuation = mapPunctuationItemsToWords(tmpWords);
-  const wordsByParagraphs = groupWordsInParagraphs(
-    wordsWithRemappedPunctuation
-  );
+  let speakerSegmentation = typeof speakerLabels != undefined; 
+
+  const wordsByParagraphs =  speakerSegmentation ?
+    groupSpeakerWordsInParagraphs(wordsWithRemappedPunctuation, amazonTranscribeJson.results.speaker_labels) :
+    groupWordsInParagraphs(
+      wordsWithRemappedPunctuation
+    );
+  
   wordsByParagraphs.forEach((paragraph, i) => {
     const draftJsContentBlockParagraph = {
       text: paragraph.text.join(' '),
       type: 'paragraph',
       data: {
-        speaker: `TBC ${ i }`,
+        speaker: paragraph.speaker ? `Speaker ${paragraph.speaker}` : `TBC ${ i }`,
         words: paragraph.words,
         start: parseFloat(paragraph.words[0].start)
       },

--- a/src/lib/Util/adapters/amazon-transcribe/index.js
+++ b/src/lib/Util/adapters/amazon-transcribe/index.js
@@ -4,7 +4,7 @@
  */
 
 import generateEntitiesRanges from '../generate-entities-ranges/index.js';
-import {groupWordsBySpeaker} from './group-words-by-speakers'
+import { groupWordsBySpeaker } from './group-words-by-speakers';
 
 export const stripLeadingSpace = word => {
   return word.replace(/^\s/, '');
@@ -89,7 +89,7 @@ const groupWordsInParagraphs = words => {
     words: [],
     text: []
   };
-  words.forEach((word, index) => {
+  words.forEach((word) => {
     const content = getBestAlternativeForWord(word).content;
     const normalizedWord = normalizeWord(word);
     if (/[.?!]/.test(content)) {
@@ -108,35 +108,36 @@ const groupWordsInParagraphs = words => {
 };
 
 const groupSpeakerWordsInParagraphs = (words, speakerLabels) => {
-  const wordsBySpeaker = groupWordsBySpeaker(words, speakerLabels)
+  const wordsBySpeaker = groupWordsBySpeaker(words, speakerLabels);
+
   return wordsBySpeaker.map((speakerGroup) => {
     return {
       words: speakerGroup.words.map(normalizeWord),
       text: speakerGroup.words.map((w) => getBestAlternativeForWord(w).content),
       speaker: speakerGroup.speaker
-    }
+    };
   });
-}
+};
 
 const amazonTranscribeToDraft = amazonTranscribeJson => {
   const results = [];
   const tmpWords = amazonTranscribeJson.results.items;
   const speakerLabels = amazonTranscribeJson.results.speaker_labels;
   const wordsWithRemappedPunctuation = mapPunctuationItemsToWords(tmpWords);
-  let speakerSegmentation = typeof(speakerLabels) != "undefined";
+  const speakerSegmentation = typeof(speakerLabels) != 'undefined';
 
-  const wordsByParagraphs =  speakerSegmentation ?
+  const wordsByParagraphs = speakerSegmentation ?
     groupSpeakerWordsInParagraphs(wordsWithRemappedPunctuation, speakerLabels) :
     groupWordsInParagraphs(
       wordsWithRemappedPunctuation
     );
-  
+
   wordsByParagraphs.forEach((paragraph, i) => {
     const draftJsContentBlockParagraph = {
       text: paragraph.text.join(' '),
       type: 'paragraph',
       data: {
-        speaker: paragraph.speaker ? `Speaker ${paragraph.speaker}` : `TBC ${ i }`,
+        speaker: paragraph.speaker ? `Speaker ${ paragraph.speaker }` : `TBC ${ i }`,
         words: paragraph.words,
         start: parseFloat(paragraph.words[0].start)
       },

--- a/src/lib/Util/adapters/amazon-transcribe/index.js
+++ b/src/lib/Util/adapters/amazon-transcribe/index.js
@@ -123,10 +123,10 @@ const amazonTranscribeToDraft = amazonTranscribeJson => {
   const tmpWords = amazonTranscribeJson.results.items;
   const speakerLabels = amazonTranscribeJson.results.speaker_labels;
   const wordsWithRemappedPunctuation = mapPunctuationItemsToWords(tmpWords);
-  let speakerSegmentation = typeof speakerLabels != undefined; 
+  let speakerSegmentation = typeof(speakerLabels) != "undefined";
 
   const wordsByParagraphs =  speakerSegmentation ?
-    groupSpeakerWordsInParagraphs(wordsWithRemappedPunctuation, amazonTranscribeJson.results.speaker_labels) :
+    groupSpeakerWordsInParagraphs(wordsWithRemappedPunctuation, speakerLabels) :
     groupWordsInParagraphs(
       wordsWithRemappedPunctuation
     );

--- a/src/lib/Util/adapters/amazon-transcribe/sample/todayinfocus.sample.json
+++ b/src/lib/Util/adapters/amazon-transcribe/sample/todayinfocus.sample.json
@@ -1,0 +1,12648 @@
+{
+    "jobName": "todayinfocus_sample",
+    "accountId": "702972749545",
+    "results": {
+        "transcripts": [
+            {
+                "transcript": "Today the devastation of Cyclone e di one of the worst weather related disasters. Toe ever hit the Southern Hemisphere  on DH Sonya Soda on what on earth is going on in Parliament?   The people who were perhaps in the worst situation with the people who were stuck in the trees because it wasn't just people who got driven up into into the trees by the water, but snakes as well. And people getting bitten while they're up in the trees. Oh my God, it's terrifying. Yeah, it's terrifying. Kind of Imagine that choice of being in the tree and being in a tree above water and not knowing when the water is going to go away and not knowing how long you consider in the tree for Onda having to share that space with with snakes. Two weeks ago, Cyclone E. Di hit Mozambique, one of the poorest countries in the world. It caused catastrophic damage, obliterating most of the city of bearer, killing hundreds on destroying the homes of thousands of others. And then the floods came. The fallout from the tropical storm has affected almost two million lives, not just in Mozambique but also Malawi and Zimbabwe. Questions are being asked about why the government did not doom or to protect the opposition city of bearer. And now the first cases of the waterborne disease cholera are complicating an already massive and complex emergency from the Guardian. I'm Anoushka Astana today in focus the devastation of Cyclone E Di, one of the worst weather disasters toe ever hit the southern hemisphere.    Last Wednesday, Peter Bowman, a senior reporter at the Guardian, reached the city of bearer on the coast of Mozambique just days after Cyclone E Di had devastated the region. As soon as you arrive, you're aware that you're you're the centre of a big emergency response effort. There's a bustle of kind of aid workers. The Operation Centre is right next to the arrivals hall. I got there about eleven o'Clock at night and sort of at that stage, I mean in the dark. You're aware of all these fallen trees on A ll the roads. No lights at all. No people on bits of standing water, glass bits of us Best us off the roof, corrugated iron instead of all coming out of the dark atyou. Can you describe error for May? There's a small city on the coast. It's run down. It could have seen better days. It's an opposition city, so hasn't really seen Ah lot of love from the government. There are a few old sort of Portuguese colonial buildings and I had a lot of truce. So, you know, at one stage you kind of think if you've been there before the storm, it would have a certain charm from all the trees. Now, of course, a lot of the poorer neighbourhoods have been very, very heavily hit. I mean, you you drive through them and you see people in the house is still standing. But you know, maybe in one hundred metres of  of muddy water tryingto live above the standing water. It was probably ninety percent damaged but not destroyed. The rial catastrophe had taken place outside the city Thank you. Do people know the cyclone was coming? Cyclones are common in this part of the world. I mean, it's the Indian Ocean. It's a big, swirling depression of off winds and rain. They plan for a fairly major event. I mean, what what? I She happened in this case, this very slow moving storm. Hence the coast by bearer on. Then it kind of doubles back and it hits again. So said the storm makes landfall twice on as its grinding over the coast. It is putting down absolutely phenomenal amounts of water. So when this happened on the Thursday night, people emerged from this thinking I'm still here. Okay, it's done. We're going to start tidying up. Double tap, as it were that happened, was the water that had fallen on the higher ground over the Zimbabwean Zimbabwean border. The ground slopes down from the border all the way to this area, which is the lowest lying ground in Mozambique. The dam's topped out from sheer amount of rainfall and then poured down into this into this this low flat area"
+            }
+        ],
+        "speaker_labels": {
+            "speakers": 3,
+            "segments": [
+                {
+                    "start_time": "2.64",
+                    "speaker_label": "",
+                    "end_time": "3.15",
+                    "items": []
+                },
+                {
+                    "start_time": "3.84",
+                    "speaker_label": "spk_0",
+                    "end_time": "4.05",
+                    "items": []
+                },
+                {
+                    "start_time": "5.24",
+                    "speaker_label": "spk_0",
+                    "end_time": "12.83",
+                    "items": [
+                        {
+                            "start_time": "5.24",
+                            "speaker_label": "spk_0",
+                            "end_time": "5.85"
+                        },
+                        {
+                            "start_time": "6.3",
+                            "speaker_label": "spk_0",
+                            "end_time": "6.4"
+                        },
+                        {
+                            "start_time": "6.4",
+                            "speaker_label": "spk_0",
+                            "end_time": "7.24"
+                        },
+                        {
+                            "start_time": "7.25",
+                            "speaker_label": "spk_0",
+                            "end_time": "7.39"
+                        },
+                        {
+                            "start_time": "7.39",
+                            "speaker_label": "spk_0",
+                            "end_time": "7.96"
+                        },
+                        {
+                            "start_time": "7.97",
+                            "speaker_label": "spk_0",
+                            "end_time": "8.17"
+                        },
+                        {
+                            "start_time": "8.17",
+                            "speaker_label": "spk_0",
+                            "end_time": "8.57"
+                        },
+                        {
+                            "start_time": "8.65",
+                            "speaker_label": "spk_0",
+                            "end_time": "8.98"
+                        },
+                        {
+                            "start_time": "8.98",
+                            "speaker_label": "spk_0",
+                            "end_time": "9.05"
+                        },
+                        {
+                            "start_time": "9.05",
+                            "speaker_label": "spk_0",
+                            "end_time": "9.15"
+                        },
+                        {
+                            "start_time": "9.15",
+                            "speaker_label": "spk_0",
+                            "end_time": "9.76"
+                        },
+                        {
+                            "start_time": "9.76",
+                            "speaker_label": "spk_0",
+                            "end_time": "10.09"
+                        },
+                        {
+                            "start_time": "10.09",
+                            "speaker_label": "spk_0",
+                            "end_time": "10.51"
+                        },
+                        {
+                            "start_time": "10.51",
+                            "speaker_label": "spk_0",
+                            "end_time": "11.07"
+                        },
+                        {
+                            "start_time": "11.07",
+                            "speaker_label": "spk_0",
+                            "end_time": "11.25"
+                        },
+                        {
+                            "start_time": "11.26",
+                            "speaker_label": "spk_0",
+                            "end_time": "11.49"
+                        },
+                        {
+                            "start_time": "11.49",
+                            "speaker_label": "spk_0",
+                            "end_time": "11.79"
+                        },
+                        {
+                            "start_time": "11.8",
+                            "speaker_label": "spk_0",
+                            "end_time": "11.92"
+                        },
+                        {
+                            "start_time": "11.92",
+                            "speaker_label": "spk_0",
+                            "end_time": "12.23"
+                        },
+                        {
+                            "start_time": "12.23",
+                            "speaker_label": "spk_0",
+                            "end_time": "12.83"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "13.54",
+                    "speaker_label": "",
+                    "end_time": "13.66",
+                    "items": []
+                },
+                {
+                    "start_time": "13.66",
+                    "speaker_label": "spk_0",
+                    "end_time": "18.25",
+                    "items": [
+                        {
+                            "start_time": "13.66",
+                            "speaker_label": "spk_0",
+                            "end_time": "13.98"
+                        },
+                        {
+                            "start_time": "13.98",
+                            "speaker_label": "spk_0",
+                            "end_time": "14.15"
+                        },
+                        {
+                            "start_time": "14.47",
+                            "speaker_label": "spk_0",
+                            "end_time": "14.9"
+                        },
+                        {
+                            "start_time": "14.9",
+                            "speaker_label": "spk_0",
+                            "end_time": "15.53"
+                        },
+                        {
+                            "start_time": "15.71",
+                            "speaker_label": "spk_0",
+                            "end_time": "15.99"
+                        },
+                        {
+                            "start_time": "15.99",
+                            "speaker_label": "spk_0",
+                            "end_time": "16.2"
+                        },
+                        {
+                            "start_time": "16.2",
+                            "speaker_label": "spk_0",
+                            "end_time": "16.41"
+                        },
+                        {
+                            "start_time": "16.42",
+                            "speaker_label": "spk_0",
+                            "end_time": "16.88"
+                        },
+                        {
+                            "start_time": "16.89",
+                            "speaker_label": "spk_0",
+                            "end_time": "17.11"
+                        },
+                        {
+                            "start_time": "17.12",
+                            "speaker_label": "spk_0",
+                            "end_time": "17.42"
+                        },
+                        {
+                            "start_time": "17.42",
+                            "speaker_label": "spk_0",
+                            "end_time": "17.54"
+                        },
+                        {
+                            "start_time": "17.54",
+                            "speaker_label": "spk_0",
+                            "end_time": "17.63"
+                        },
+                        {
+                            "start_time": "17.63",
+                            "speaker_label": "spk_0",
+                            "end_time": "18.25"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "21.14",
+                    "speaker_label": "",
+                    "end_time": "21.35",
+                    "items": []
+                },
+                {
+                    "start_time": "22.94",
+                    "speaker_label": "",
+                    "end_time": "23.85",
+                    "items": []
+                },
+                {
+                    "start_time": "27.97",
+                    "speaker_label": "spk_1",
+                    "end_time": "56.22",
+                    "items": [
+                        {
+                            "start_time": "27.97",
+                            "speaker_label": "spk_1",
+                            "end_time": "28.19"
+                        },
+                        {
+                            "start_time": "28.19",
+                            "speaker_label": "spk_1",
+                            "end_time": "28.56"
+                        },
+                        {
+                            "start_time": "28.56",
+                            "speaker_label": "spk_1",
+                            "end_time": "28.71"
+                        },
+                        {
+                            "start_time": "28.71",
+                            "speaker_label": "spk_1",
+                            "end_time": "29.19"
+                        },
+                        {
+                            "start_time": "29.2",
+                            "speaker_label": "spk_1",
+                            "end_time": "29.64"
+                        },
+                        {
+                            "start_time": "29.64",
+                            "speaker_label": "spk_1",
+                            "end_time": "29.71"
+                        },
+                        {
+                            "start_time": "29.71",
+                            "speaker_label": "spk_1",
+                            "end_time": "29.8"
+                        },
+                        {
+                            "start_time": "29.8",
+                            "speaker_label": "spk_1",
+                            "end_time": "30.08"
+                        },
+                        {
+                            "start_time": "30.08",
+                            "speaker_label": "spk_1",
+                            "end_time": "30.6"
+                        },
+                        {
+                            "start_time": "30.6",
+                            "speaker_label": "spk_1",
+                            "end_time": "30.69"
+                        },
+                        {
+                            "start_time": "30.69",
+                            "speaker_label": "spk_1",
+                            "end_time": "30.75"
+                        },
+                        {
+                            "start_time": "30.75",
+                            "speaker_label": "spk_1",
+                            "end_time": "31.06"
+                        },
+                        {
+                            "start_time": "31.06",
+                            "speaker_label": "spk_1",
+                            "end_time": "31.17"
+                        },
+                        {
+                            "start_time": "31.17",
+                            "speaker_label": "spk_1",
+                            "end_time": "31.25"
+                        },
+                        {
+                            "start_time": "31.25",
+                            "speaker_label": "spk_1",
+                            "end_time": "31.6"
+                        },
+                        {
+                            "start_time": "31.6",
+                            "speaker_label": "spk_1",
+                            "end_time": "31.69"
+                        },
+                        {
+                            "start_time": "31.69",
+                            "speaker_label": "spk_1",
+                            "end_time": "31.78"
+                        },
+                        {
+                            "start_time": "31.78",
+                            "speaker_label": "spk_1",
+                            "end_time": "32.27"
+                        },
+                        {
+                            "start_time": "32.27",
+                            "speaker_label": "spk_1",
+                            "end_time": "32.72"
+                        },
+                        {
+                            "start_time": "33.03",
+                            "speaker_label": "spk_1",
+                            "end_time": "33.23"
+                        },
+                        {
+                            "start_time": "33.23",
+                            "speaker_label": "spk_1",
+                            "end_time": "33.51"
+                        },
+                        {
+                            "start_time": "33.51",
+                            "speaker_label": "spk_1",
+                            "end_time": "33.77"
+                        },
+                        {
+                            "start_time": "33.77",
+                            "speaker_label": "spk_1",
+                            "end_time": "34.17"
+                        },
+                        {
+                            "start_time": "34.17",
+                            "speaker_label": "spk_1",
+                            "end_time": "34.31"
+                        },
+                        {
+                            "start_time": "34.31",
+                            "speaker_label": "spk_1",
+                            "end_time": "34.51"
+                        },
+                        {
+                            "start_time": "34.51",
+                            "speaker_label": "spk_1",
+                            "end_time": "34.86"
+                        },
+                        {
+                            "start_time": "34.86",
+                            "speaker_label": "spk_1",
+                            "end_time": "35.1"
+                        },
+                        {
+                            "start_time": "35.1",
+                            "speaker_label": "spk_1",
+                            "end_time": "35.47"
+                        },
+                        {
+                            "start_time": "35.48",
+                            "speaker_label": "spk_1",
+                            "end_time": "35.81"
+                        },
+                        {
+                            "start_time": "35.81",
+                            "speaker_label": "spk_1",
+                            "end_time": "35.92"
+                        },
+                        {
+                            "start_time": "35.92",
+                            "speaker_label": "spk_1",
+                            "end_time": "36.3"
+                        },
+                        {
+                            "start_time": "36.3",
+                            "speaker_label": "spk_1",
+                            "end_time": "36.48"
+                        },
+                        {
+                            "start_time": "36.48",
+                            "speaker_label": "spk_1",
+                            "end_time": "36.6"
+                        },
+                        {
+                            "start_time": "36.6",
+                            "speaker_label": "spk_1",
+                            "end_time": "36.9"
+                        },
+                        {
+                            "start_time": "36.9",
+                            "speaker_label": "spk_1",
+                            "end_time": "37.06"
+                        },
+                        {
+                            "start_time": "37.06",
+                            "speaker_label": "spk_1",
+                            "end_time": "37.54"
+                        },
+                        {
+                            "start_time": "37.54",
+                            "speaker_label": "spk_1",
+                            "end_time": "37.68"
+                        },
+                        {
+                            "start_time": "37.68",
+                            "speaker_label": "spk_1",
+                            "end_time": "38.03"
+                        },
+                        {
+                            "start_time": "38.03",
+                            "speaker_label": "spk_1",
+                            "end_time": "38.21"
+                        },
+                        {
+                            "start_time": "38.21",
+                            "speaker_label": "spk_1",
+                            "end_time": "38.56"
+                        },
+                        {
+                            "start_time": "38.56",
+                            "speaker_label": "spk_1",
+                            "end_time": "38.85"
+                        },
+                        {
+                            "start_time": "38.85",
+                            "speaker_label": "spk_1",
+                            "end_time": "39.15"
+                        },
+                        {
+                            "start_time": "39.15",
+                            "speaker_label": "spk_1",
+                            "end_time": "39.35"
+                        },
+                        {
+                            "start_time": "39.35",
+                            "speaker_label": "spk_1",
+                            "end_time": "39.49"
+                        },
+                        {
+                            "start_time": "39.49",
+                            "speaker_label": "spk_1",
+                            "end_time": "39.65"
+                        },
+                        {
+                            "start_time": "39.65",
+                            "speaker_label": "spk_1",
+                            "end_time": "39.74"
+                        },
+                        {
+                            "start_time": "39.74",
+                            "speaker_label": "spk_1",
+                            "end_time": "39.82"
+                        },
+                        {
+                            "start_time": "39.82",
+                            "speaker_label": "spk_1",
+                            "end_time": "40.31"
+                        },
+                        {
+                            "start_time": "40.53",
+                            "speaker_label": "spk_1",
+                            "end_time": "40.63"
+                        },
+                        {
+                            "start_time": "40.63",
+                            "speaker_label": "spk_1",
+                            "end_time": "40.76"
+                        },
+                        {
+                            "start_time": "40.76",
+                            "speaker_label": "spk_1",
+                            "end_time": "41.02"
+                        },
+                        {
+                            "start_time": "41.02",
+                            "speaker_label": "spk_1",
+                            "end_time": "41.16"
+                        },
+                        {
+                            "start_time": "41.16",
+                            "speaker_label": "spk_1",
+                            "end_time": "41.99"
+                        },
+                        {
+                            "start_time": "42.21",
+                            "speaker_label": "spk_1",
+                            "end_time": "42.4"
+                        },
+                        {
+                            "start_time": "42.4",
+                            "speaker_label": "spk_1",
+                            "end_time": "42.55"
+                        },
+                        {
+                            "start_time": "42.55",
+                            "speaker_label": "spk_1",
+                            "end_time": "43.28"
+                        },
+                        {
+                            "start_time": "43.29",
+                            "speaker_label": "spk_1",
+                            "end_time": "43.56"
+                        },
+                        {
+                            "start_time": "43.56",
+                            "speaker_label": "spk_1",
+                            "end_time": "43.64"
+                        },
+                        {
+                            "start_time": "43.64",
+                            "speaker_label": "spk_1",
+                            "end_time": "44.17"
+                        },
+                        {
+                            "start_time": "44.17",
+                            "speaker_label": "spk_1",
+                            "end_time": "44.4"
+                        },
+                        {
+                            "start_time": "44.4",
+                            "speaker_label": "spk_1",
+                            "end_time": "44.74"
+                        },
+                        {
+                            "start_time": "44.74",
+                            "speaker_label": "spk_1",
+                            "end_time": "44.83"
+                        },
+                        {
+                            "start_time": "44.84",
+                            "speaker_label": "spk_1",
+                            "end_time": "45.07"
+                        },
+                        {
+                            "start_time": "45.07",
+                            "speaker_label": "spk_1",
+                            "end_time": "45.16"
+                        },
+                        {
+                            "start_time": "45.16",
+                            "speaker_label": "spk_1",
+                            "end_time": "45.27"
+                        },
+                        {
+                            "start_time": "45.27",
+                            "speaker_label": "spk_1",
+                            "end_time": "45.63"
+                        },
+                        {
+                            "start_time": "45.63",
+                            "speaker_label": "spk_1",
+                            "end_time": "45.85"
+                        },
+                        {
+                            "start_time": "46.24",
+                            "speaker_label": "spk_1",
+                            "end_time": "46.52"
+                        },
+                        {
+                            "start_time": "46.52",
+                            "speaker_label": "spk_1",
+                            "end_time": "46.61"
+                        },
+                        {
+                            "start_time": "46.61",
+                            "speaker_label": "spk_1",
+                            "end_time": "46.67"
+                        },
+                        {
+                            "start_time": "46.67",
+                            "speaker_label": "spk_1",
+                            "end_time": "47.1"
+                        },
+                        {
+                            "start_time": "47.1",
+                            "speaker_label": "spk_1",
+                            "end_time": "47.51"
+                        },
+                        {
+                            "start_time": "47.51",
+                            "speaker_label": "spk_1",
+                            "end_time": "47.89"
+                        },
+                        {
+                            "start_time": "47.89",
+                            "speaker_label": "spk_1",
+                            "end_time": "48.0"
+                        },
+                        {
+                            "start_time": "48.0",
+                            "speaker_label": "spk_1",
+                            "end_time": "48.23"
+                        },
+                        {
+                            "start_time": "48.23",
+                            "speaker_label": "spk_1",
+                            "end_time": "48.55"
+                        },
+                        {
+                            "start_time": "48.55",
+                            "speaker_label": "spk_1",
+                            "end_time": "48.67"
+                        },
+                        {
+                            "start_time": "48.67",
+                            "speaker_label": "spk_1",
+                            "end_time": "48.75"
+                        },
+                        {
+                            "start_time": "48.75",
+                            "speaker_label": "spk_1",
+                            "end_time": "49.04"
+                        },
+                        {
+                            "start_time": "49.04",
+                            "speaker_label": "spk_1",
+                            "end_time": "49.13"
+                        },
+                        {
+                            "start_time": "49.13",
+                            "speaker_label": "spk_1",
+                            "end_time": "49.27"
+                        },
+                        {
+                            "start_time": "49.27",
+                            "speaker_label": "spk_1",
+                            "end_time": "49.35"
+                        },
+                        {
+                            "start_time": "49.35",
+                            "speaker_label": "spk_1",
+                            "end_time": "49.55"
+                        },
+                        {
+                            "start_time": "49.55",
+                            "speaker_label": "spk_1",
+                            "end_time": "49.92"
+                        },
+                        {
+                            "start_time": "49.92",
+                            "speaker_label": "spk_1",
+                            "end_time": "50.1"
+                        },
+                        {
+                            "start_time": "50.49",
+                            "speaker_label": "spk_1",
+                            "end_time": "50.78"
+                        },
+                        {
+                            "start_time": "50.78",
+                            "speaker_label": "spk_1",
+                            "end_time": "51.07"
+                        },
+                        {
+                            "start_time": "51.07",
+                            "speaker_label": "spk_1",
+                            "end_time": "51.26"
+                        },
+                        {
+                            "start_time": "51.26",
+                            "speaker_label": "spk_1",
+                            "end_time": "51.43"
+                        },
+                        {
+                            "start_time": "51.43",
+                            "speaker_label": "spk_1",
+                            "end_time": "51.53"
+                        },
+                        {
+                            "start_time": "51.53",
+                            "speaker_label": "spk_1",
+                            "end_time": "51.94"
+                        },
+                        {
+                            "start_time": "51.94",
+                            "speaker_label": "spk_1",
+                            "end_time": "52.02"
+                        },
+                        {
+                            "start_time": "52.02",
+                            "speaker_label": "spk_1",
+                            "end_time": "52.11"
+                        },
+                        {
+                            "start_time": "52.11",
+                            "speaker_label": "spk_1",
+                            "end_time": "52.4"
+                        },
+                        {
+                            "start_time": "52.4",
+                            "speaker_label": "spk_1",
+                            "end_time": "52.92"
+                        },
+                        {
+                            "start_time": "52.93",
+                            "speaker_label": "spk_1",
+                            "end_time": "53.78"
+                        },
+                        {
+                            "start_time": "53.78",
+                            "speaker_label": "spk_1",
+                            "end_time": "53.96"
+                        },
+                        {
+                            "start_time": "53.96",
+                            "speaker_label": "spk_1",
+                            "end_time": "54.04"
+                        },
+                        {
+                            "start_time": "54.04",
+                            "speaker_label": "spk_1",
+                            "end_time": "54.28"
+                        },
+                        {
+                            "start_time": "54.28",
+                            "speaker_label": "spk_1",
+                            "end_time": "54.46"
+                        },
+                        {
+                            "start_time": "54.46",
+                            "speaker_label": "spk_1",
+                            "end_time": "54.95"
+                        },
+                        {
+                            "start_time": "54.95",
+                            "speaker_label": "spk_1",
+                            "end_time": "55.34"
+                        },
+                        {
+                            "start_time": "55.35",
+                            "speaker_label": "spk_1",
+                            "end_time": "55.6"
+                        },
+                        {
+                            "start_time": "55.6",
+                            "speaker_label": "spk_1",
+                            "end_time": "56.22"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "58.17",
+                    "speaker_label": "spk_0",
+                    "end_time": "63.75",
+                    "items": [
+                        {
+                            "start_time": "58.17",
+                            "speaker_label": "spk_0",
+                            "end_time": "58.62"
+                        },
+                        {
+                            "start_time": "58.62",
+                            "speaker_label": "spk_0",
+                            "end_time": "58.91"
+                        },
+                        {
+                            "start_time": "58.91",
+                            "speaker_label": "spk_0",
+                            "end_time": "59.38"
+                        },
+                        {
+                            "start_time": "59.39",
+                            "speaker_label": "spk_0",
+                            "end_time": "60.04"
+                        },
+                        {
+                            "start_time": "60.05",
+                            "speaker_label": "spk_0",
+                            "end_time": "60.23"
+                        },
+                        {
+                            "start_time": "60.23",
+                            "speaker_label": "spk_0",
+                            "end_time": "60.64"
+                        },
+                        {
+                            "start_time": "60.65",
+                            "speaker_label": "spk_0",
+                            "end_time": "61.05"
+                        },
+                        {
+                            "start_time": "61.05",
+                            "speaker_label": "spk_0",
+                            "end_time": "61.83"
+                        },
+                        {
+                            "start_time": "61.84",
+                            "speaker_label": "spk_0",
+                            "end_time": "62.11"
+                        },
+                        {
+                            "start_time": "62.11",
+                            "speaker_label": "spk_0",
+                            "end_time": "62.17"
+                        },
+                        {
+                            "start_time": "62.17",
+                            "speaker_label": "spk_0",
+                            "end_time": "62.25"
+                        },
+                        {
+                            "start_time": "62.25",
+                            "speaker_label": "spk_0",
+                            "end_time": "62.71"
+                        },
+                        {
+                            "start_time": "62.71",
+                            "speaker_label": "spk_0",
+                            "end_time": "63.09"
+                        },
+                        {
+                            "start_time": "63.09",
+                            "speaker_label": "spk_0",
+                            "end_time": "63.18"
+                        },
+                        {
+                            "start_time": "63.18",
+                            "speaker_label": "spk_0",
+                            "end_time": "63.26"
+                        },
+                        {
+                            "start_time": "63.26",
+                            "speaker_label": "spk_0",
+                            "end_time": "63.75"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "64.44",
+                    "speaker_label": "spk_0",
+                    "end_time": "72.75",
+                    "items": [
+                        {
+                            "start_time": "64.44",
+                            "speaker_label": "spk_0",
+                            "end_time": "64.66"
+                        },
+                        {
+                            "start_time": "64.66",
+                            "speaker_label": "spk_0",
+                            "end_time": "65.08"
+                        },
+                        {
+                            "start_time": "65.09",
+                            "speaker_label": "spk_0",
+                            "end_time": "66.03"
+                        },
+                        {
+                            "start_time": "66.03",
+                            "speaker_label": "spk_0",
+                            "end_time": "66.58"
+                        },
+                        {
+                            "start_time": "66.89",
+                            "speaker_label": "spk_0",
+                            "end_time": "67.66"
+                        },
+                        {
+                            "start_time": "67.66",
+                            "speaker_label": "spk_0",
+                            "end_time": "67.93"
+                        },
+                        {
+                            "start_time": "67.93",
+                            "speaker_label": "spk_0",
+                            "end_time": "68.0"
+                        },
+                        {
+                            "start_time": "68.0",
+                            "speaker_label": "spk_0",
+                            "end_time": "68.08"
+                        },
+                        {
+                            "start_time": "68.08",
+                            "speaker_label": "spk_0",
+                            "end_time": "68.4"
+                        },
+                        {
+                            "start_time": "68.4",
+                            "speaker_label": "spk_0",
+                            "end_time": "68.52"
+                        },
+                        {
+                            "start_time": "68.53",
+                            "speaker_label": "spk_0",
+                            "end_time": "69.06"
+                        },
+                        {
+                            "start_time": "69.3",
+                            "speaker_label": "spk_0",
+                            "end_time": "69.73"
+                        },
+                        {
+                            "start_time": "69.74",
+                            "speaker_label": "spk_0",
+                            "end_time": "70.53"
+                        },
+                        {
+                            "start_time": "70.62",
+                            "speaker_label": "spk_0",
+                            "end_time": "70.76"
+                        },
+                        {
+                            "start_time": "70.76",
+                            "speaker_label": "spk_0",
+                            "end_time": "71.18"
+                        },
+                        {
+                            "start_time": "71.18",
+                            "speaker_label": "spk_0",
+                            "end_time": "71.27"
+                        },
+                        {
+                            "start_time": "71.27",
+                            "speaker_label": "spk_0",
+                            "end_time": "71.6"
+                        },
+                        {
+                            "start_time": "71.6",
+                            "speaker_label": "spk_0",
+                            "end_time": "71.72"
+                        },
+                        {
+                            "start_time": "71.73",
+                            "speaker_label": "spk_0",
+                            "end_time": "72.21"
+                        },
+                        {
+                            "start_time": "72.21",
+                            "speaker_label": "spk_0",
+                            "end_time": "72.31"
+                        },
+                        {
+                            "start_time": "72.31",
+                            "speaker_label": "spk_0",
+                            "end_time": "72.75"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "73.4",
+                    "speaker_label": "spk_0",
+                    "end_time": "75.75",
+                    "items": [
+                        {
+                            "start_time": "73.4",
+                            "speaker_label": "spk_0",
+                            "end_time": "73.65"
+                        },
+                        {
+                            "start_time": "73.66",
+                            "speaker_label": "spk_0",
+                            "end_time": "74.08"
+                        },
+                        {
+                            "start_time": "74.36",
+                            "speaker_label": "spk_0",
+                            "end_time": "74.49"
+                        },
+                        {
+                            "start_time": "74.49",
+                            "speaker_label": "spk_0",
+                            "end_time": "74.84"
+                        },
+                        {
+                            "start_time": "74.84",
+                            "speaker_label": "spk_0",
+                            "end_time": "75.75"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "77.44",
+                    "speaker_label": "spk_0",
+                    "end_time": "84.93",
+                    "items": [
+                        {
+                            "start_time": "77.44",
+                            "speaker_label": "spk_0",
+                            "end_time": "77.69"
+                        },
+                        {
+                            "start_time": "77.69",
+                            "speaker_label": "spk_0",
+                            "end_time": "78.21"
+                        },
+                        {
+                            "start_time": "78.22",
+                            "speaker_label": "spk_0",
+                            "end_time": "78.36"
+                        },
+                        {
+                            "start_time": "78.36",
+                            "speaker_label": "spk_0",
+                            "end_time": "78.43"
+                        },
+                        {
+                            "start_time": "78.43",
+                            "speaker_label": "spk_0",
+                            "end_time": "78.84"
+                        },
+                        {
+                            "start_time": "78.84",
+                            "speaker_label": "spk_0",
+                            "end_time": "79.25"
+                        },
+                        {
+                            "start_time": "79.25",
+                            "speaker_label": "spk_0",
+                            "end_time": "79.38"
+                        },
+                        {
+                            "start_time": "79.38",
+                            "speaker_label": "spk_0",
+                            "end_time": "79.85"
+                        },
+                        {
+                            "start_time": "79.86",
+                            "speaker_label": "spk_0",
+                            "end_time": "80.27"
+                        },
+                        {
+                            "start_time": "80.28",
+                            "speaker_label": "spk_0",
+                            "end_time": "80.58"
+                        },
+                        {
+                            "start_time": "80.58",
+                            "speaker_label": "spk_0",
+                            "end_time": "80.98"
+                        },
+                        {
+                            "start_time": "80.98",
+                            "speaker_label": "spk_0",
+                            "end_time": "81.53"
+                        },
+                        {
+                            "start_time": "81.75",
+                            "speaker_label": "spk_0",
+                            "end_time": "81.96"
+                        },
+                        {
+                            "start_time": "81.96",
+                            "speaker_label": "spk_0",
+                            "end_time": "82.19"
+                        },
+                        {
+                            "start_time": "82.19",
+                            "speaker_label": "spk_0",
+                            "end_time": "82.27"
+                        },
+                        {
+                            "start_time": "82.27",
+                            "speaker_label": "spk_0",
+                            "end_time": "83.03"
+                        },
+                        {
+                            "start_time": "83.04",
+                            "speaker_label": "spk_0",
+                            "end_time": "83.18"
+                        },
+                        {
+                            "start_time": "83.18",
+                            "speaker_label": "spk_0",
+                            "end_time": "83.47"
+                        },
+                        {
+                            "start_time": "83.47",
+                            "speaker_label": "spk_0",
+                            "end_time": "84.01"
+                        },
+                        {
+                            "start_time": "84.01",
+                            "speaker_label": "spk_0",
+                            "end_time": "84.17"
+                        },
+                        {
+                            "start_time": "84.17",
+                            "speaker_label": "spk_0",
+                            "end_time": "84.93"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "85.54",
+                    "speaker_label": "spk_0",
+                    "end_time": "90.57",
+                    "items": [
+                        {
+                            "start_time": "85.54",
+                            "speaker_label": "spk_0",
+                            "end_time": "86.02"
+                        },
+                        {
+                            "start_time": "86.02",
+                            "speaker_label": "spk_0",
+                            "end_time": "86.08"
+                        },
+                        {
+                            "start_time": "86.08",
+                            "speaker_label": "spk_0",
+                            "end_time": "86.29"
+                        },
+                        {
+                            "start_time": "86.29",
+                            "speaker_label": "spk_0",
+                            "end_time": "86.51"
+                        },
+                        {
+                            "start_time": "86.51",
+                            "speaker_label": "spk_0",
+                            "end_time": "86.72"
+                        },
+                        {
+                            "start_time": "86.72",
+                            "speaker_label": "spk_0",
+                            "end_time": "86.9"
+                        },
+                        {
+                            "start_time": "86.9",
+                            "speaker_label": "spk_0",
+                            "end_time": "87.01"
+                        },
+                        {
+                            "start_time": "87.01",
+                            "speaker_label": "spk_0",
+                            "end_time": "87.43"
+                        },
+                        {
+                            "start_time": "87.44",
+                            "speaker_label": "spk_0",
+                            "end_time": "87.58"
+                        },
+                        {
+                            "start_time": "87.58",
+                            "speaker_label": "spk_0",
+                            "end_time": "87.78"
+                        },
+                        {
+                            "start_time": "87.78",
+                            "speaker_label": "spk_0",
+                            "end_time": "88.05"
+                        },
+                        {
+                            "start_time": "88.05",
+                            "speaker_label": "spk_0",
+                            "end_time": "88.35"
+                        },
+                        {
+                            "start_time": "88.35",
+                            "speaker_label": "spk_0",
+                            "end_time": "88.44"
+                        },
+                        {
+                            "start_time": "88.45",
+                            "speaker_label": "spk_0",
+                            "end_time": "88.81"
+                        },
+                        {
+                            "start_time": "88.81",
+                            "speaker_label": "spk_0",
+                            "end_time": "88.91"
+                        },
+                        {
+                            "start_time": "88.91",
+                            "speaker_label": "spk_0",
+                            "end_time": "89.44"
+                        },
+                        {
+                            "start_time": "89.44",
+                            "speaker_label": "spk_0",
+                            "end_time": "89.91"
+                        },
+                        {
+                            "start_time": "89.91",
+                            "speaker_label": "spk_0",
+                            "end_time": "90.08"
+                        },
+                        {
+                            "start_time": "90.09",
+                            "speaker_label": "spk_0",
+                            "end_time": "90.57"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "91.23",
+                    "speaker_label": "spk_0",
+                    "end_time": "98.85",
+                    "items": [
+                        {
+                            "start_time": "91.23",
+                            "speaker_label": "spk_0",
+                            "end_time": "91.39"
+                        },
+                        {
+                            "start_time": "91.39",
+                            "speaker_label": "spk_0",
+                            "end_time": "91.56"
+                        },
+                        {
+                            "start_time": "91.56",
+                            "speaker_label": "spk_0",
+                            "end_time": "91.7"
+                        },
+                        {
+                            "start_time": "91.71",
+                            "speaker_label": "spk_0",
+                            "end_time": "92.06"
+                        },
+                        {
+                            "start_time": "92.06",
+                            "speaker_label": "spk_0",
+                            "end_time": "92.47"
+                        },
+                        {
+                            "start_time": "92.47",
+                            "speaker_label": "spk_0",
+                            "end_time": "92.58"
+                        },
+                        {
+                            "start_time": "92.59",
+                            "speaker_label": "spk_0",
+                            "end_time": "92.7"
+                        },
+                        {
+                            "start_time": "92.7",
+                            "speaker_label": "spk_0",
+                            "end_time": "93.29"
+                        },
+                        {
+                            "start_time": "93.29",
+                            "speaker_label": "spk_0",
+                            "end_time": "93.83"
+                        },
+                        {
+                            "start_time": "93.83",
+                            "speaker_label": "spk_0",
+                            "end_time": "94.39"
+                        },
+                        {
+                            "start_time": "94.72",
+                            "speaker_label": "spk_0",
+                            "end_time": "94.83"
+                        },
+                        {
+                            "start_time": "94.83",
+                            "speaker_label": "spk_0",
+                            "end_time": "95.6"
+                        },
+                        {
+                            "start_time": "95.61",
+                            "speaker_label": "spk_0",
+                            "end_time": "95.74"
+                        },
+                        {
+                            "start_time": "95.74",
+                            "speaker_label": "spk_0",
+                            "end_time": "96.2"
+                        },
+                        {
+                            "start_time": "96.2",
+                            "speaker_label": "spk_0",
+                            "end_time": "96.88"
+                        },
+                        {
+                            "start_time": "97.19",
+                            "speaker_label": "spk_0",
+                            "end_time": "97.39"
+                        },
+                        {
+                            "start_time": "97.39",
+                            "speaker_label": "spk_0",
+                            "end_time": "98.06"
+                        },
+                        {
+                            "start_time": "98.07",
+                            "speaker_label": "spk_0",
+                            "end_time": "98.85"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "100.44",
+                    "speaker_label": "spk_0",
+                    "end_time": "102.75",
+                    "items": [
+                        {
+                            "start_time": "100.44",
+                            "speaker_label": "spk_0",
+                            "end_time": "100.75"
+                        },
+                        {
+                            "start_time": "100.75",
+                            "speaker_label": "spk_0",
+                            "end_time": "100.83"
+                        },
+                        {
+                            "start_time": "100.83",
+                            "speaker_label": "spk_0",
+                            "end_time": "101.36"
+                        },
+                        {
+                            "start_time": "101.46",
+                            "speaker_label": "spk_0",
+                            "end_time": "101.69"
+                        },
+                        {
+                            "start_time": "101.69",
+                            "speaker_label": "spk_0",
+                            "end_time": "102.11"
+                        },
+                        {
+                            "start_time": "102.11",
+                            "speaker_label": "spk_0",
+                            "end_time": "102.75"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "103.31",
+                    "speaker_label": "spk_0",
+                    "end_time": "111.28",
+                    "items": [
+                        {
+                            "start_time": "103.31",
+                            "speaker_label": "spk_0",
+                            "end_time": "103.71"
+                        },
+                        {
+                            "start_time": "103.71",
+                            "speaker_label": "spk_0",
+                            "end_time": "103.84"
+                        },
+                        {
+                            "start_time": "103.85",
+                            "speaker_label": "spk_0",
+                            "end_time": "104.63"
+                        },
+                        {
+                            "start_time": "105.09",
+                            "speaker_label": "spk_0",
+                            "end_time": "105.18"
+                        },
+                        {
+                            "start_time": "105.19",
+                            "speaker_label": "spk_0",
+                            "end_time": "106.18"
+                        },
+                        {
+                            "start_time": "106.19",
+                            "speaker_label": "spk_0",
+                            "end_time": "106.32"
+                        },
+                        {
+                            "start_time": "106.32",
+                            "speaker_label": "spk_0",
+                            "end_time": "106.87"
+                        },
+                        {
+                            "start_time": "106.88",
+                            "speaker_label": "spk_0",
+                            "end_time": "107.06"
+                        },
+                        {
+                            "start_time": "107.06",
+                            "speaker_label": "spk_0",
+                            "end_time": "107.41"
+                        },
+                        {
+                            "start_time": "107.48",
+                            "speaker_label": "spk_0",
+                            "end_time": "107.89"
+                        },
+                        {
+                            "start_time": "107.89",
+                            "speaker_label": "spk_0",
+                            "end_time": "107.95"
+                        },
+                        {
+                            "start_time": "107.95",
+                            "speaker_label": "spk_0",
+                            "end_time": "108.04"
+                        },
+                        {
+                            "start_time": "108.04",
+                            "speaker_label": "spk_0",
+                            "end_time": "108.46"
+                        },
+                        {
+                            "start_time": "108.46",
+                            "speaker_label": "spk_0",
+                            "end_time": "108.66"
+                        },
+                        {
+                            "start_time": "108.66",
+                            "speaker_label": "spk_0",
+                            "end_time": "109.23"
+                        },
+                        {
+                            "start_time": "109.23",
+                            "speaker_label": "spk_0",
+                            "end_time": "109.45"
+                        },
+                        {
+                            "start_time": "109.46",
+                            "speaker_label": "spk_0",
+                            "end_time": "109.71"
+                        },
+                        {
+                            "start_time": "109.71",
+                            "speaker_label": "spk_0",
+                            "end_time": "110.2"
+                        },
+                        {
+                            "start_time": "110.21",
+                            "speaker_label": "spk_0",
+                            "end_time": "110.34"
+                        },
+                        {
+                            "start_time": "110.34",
+                            "speaker_label": "spk_0",
+                            "end_time": "110.69"
+                        },
+                        {
+                            "start_time": "110.69",
+                            "speaker_label": "spk_0",
+                            "end_time": "111.28"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "117.74",
+                    "speaker_label": "",
+                    "end_time": "118.05",
+                    "items": []
+                },
+                {
+                    "start_time": "118.74",
+                    "speaker_label": "",
+                    "end_time": "118.95",
+                    "items": []
+                },
+                {
+                    "start_time": "119.92",
+                    "speaker_label": "",
+                    "end_time": "120.93",
+                    "items": []
+                },
+                {
+                    "start_time": "122.92",
+                    "speaker_label": "spk_0",
+                    "end_time": "134.07",
+                    "items": [
+                        {
+                            "start_time": "122.92",
+                            "speaker_label": "spk_0",
+                            "end_time": "123.27"
+                        },
+                        {
+                            "start_time": "123.27",
+                            "speaker_label": "spk_0",
+                            "end_time": "123.89"
+                        },
+                        {
+                            "start_time": "123.95",
+                            "speaker_label": "spk_0",
+                            "end_time": "124.27"
+                        },
+                        {
+                            "start_time": "124.27",
+                            "speaker_label": "spk_0",
+                            "end_time": "124.79"
+                        },
+                        {
+                            "start_time": "124.82",
+                            "speaker_label": "spk_0",
+                            "end_time": "124.96"
+                        },
+                        {
+                            "start_time": "124.96",
+                            "speaker_label": "spk_0",
+                            "end_time": "125.38"
+                        },
+                        {
+                            "start_time": "125.38",
+                            "speaker_label": "spk_0",
+                            "end_time": "125.88"
+                        },
+                        {
+                            "start_time": "125.88",
+                            "speaker_label": "spk_0",
+                            "end_time": "126.02"
+                        },
+                        {
+                            "start_time": "126.02",
+                            "speaker_label": "spk_0",
+                            "end_time": "126.11"
+                        },
+                        {
+                            "start_time": "126.11",
+                            "speaker_label": "spk_0",
+                            "end_time": "126.7"
+                        },
+                        {
+                            "start_time": "126.71",
+                            "speaker_label": "spk_0",
+                            "end_time": "127.03"
+                        },
+                        {
+                            "start_time": "127.03",
+                            "speaker_label": "spk_0",
+                            "end_time": "127.12"
+                        },
+                        {
+                            "start_time": "127.12",
+                            "speaker_label": "spk_0",
+                            "end_time": "127.44"
+                        },
+                        {
+                            "start_time": "127.44",
+                            "speaker_label": "spk_0",
+                            "end_time": "127.59"
+                        },
+                        {
+                            "start_time": "127.6",
+                            "speaker_label": "spk_0",
+                            "end_time": "128.11"
+                        },
+                        {
+                            "start_time": "128.12",
+                            "speaker_label": "spk_0",
+                            "end_time": "128.42"
+                        },
+                        {
+                            "start_time": "128.42",
+                            "speaker_label": "spk_0",
+                            "end_time": "128.49"
+                        },
+                        {
+                            "start_time": "128.49",
+                            "speaker_label": "spk_0",
+                            "end_time": "128.83"
+                        },
+                        {
+                            "start_time": "128.83",
+                            "speaker_label": "spk_0",
+                            "end_time": "128.91"
+                        },
+                        {
+                            "start_time": "128.91",
+                            "speaker_label": "spk_0",
+                            "end_time": "129.68"
+                        },
+                        {
+                            "start_time": "129.98",
+                            "speaker_label": "spk_0",
+                            "end_time": "130.34"
+                        },
+                        {
+                            "start_time": "130.35",
+                            "speaker_label": "spk_0",
+                            "end_time": "130.89"
+                        },
+                        {
+                            "start_time": "131.04",
+                            "speaker_label": "spk_0",
+                            "end_time": "131.33"
+                        },
+                        {
+                            "start_time": "131.33",
+                            "speaker_label": "spk_0",
+                            "end_time": "131.95"
+                        },
+                        {
+                            "start_time": "132.06",
+                            "speaker_label": "spk_0",
+                            "end_time": "132.25"
+                        },
+                        {
+                            "start_time": "132.25",
+                            "speaker_label": "spk_0",
+                            "end_time": "132.56"
+                        },
+                        {
+                            "start_time": "132.57",
+                            "speaker_label": "spk_0",
+                            "end_time": "132.77"
+                        },
+                        {
+                            "start_time": "132.85",
+                            "speaker_label": "spk_0",
+                            "end_time": "133.52"
+                        },
+                        {
+                            "start_time": "133.52",
+                            "speaker_label": "spk_0",
+                            "end_time": "133.62"
+                        },
+                        {
+                            "start_time": "133.62",
+                            "speaker_label": "spk_0",
+                            "end_time": "134.07"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "135.27",
+                    "speaker_label": "spk_0",
+                    "end_time": "135.41",
+                    "items": [
+                        {
+                            "start_time": "135.27",
+                            "speaker_label": "spk_0",
+                            "end_time": "135.41"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "135.41",
+                    "speaker_label": "spk_1",
+                    "end_time": "141.36",
+                    "items": [
+                        {
+                            "start_time": "135.41",
+                            "speaker_label": "spk_1",
+                            "end_time": "135.86"
+                        },
+                        {
+                            "start_time": "135.86",
+                            "speaker_label": "spk_1",
+                            "end_time": "136.01"
+                        },
+                        {
+                            "start_time": "136.01",
+                            "speaker_label": "spk_1",
+                            "end_time": "136.18"
+                        },
+                        {
+                            "start_time": "136.18",
+                            "speaker_label": "spk_1",
+                            "end_time": "136.71"
+                        },
+                        {
+                            "start_time": "136.71",
+                            "speaker_label": "spk_1",
+                            "end_time": "136.9"
+                        },
+                        {
+                            "start_time": "136.9",
+                            "speaker_label": "spk_1",
+                            "end_time": "137.35"
+                        },
+                        {
+                            "start_time": "137.35",
+                            "speaker_label": "spk_1",
+                            "end_time": "137.54"
+                        },
+                        {
+                            "start_time": "137.55",
+                            "speaker_label": "spk_1",
+                            "end_time": "137.95"
+                        },
+                        {
+                            "start_time": "137.96",
+                            "speaker_label": "spk_1",
+                            "end_time": "138.26"
+                        },
+                        {
+                            "start_time": "138.27",
+                            "speaker_label": "spk_1",
+                            "end_time": "138.34"
+                        },
+                        {
+                            "start_time": "138.34",
+                            "speaker_label": "spk_1",
+                            "end_time": "138.81"
+                        },
+                        {
+                            "start_time": "138.81",
+                            "speaker_label": "spk_1",
+                            "end_time": "138.96"
+                        },
+                        {
+                            "start_time": "138.96",
+                            "speaker_label": "spk_1",
+                            "end_time": "139.21"
+                        },
+                        {
+                            "start_time": "139.32",
+                            "speaker_label": "spk_1",
+                            "end_time": "139.63"
+                        },
+                        {
+                            "start_time": "139.63",
+                            "speaker_label": "spk_1",
+                            "end_time": "140.39"
+                        },
+                        {
+                            "start_time": "140.39",
+                            "speaker_label": "spk_1",
+                            "end_time": "140.9"
+                        },
+                        {
+                            "start_time": "140.9",
+                            "speaker_label": "spk_1",
+                            "end_time": "141.36"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "141.97",
+                    "speaker_label": "spk_1",
+                    "end_time": "147.58",
+                    "items": [
+                        {
+                            "start_time": "141.97",
+                            "speaker_label": "spk_1",
+                            "end_time": "142.3"
+                        },
+                        {
+                            "start_time": "142.3",
+                            "speaker_label": "spk_1",
+                            "end_time": "142.45"
+                        },
+                        {
+                            "start_time": "142.46",
+                            "speaker_label": "spk_1",
+                            "end_time": "142.9"
+                        },
+                        {
+                            "start_time": "142.9",
+                            "speaker_label": "spk_1",
+                            "end_time": "143.28"
+                        },
+                        {
+                            "start_time": "143.29",
+                            "speaker_label": "spk_1",
+                            "end_time": "143.66"
+                        },
+                        {
+                            "start_time": "143.66",
+                            "speaker_label": "spk_1",
+                            "end_time": "143.97"
+                        },
+                        {
+                            "start_time": "143.98",
+                            "speaker_label": "spk_1",
+                            "end_time": "144.34"
+                        },
+                        {
+                            "start_time": "144.34",
+                            "speaker_label": "spk_1",
+                            "end_time": "144.76"
+                        },
+                        {
+                            "start_time": "144.76",
+                            "speaker_label": "spk_1",
+                            "end_time": "144.85"
+                        },
+                        {
+                            "start_time": "144.85",
+                            "speaker_label": "spk_1",
+                            "end_time": "145.43"
+                        },
+                        {
+                            "start_time": "145.43",
+                            "speaker_label": "spk_1",
+                            "end_time": "145.85"
+                        },
+                        {
+                            "start_time": "145.85",
+                            "speaker_label": "spk_1",
+                            "end_time": "146.01"
+                        },
+                        {
+                            "start_time": "146.01",
+                            "speaker_label": "spk_1",
+                            "end_time": "146.25"
+                        },
+                        {
+                            "start_time": "146.25",
+                            "speaker_label": "spk_1",
+                            "end_time": "146.53"
+                        },
+                        {
+                            "start_time": "146.53",
+                            "speaker_label": "spk_1",
+                            "end_time": "146.59"
+                        },
+                        {
+                            "start_time": "146.59",
+                            "speaker_label": "spk_1",
+                            "end_time": "146.68"
+                        },
+                        {
+                            "start_time": "146.68",
+                            "speaker_label": "spk_1",
+                            "end_time": "147.24"
+                        },
+                        {
+                            "start_time": "147.24",
+                            "speaker_label": "spk_1",
+                            "end_time": "147.58"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "149.12",
+                    "speaker_label": "spk_1",
+                    "end_time": "153.0",
+                    "items": [
+                        {
+                            "start_time": "149.12",
+                            "speaker_label": "spk_1",
+                            "end_time": "149.21"
+                        },
+                        {
+                            "start_time": "149.21",
+                            "speaker_label": "spk_1",
+                            "end_time": "149.39"
+                        },
+                        {
+                            "start_time": "149.39",
+                            "speaker_label": "spk_1",
+                            "end_time": "149.5"
+                        },
+                        {
+                            "start_time": "149.5",
+                            "speaker_label": "spk_1",
+                            "end_time": "149.73"
+                        },
+                        {
+                            "start_time": "149.73",
+                            "speaker_label": "spk_1",
+                            "end_time": "149.98"
+                        },
+                        {
+                            "start_time": "149.98",
+                            "speaker_label": "spk_1",
+                            "end_time": "150.29"
+                        },
+                        {
+                            "start_time": "150.29",
+                            "speaker_label": "spk_1",
+                            "end_time": "150.37"
+                        },
+                        {
+                            "start_time": "150.37",
+                            "speaker_label": "spk_1",
+                            "end_time": "150.74"
+                        },
+                        {
+                            "start_time": "150.75",
+                            "speaker_label": "spk_1",
+                            "end_time": "150.98"
+                        },
+                        {
+                            "start_time": "150.98",
+                            "speaker_label": "spk_1",
+                            "end_time": "151.16"
+                        },
+                        {
+                            "start_time": "151.16",
+                            "speaker_label": "spk_1",
+                            "end_time": "151.48"
+                        },
+                        {
+                            "start_time": "151.77",
+                            "speaker_label": "spk_1",
+                            "end_time": "151.93"
+                        },
+                        {
+                            "start_time": "151.93",
+                            "speaker_label": "spk_1",
+                            "end_time": "152.18"
+                        },
+                        {
+                            "start_time": "152.18",
+                            "speaker_label": "spk_1",
+                            "end_time": "152.68"
+                        },
+                        {
+                            "start_time": "152.68",
+                            "speaker_label": "spk_1",
+                            "end_time": "152.71"
+                        },
+                        {
+                            "start_time": "152.71",
+                            "speaker_label": "spk_1",
+                            "end_time": "153.0"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "153.66",
+                    "speaker_label": "spk_1",
+                    "end_time": "159.75",
+                    "items": [
+                        {
+                            "start_time": "153.66",
+                            "speaker_label": "spk_1",
+                            "end_time": "153.84"
+                        },
+                        {
+                            "start_time": "153.84",
+                            "speaker_label": "spk_1",
+                            "end_time": "153.95"
+                        },
+                        {
+                            "start_time": "153.95",
+                            "speaker_label": "spk_1",
+                            "end_time": "154.45"
+                        },
+                        {
+                            "start_time": "154.45",
+                            "speaker_label": "spk_1",
+                            "end_time": "154.61"
+                        },
+                        {
+                            "start_time": "154.61",
+                            "speaker_label": "spk_1",
+                            "end_time": "154.99"
+                        },
+                        {
+                            "start_time": "154.99",
+                            "speaker_label": "spk_1",
+                            "end_time": "155.09"
+                        },
+                        {
+                            "start_time": "155.09",
+                            "speaker_label": "spk_1",
+                            "end_time": "155.28"
+                        },
+                        {
+                            "start_time": "155.28",
+                            "speaker_label": "spk_1",
+                            "end_time": "155.56"
+                        },
+                        {
+                            "start_time": "155.56",
+                            "speaker_label": "spk_1",
+                            "end_time": "156.07"
+                        },
+                        {
+                            "start_time": "156.07",
+                            "speaker_label": "spk_1",
+                            "end_time": "156.8"
+                        },
+                        {
+                            "start_time": "157.11",
+                            "speaker_label": "spk_1",
+                            "end_time": "157.32"
+                        },
+                        {
+                            "start_time": "157.32",
+                            "speaker_label": "spk_1",
+                            "end_time": "157.39"
+                        },
+                        {
+                            "start_time": "157.39",
+                            "speaker_label": "spk_1",
+                            "end_time": "157.57"
+                        },
+                        {
+                            "start_time": "157.57",
+                            "speaker_label": "spk_1",
+                            "end_time": "157.67"
+                        },
+                        {
+                            "start_time": "157.67",
+                            "speaker_label": "spk_1",
+                            "end_time": "158.28"
+                        },
+                        {
+                            "start_time": "158.42",
+                            "speaker_label": "spk_1",
+                            "end_time": "158.84"
+                        },
+                        {
+                            "start_time": "158.84",
+                            "speaker_label": "spk_1",
+                            "end_time": "159.25"
+                        },
+                        {
+                            "start_time": "159.25",
+                            "speaker_label": "spk_1",
+                            "end_time": "159.4"
+                        },
+                        {
+                            "start_time": "159.4",
+                            "speaker_label": "spk_1",
+                            "end_time": "159.75"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "160.27",
+                    "speaker_label": "spk_1",
+                    "end_time": "163.19",
+                    "items": [
+                        {
+                            "start_time": "160.27",
+                            "speaker_label": "spk_1",
+                            "end_time": "160.7"
+                        },
+                        {
+                            "start_time": "160.7",
+                            "speaker_label": "spk_1",
+                            "end_time": "161.28"
+                        },
+                        {
+                            "start_time": "161.42",
+                            "speaker_label": "spk_1",
+                            "end_time": "161.65"
+                        },
+                        {
+                            "start_time": "161.66",
+                            "speaker_label": "spk_1",
+                            "end_time": "162.05"
+                        },
+                        {
+                            "start_time": "162.05",
+                            "speaker_label": "spk_1",
+                            "end_time": "162.13"
+                        },
+                        {
+                            "start_time": "162.13",
+                            "speaker_label": "spk_1",
+                            "end_time": "162.65"
+                        },
+                        {
+                            "start_time": "162.65",
+                            "speaker_label": "spk_1",
+                            "end_time": "163.19"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "163.72",
+                    "speaker_label": "spk_1",
+                    "end_time": "169.77",
+                    "items": [
+                        {
+                            "start_time": "163.72",
+                            "speaker_label": "spk_1",
+                            "end_time": "164.46"
+                        },
+                        {
+                            "start_time": "164.65",
+                            "speaker_label": "spk_1",
+                            "end_time": "164.96"
+                        },
+                        {
+                            "start_time": "164.96",
+                            "speaker_label": "spk_1",
+                            "end_time": "165.05"
+                        },
+                        {
+                            "start_time": "165.05",
+                            "speaker_label": "spk_1",
+                            "end_time": "165.23"
+                        },
+                        {
+                            "start_time": "165.23",
+                            "speaker_label": "spk_1",
+                            "end_time": "165.62"
+                        },
+                        {
+                            "start_time": "165.62",
+                            "speaker_label": "spk_1",
+                            "end_time": "165.81"
+                        },
+                        {
+                            "start_time": "165.81",
+                            "speaker_label": "spk_1",
+                            "end_time": "166.05"
+                        },
+                        {
+                            "start_time": "166.06",
+                            "speaker_label": "spk_1",
+                            "end_time": "166.16"
+                        },
+                        {
+                            "start_time": "166.16",
+                            "speaker_label": "spk_1",
+                            "end_time": "166.54"
+                        },
+                        {
+                            "start_time": "166.54",
+                            "speaker_label": "spk_1",
+                            "end_time": "167.33"
+                        },
+                        {
+                            "start_time": "167.33",
+                            "speaker_label": "spk_1",
+                            "end_time": "167.6"
+                        },
+                        {
+                            "start_time": "167.61",
+                            "speaker_label": "spk_1",
+                            "end_time": "167.87"
+                        },
+                        {
+                            "start_time": "167.87",
+                            "speaker_label": "spk_1",
+                            "end_time": "167.95"
+                        },
+                        {
+                            "start_time": "167.95",
+                            "speaker_label": "spk_1",
+                            "end_time": "168.31"
+                        },
+                        {
+                            "start_time": "168.32",
+                            "speaker_label": "spk_1",
+                            "end_time": "168.64"
+                        },
+                        {
+                            "start_time": "168.64",
+                            "speaker_label": "spk_1",
+                            "end_time": "168.87"
+                        },
+                        {
+                            "start_time": "168.87",
+                            "speaker_label": "spk_1",
+                            "end_time": "168.94"
+                        },
+                        {
+                            "start_time": "168.94",
+                            "speaker_label": "spk_1",
+                            "end_time": "169.04"
+                        },
+                        {
+                            "start_time": "169.04",
+                            "speaker_label": "spk_1",
+                            "end_time": "169.4"
+                        },
+                        {
+                            "start_time": "169.4",
+                            "speaker_label": "spk_1",
+                            "end_time": "169.77"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "172.02",
+                    "speaker_label": "spk_0",
+                    "end_time": "173.86",
+                    "items": [
+                        {
+                            "start_time": "172.02",
+                            "speaker_label": "spk_0",
+                            "end_time": "172.3"
+                        },
+                        {
+                            "start_time": "172.3",
+                            "speaker_label": "spk_0",
+                            "end_time": "172.38"
+                        },
+                        {
+                            "start_time": "172.38",
+                            "speaker_label": "spk_0",
+                            "end_time": "173.01"
+                        },
+                        {
+                            "start_time": "173.01",
+                            "speaker_label": "spk_0",
+                            "end_time": "173.32"
+                        },
+                        {
+                            "start_time": "173.32",
+                            "speaker_label": "spk_0",
+                            "end_time": "173.6"
+                        },
+                        {
+                            "start_time": "173.6",
+                            "speaker_label": "spk_0",
+                            "end_time": "173.86"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "174.32",
+                    "speaker_label": "spk_1",
+                    "end_time": "211.97",
+                    "items": [
+                        {
+                            "start_time": "174.32",
+                            "speaker_label": "spk_1",
+                            "end_time": "175.07"
+                        },
+                        {
+                            "start_time": "175.35",
+                            "speaker_label": "spk_1",
+                            "end_time": "175.7"
+                        },
+                        {
+                            "start_time": "175.7",
+                            "speaker_label": "spk_1",
+                            "end_time": "176.15"
+                        },
+                        {
+                            "start_time": "176.15",
+                            "speaker_label": "spk_1",
+                            "end_time": "176.55"
+                        },
+                        {
+                            "start_time": "176.55",
+                            "speaker_label": "spk_1",
+                            "end_time": "176.7"
+                        },
+                        {
+                            "start_time": "176.7",
+                            "speaker_label": "spk_1",
+                            "end_time": "177.36"
+                        },
+                        {
+                            "start_time": "177.37",
+                            "speaker_label": "spk_1",
+                            "end_time": "177.95"
+                        },
+                        {
+                            "start_time": "178.22",
+                            "speaker_label": "spk_1",
+                            "end_time": "178.62"
+                        },
+                        {
+                            "start_time": "178.62",
+                            "speaker_label": "spk_1",
+                            "end_time": "178.9"
+                        },
+                        {
+                            "start_time": "178.9",
+                            "speaker_label": "spk_1",
+                            "end_time": "179.36"
+                        },
+                        {
+                            "start_time": "179.36",
+                            "speaker_label": "spk_1",
+                            "end_time": "179.48"
+                        },
+                        {
+                            "start_time": "179.48",
+                            "speaker_label": "spk_1",
+                            "end_time": "179.66"
+                        },
+                        {
+                            "start_time": "179.66",
+                            "speaker_label": "spk_1",
+                            "end_time": "179.82"
+                        },
+                        {
+                            "start_time": "179.82",
+                            "speaker_label": "spk_1",
+                            "end_time": "180.08"
+                        },
+                        {
+                            "start_time": "180.08",
+                            "speaker_label": "spk_1",
+                            "end_time": "180.4"
+                        },
+                        {
+                            "start_time": "180.4",
+                            "speaker_label": "spk_1",
+                            "end_time": "180.97"
+                        },
+                        {
+                            "start_time": "180.98",
+                            "speaker_label": "spk_1",
+                            "end_time": "181.13"
+                        },
+                        {
+                            "start_time": "181.13",
+                            "speaker_label": "spk_1",
+                            "end_time": "181.22"
+                        },
+                        {
+                            "start_time": "181.22",
+                            "speaker_label": "spk_1",
+                            "end_time": "181.85"
+                        },
+                        {
+                            "start_time": "181.85",
+                            "speaker_label": "spk_1",
+                            "end_time": "182.27"
+                        },
+                        {
+                            "start_time": "182.27",
+                            "speaker_label": "spk_1",
+                            "end_time": "182.76"
+                        },
+                        {
+                            "start_time": "182.77",
+                            "speaker_label": "spk_1",
+                            "end_time": "183.63"
+                        },
+                        {
+                            "start_time": "183.63",
+                            "speaker_label": "spk_1",
+                            "end_time": "184.06"
+                        },
+                        {
+                            "start_time": "184.06",
+                            "speaker_label": "spk_1",
+                            "end_time": "184.68"
+                        },
+                        {
+                            "start_time": "184.78",
+                            "speaker_label": "spk_1",
+                            "end_time": "185.26"
+                        },
+                        {
+                            "start_time": "185.26",
+                            "speaker_label": "spk_1",
+                            "end_time": "185.52"
+                        },
+                        {
+                            "start_time": "185.52",
+                            "speaker_label": "spk_1",
+                            "end_time": "185.66"
+                        },
+                        {
+                            "start_time": "185.66",
+                            "speaker_label": "spk_1",
+                            "end_time": "185.92"
+                        },
+                        {
+                            "start_time": "185.92",
+                            "speaker_label": "spk_1",
+                            "end_time": "186.19"
+                        },
+                        {
+                            "start_time": "186.19",
+                            "speaker_label": "spk_1",
+                            "end_time": "186.27"
+                        },
+                        {
+                            "start_time": "186.27",
+                            "speaker_label": "spk_1",
+                            "end_time": "186.82"
+                        },
+                        {
+                            "start_time": "186.83",
+                            "speaker_label": "spk_1",
+                            "end_time": "187.03"
+                        },
+                        {
+                            "start_time": "187.03",
+                            "speaker_label": "spk_1",
+                            "end_time": "187.1"
+                        },
+                        {
+                            "start_time": "187.1",
+                            "speaker_label": "spk_1",
+                            "end_time": "187.35"
+                        },
+                        {
+                            "start_time": "187.47",
+                            "speaker_label": "spk_1",
+                            "end_time": "187.94"
+                        },
+                        {
+                            "start_time": "187.94",
+                            "speaker_label": "spk_1",
+                            "end_time": "188.32"
+                        },
+                        {
+                            "start_time": "188.8",
+                            "speaker_label": "spk_1",
+                            "end_time": "189.05"
+                        },
+                        {
+                            "start_time": "189.05",
+                            "speaker_label": "spk_1",
+                            "end_time": "189.14"
+                        },
+                        {
+                            "start_time": "189.14",
+                            "speaker_label": "spk_1",
+                            "end_time": "189.91"
+                        },
+                        {
+                            "start_time": "189.91",
+                            "speaker_label": "spk_1",
+                            "end_time": "190.48"
+                        },
+                        {
+                            "start_time": "190.48",
+                            "speaker_label": "spk_1",
+                            "end_time": "191.19"
+                        },
+                        {
+                            "start_time": "191.56",
+                            "speaker_label": "spk_1",
+                            "end_time": "191.7"
+                        },
+                        {
+                            "start_time": "191.7",
+                            "speaker_label": "spk_1",
+                            "end_time": "191.73"
+                        },
+                        {
+                            "start_time": "191.73",
+                            "speaker_label": "spk_1",
+                            "end_time": "191.88"
+                        },
+                        {
+                            "start_time": "191.88",
+                            "speaker_label": "spk_1",
+                            "end_time": "191.92"
+                        },
+                        {
+                            "start_time": "191.92",
+                            "speaker_label": "spk_1",
+                            "end_time": "192.1"
+                        },
+                        {
+                            "start_time": "192.1",
+                            "speaker_label": "spk_1",
+                            "end_time": "192.21"
+                        },
+                        {
+                            "start_time": "192.21",
+                            "speaker_label": "spk_1",
+                            "end_time": "192.85"
+                        },
+                        {
+                            "start_time": "192.86",
+                            "speaker_label": "spk_1",
+                            "end_time": "193.63"
+                        },
+                        {
+                            "start_time": "193.92",
+                            "speaker_label": "spk_1",
+                            "end_time": "194.38"
+                        },
+                        {
+                            "start_time": "194.38",
+                            "speaker_label": "spk_1",
+                            "end_time": "194.56"
+                        },
+                        {
+                            "start_time": "194.56",
+                            "speaker_label": "spk_1",
+                            "end_time": "194.7"
+                        },
+                        {
+                            "start_time": "194.7",
+                            "speaker_label": "spk_1",
+                            "end_time": "194.88"
+                        },
+                        {
+                            "start_time": "194.88",
+                            "speaker_label": "spk_1",
+                            "end_time": "195.29"
+                        },
+                        {
+                            "start_time": "195.29",
+                            "speaker_label": "spk_1",
+                            "end_time": "195.39"
+                        },
+                        {
+                            "start_time": "195.39",
+                            "speaker_label": "spk_1",
+                            "end_time": "195.61"
+                        },
+                        {
+                            "start_time": "195.61",
+                            "speaker_label": "spk_1",
+                            "end_time": "195.68"
+                        },
+                        {
+                            "start_time": "195.68",
+                            "speaker_label": "spk_1",
+                            "end_time": "196.23"
+                        },
+                        {
+                            "start_time": "196.42",
+                            "speaker_label": "spk_1",
+                            "end_time": "196.54"
+                        },
+                        {
+                            "start_time": "196.54",
+                            "speaker_label": "spk_1",
+                            "end_time": "196.68"
+                        },
+                        {
+                            "start_time": "196.68",
+                            "speaker_label": "spk_1",
+                            "end_time": "196.88"
+                        },
+                        {
+                            "start_time": "196.88",
+                            "speaker_label": "spk_1",
+                            "end_time": "197.04"
+                        },
+                        {
+                            "start_time": "197.04",
+                            "speaker_label": "spk_1",
+                            "end_time": "197.39"
+                        },
+                        {
+                            "start_time": "197.39",
+                            "speaker_label": "spk_1",
+                            "end_time": "197.47"
+                        },
+                        {
+                            "start_time": "197.47",
+                            "speaker_label": "spk_1",
+                            "end_time": "197.88"
+                        },
+                        {
+                            "start_time": "197.88",
+                            "speaker_label": "spk_1",
+                            "end_time": "198.01"
+                        },
+                        {
+                            "start_time": "198.01",
+                            "speaker_label": "spk_1",
+                            "end_time": "198.14"
+                        },
+                        {
+                            "start_time": "198.14",
+                            "speaker_label": "spk_1",
+                            "end_time": "198.33"
+                        },
+                        {
+                            "start_time": "198.33",
+                            "speaker_label": "spk_1",
+                            "end_time": "198.39"
+                        },
+                        {
+                            "start_time": "198.39",
+                            "speaker_label": "spk_1",
+                            "end_time": "198.77"
+                        },
+                        {
+                            "start_time": "198.77",
+                            "speaker_label": "spk_1",
+                            "end_time": "199.19"
+                        },
+                        {
+                            "start_time": "199.19",
+                            "speaker_label": "spk_1",
+                            "end_time": "199.36"
+                        },
+                        {
+                            "start_time": "199.36",
+                            "speaker_label": "spk_1",
+                            "end_time": "199.6"
+                        },
+                        {
+                            "start_time": "199.6",
+                            "speaker_label": "spk_1",
+                            "end_time": "199.7"
+                        },
+                        {
+                            "start_time": "199.7",
+                            "speaker_label": "spk_1",
+                            "end_time": "200.26"
+                        },
+                        {
+                            "start_time": "200.7",
+                            "speaker_label": "spk_1",
+                            "end_time": "201.23"
+                        },
+                        {
+                            "start_time": "201.23",
+                            "speaker_label": "spk_1",
+                            "end_time": "201.35"
+                        },
+                        {
+                            "start_time": "201.35",
+                            "speaker_label": "spk_1",
+                            "end_time": "201.71"
+                        },
+                        {
+                            "start_time": "201.71",
+                            "speaker_label": "spk_1",
+                            "end_time": "201.79"
+                        },
+                        {
+                            "start_time": "201.79",
+                            "speaker_label": "spk_1",
+                            "end_time": "202.02"
+                        },
+                        {
+                            "start_time": "202.02",
+                            "speaker_label": "spk_1",
+                            "end_time": "202.18"
+                        },
+                        {
+                            "start_time": "202.19",
+                            "speaker_label": "spk_1",
+                            "end_time": "202.5"
+                        },
+                        {
+                            "start_time": "202.51",
+                            "speaker_label": "spk_1",
+                            "end_time": "202.83"
+                        },
+                        {
+                            "start_time": "202.83",
+                            "speaker_label": "spk_1",
+                            "end_time": "203.33"
+                        },
+                        {
+                            "start_time": "203.33",
+                            "speaker_label": "spk_1",
+                            "end_time": "203.44"
+                        },
+                        {
+                            "start_time": "203.44",
+                            "speaker_label": "spk_1",
+                            "end_time": "203.64"
+                        },
+                        {
+                            "start_time": "203.64",
+                            "speaker_label": "spk_1",
+                            "end_time": "203.94"
+                        },
+                        {
+                            "start_time": "203.94",
+                            "speaker_label": "spk_1",
+                            "end_time": "204.19"
+                        },
+                        {
+                            "start_time": "204.19",
+                            "speaker_label": "spk_1",
+                            "end_time": "204.6"
+                        },
+                        {
+                            "start_time": "204.6",
+                            "speaker_label": "spk_1",
+                            "end_time": "204.88"
+                        },
+                        {
+                            "start_time": "204.88",
+                            "speaker_label": "spk_1",
+                            "end_time": "204.93"
+                        },
+                        {
+                            "start_time": "204.93",
+                            "speaker_label": "spk_1",
+                            "end_time": "205.12"
+                        },
+                        {
+                            "start_time": "205.12",
+                            "speaker_label": "spk_1",
+                            "end_time": "205.32"
+                        },
+                        {
+                            "start_time": "205.68",
+                            "speaker_label": "spk_1",
+                            "end_time": "205.86"
+                        },
+                        {
+                            "start_time": "205.86",
+                            "speaker_label": "spk_1",
+                            "end_time": "206.18"
+                        },
+                        {
+                            "start_time": "206.18",
+                            "speaker_label": "spk_1",
+                            "end_time": "206.45"
+                        },
+                        {
+                            "start_time": "206.45",
+                            "speaker_label": "spk_1",
+                            "end_time": "206.67"
+                        },
+                        {
+                            "start_time": "206.67",
+                            "speaker_label": "spk_1",
+                            "end_time": "206.93"
+                        },
+                        {
+                            "start_time": "206.97",
+                            "speaker_label": "spk_1",
+                            "end_time": "207.4"
+                        },
+                        {
+                            "start_time": "207.4",
+                            "speaker_label": "spk_1",
+                            "end_time": "207.62"
+                        },
+                        {
+                            "start_time": "207.62",
+                            "speaker_label": "spk_1",
+                            "end_time": "208.0"
+                        },
+                        {
+                            "start_time": "208.0",
+                            "speaker_label": "spk_1",
+                            "end_time": "208.08"
+                        },
+                        {
+                            "start_time": "208.08",
+                            "speaker_label": "spk_1",
+                            "end_time": "208.14"
+                        },
+                        {
+                            "start_time": "208.14",
+                            "speaker_label": "spk_1",
+                            "end_time": "208.42"
+                        },
+                        {
+                            "start_time": "208.42",
+                            "speaker_label": "spk_1",
+                            "end_time": "208.63"
+                        },
+                        {
+                            "start_time": "208.64",
+                            "speaker_label": "spk_1",
+                            "end_time": "209.08"
+                        },
+                        {
+                            "start_time": "209.08",
+                            "speaker_label": "spk_1",
+                            "end_time": "209.74"
+                        },
+                        {
+                            "start_time": "209.74",
+                            "speaker_label": "spk_1",
+                            "end_time": "210.11"
+                        },
+                        {
+                            "start_time": "210.12",
+                            "speaker_label": "spk_1",
+                            "end_time": "210.29"
+                        },
+                        {
+                            "start_time": "210.29",
+                            "speaker_label": "spk_1",
+                            "end_time": "210.42"
+                        },
+                        {
+                            "start_time": "210.42",
+                            "speaker_label": "spk_1",
+                            "end_time": "210.86"
+                        },
+                        {
+                            "start_time": "210.86",
+                            "speaker_label": "spk_1",
+                            "end_time": "210.94"
+                        },
+                        {
+                            "start_time": "210.94",
+                            "speaker_label": "spk_1",
+                            "end_time": "211.03"
+                        },
+                        {
+                            "start_time": "211.03",
+                            "speaker_label": "spk_1",
+                            "end_time": "211.32"
+                        },
+                        {
+                            "start_time": "211.32",
+                            "speaker_label": "spk_1",
+                            "end_time": "211.69"
+                        },
+                        {
+                            "start_time": "211.69",
+                            "speaker_label": "spk_1",
+                            "end_time": "211.97"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "211.97",
+                    "speaker_label": "",
+                    "end_time": "212.03",
+                    "items": []
+                },
+                {
+                    "start_time": "212.36",
+                    "speaker_label": "spk_1",
+                    "end_time": "223.63",
+                    "items": [
+                        {
+                            "start_time": "212.36",
+                            "speaker_label": "spk_1",
+                            "end_time": "212.64"
+                        },
+                        {
+                            "start_time": "212.64",
+                            "speaker_label": "spk_1",
+                            "end_time": "213.05"
+                        },
+                        {
+                            "start_time": "213.05",
+                            "speaker_label": "spk_1",
+                            "end_time": "213.52"
+                        },
+                        {
+                            "start_time": "213.52",
+                            "speaker_label": "spk_1",
+                            "end_time": "214.29"
+                        },
+                        {
+                            "start_time": "214.54",
+                            "speaker_label": "spk_1",
+                            "end_time": "214.96"
+                        },
+                        {
+                            "start_time": "214.96",
+                            "speaker_label": "spk_1",
+                            "end_time": "215.33"
+                        },
+                        {
+                            "start_time": "215.34",
+                            "speaker_label": "spk_1",
+                            "end_time": "215.42"
+                        },
+                        {
+                            "start_time": "215.42",
+                            "speaker_label": "spk_1",
+                            "end_time": "215.9"
+                        },
+                        {
+                            "start_time": "215.9",
+                            "speaker_label": "spk_1",
+                            "end_time": "216.39"
+                        },
+                        {
+                            "start_time": "216.53",
+                            "speaker_label": "spk_1",
+                            "end_time": "216.75"
+                        },
+                        {
+                            "start_time": "216.75",
+                            "speaker_label": "spk_1",
+                            "end_time": "216.88"
+                        },
+                        {
+                            "start_time": "216.88",
+                            "speaker_label": "spk_1",
+                            "end_time": "217.18"
+                        },
+                        {
+                            "start_time": "217.18",
+                            "speaker_label": "spk_1",
+                            "end_time": "217.59"
+                        },
+                        {
+                            "start_time": "217.59",
+                            "speaker_label": "spk_1",
+                            "end_time": "218.01"
+                        },
+                        {
+                            "start_time": "218.01",
+                            "speaker_label": "spk_1",
+                            "end_time": "218.45"
+                        },
+                        {
+                            "start_time": "218.45",
+                            "speaker_label": "spk_1",
+                            "end_time": "218.6"
+                        },
+                        {
+                            "start_time": "218.6",
+                            "speaker_label": "spk_1",
+                            "end_time": "218.82"
+                        },
+                        {
+                            "start_time": "218.82",
+                            "speaker_label": "spk_1",
+                            "end_time": "219.47"
+                        },
+                        {
+                            "start_time": "219.86",
+                            "speaker_label": "spk_1",
+                            "end_time": "220.04"
+                        },
+                        {
+                            "start_time": "220.04",
+                            "speaker_label": "spk_1",
+                            "end_time": "220.37"
+                        },
+                        {
+                            "start_time": "220.37",
+                            "speaker_label": "spk_1",
+                            "end_time": "221.38"
+                        },
+                        {
+                            "start_time": "221.39",
+                            "speaker_label": "spk_1",
+                            "end_time": "221.77"
+                        },
+                        {
+                            "start_time": "221.77",
+                            "speaker_label": "spk_1",
+                            "end_time": "222.17"
+                        },
+                        {
+                            "start_time": "222.17",
+                            "speaker_label": "spk_1",
+                            "end_time": "222.52"
+                        },
+                        {
+                            "start_time": "222.52",
+                            "speaker_label": "spk_1",
+                            "end_time": "223.01"
+                        },
+                        {
+                            "start_time": "223.01",
+                            "speaker_label": "spk_1",
+                            "end_time": "223.1"
+                        },
+                        {
+                            "start_time": "223.1",
+                            "speaker_label": "spk_1",
+                            "end_time": "223.63"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "227.12",
+                    "speaker_label": "spk_0",
+                    "end_time": "229.52",
+                    "items": [
+                        {
+                            "start_time": "227.12",
+                            "speaker_label": "spk_0",
+                            "end_time": "227.26"
+                        },
+                        {
+                            "start_time": "227.27",
+                            "speaker_label": "spk_0",
+                            "end_time": "227.33"
+                        },
+                        {
+                            "start_time": "227.72",
+                            "speaker_label": "spk_0",
+                            "end_time": "227.94"
+                        },
+                        {
+                            "start_time": "227.94",
+                            "speaker_label": "spk_0",
+                            "end_time": "228.24"
+                        },
+                        {
+                            "start_time": "228.24",
+                            "speaker_label": "spk_0",
+                            "end_time": "228.42"
+                        },
+                        {
+                            "start_time": "228.42",
+                            "speaker_label": "spk_0",
+                            "end_time": "228.51"
+                        },
+                        {
+                            "start_time": "228.51",
+                            "speaker_label": "spk_0",
+                            "end_time": "228.94"
+                        },
+                        {
+                            "start_time": "228.94",
+                            "speaker_label": "spk_0",
+                            "end_time": "229.08"
+                        },
+                        {
+                            "start_time": "229.08",
+                            "speaker_label": "spk_0",
+                            "end_time": "229.52"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "232.22",
+                    "speaker_label": "spk_1",
+                    "end_time": "242.863",
+                    "items": [
+                        {
+                            "start_time": "232.22",
+                            "speaker_label": "spk_1",
+                            "end_time": "232.74"
+                        },
+                        {
+                            "start_time": "232.74",
+                            "speaker_label": "spk_1",
+                            "end_time": "232.8"
+                        },
+                        {
+                            "start_time": "232.8",
+                            "speaker_label": "spk_1",
+                            "end_time": "233.11"
+                        },
+                        {
+                            "start_time": "233.11",
+                            "speaker_label": "spk_1",
+                            "end_time": "233.22"
+                        },
+                        {
+                            "start_time": "233.22",
+                            "speaker_label": "spk_1",
+                            "end_time": "233.39"
+                        },
+                        {
+                            "start_time": "233.39",
+                            "speaker_label": "spk_1",
+                            "end_time": "233.71"
+                        },
+                        {
+                            "start_time": "233.71",
+                            "speaker_label": "spk_1",
+                            "end_time": "233.79"
+                        },
+                        {
+                            "start_time": "233.79",
+                            "speaker_label": "spk_1",
+                            "end_time": "233.89"
+                        },
+                        {
+                            "start_time": "233.89",
+                            "speaker_label": "spk_1",
+                            "end_time": "234.24"
+                        },
+                        {
+                            "start_time": "234.24",
+                            "speaker_label": "spk_1",
+                            "end_time": "234.28"
+                        },
+                        {
+                            "start_time": "234.28",
+                            "speaker_label": "spk_1",
+                            "end_time": "234.42"
+                        },
+                        {
+                            "start_time": "234.42",
+                            "speaker_label": "spk_1",
+                            "end_time": "234.59"
+                        },
+                        {
+                            "start_time": "234.59",
+                            "speaker_label": "spk_1",
+                            "end_time": "234.68"
+                        },
+                        {
+                            "start_time": "234.68",
+                            "speaker_label": "spk_1",
+                            "end_time": "235.02"
+                        },
+                        {
+                            "start_time": "235.02",
+                            "speaker_label": "spk_1",
+                            "end_time": "235.36"
+                        },
+                        {
+                            "start_time": "235.36",
+                            "speaker_label": "spk_1",
+                            "end_time": "235.55"
+                        },
+                        {
+                            "start_time": "235.55",
+                            "speaker_label": "spk_1",
+                            "end_time": "235.61"
+                        },
+                        {
+                            "start_time": "235.61",
+                            "speaker_label": "spk_1",
+                            "end_time": "236.49"
+                        },
+                        {
+                            "start_time": "236.65",
+                            "speaker_label": "spk_1",
+                            "end_time": "237.69"
+                        },
+                        {
+                            "start_time": "237.69",
+                            "speaker_label": "spk_1",
+                            "end_time": "238.4"
+                        },
+                        {
+                            "start_time": "238.4",
+                            "speaker_label": "spk_1",
+                            "end_time": "238.79"
+                        },
+                        {
+                            "start_time": "238.88",
+                            "speaker_label": "spk_1",
+                            "end_time": "239.38"
+                        },
+                        {
+                            "start_time": "239.38",
+                            "speaker_label": "spk_1",
+                            "end_time": "239.92"
+                        },
+                        {
+                            "start_time": "239.92",
+                            "speaker_label": "spk_1",
+                            "end_time": "240.11"
+                        },
+                        {
+                            "start_time": "240.11",
+                            "speaker_label": "spk_1",
+                            "end_time": "240.5"
+                        },
+                        {
+                            "start_time": "240.863",
+                            "speaker_label": "spk_1",
+                            "end_time": "241.163"
+                        },
+                        {
+                            "start_time": "241.163",
+                            "speaker_label": "spk_1",
+                            "end_time": "241.493"
+                        },
+                        {
+                            "start_time": "241.493",
+                            "speaker_label": "spk_1",
+                            "end_time": "241.653"
+                        },
+                        {
+                            "start_time": "241.653",
+                            "speaker_label": "spk_1",
+                            "end_time": "241.713"
+                        },
+                        {
+                            "start_time": "241.713",
+                            "speaker_label": "spk_1",
+                            "end_time": "241.993"
+                        },
+                        {
+                            "start_time": "241.993",
+                            "speaker_label": "spk_1",
+                            "end_time": "242.383"
+                        },
+                        {
+                            "start_time": "242.383",
+                            "speaker_label": "spk_1",
+                            "end_time": "242.863"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "244.533",
+                    "speaker_label": "spk_1",
+                    "end_time": "260.063",
+                    "items": [
+                        {
+                            "start_time": "244.533",
+                            "speaker_label": "spk_1",
+                            "end_time": "244.613"
+                        },
+                        {
+                            "start_time": "244.613",
+                            "speaker_label": "spk_1",
+                            "end_time": "244.773"
+                        },
+                        {
+                            "start_time": "244.773",
+                            "speaker_label": "spk_1",
+                            "end_time": "245.063"
+                        },
+                        {
+                            "start_time": "245.063",
+                            "speaker_label": "spk_1",
+                            "end_time": "245.263"
+                        },
+                        {
+                            "start_time": "245.263",
+                            "speaker_label": "spk_1",
+                            "end_time": "245.383"
+                        },
+                        {
+                            "start_time": "245.383",
+                            "speaker_label": "spk_1",
+                            "end_time": "245.553"
+                        },
+                        {
+                            "start_time": "245.553",
+                            "speaker_label": "spk_1",
+                            "end_time": "245.943"
+                        },
+                        {
+                            "start_time": "245.943",
+                            "speaker_label": "spk_1",
+                            "end_time": "246.053"
+                        },
+                        {
+                            "start_time": "246.053",
+                            "speaker_label": "spk_1",
+                            "end_time": "246.233"
+                        },
+                        {
+                            "start_time": "246.233",
+                            "speaker_label": "spk_1",
+                            "end_time": "246.773"
+                        },
+                        {
+                            "start_time": "246.923",
+                            "speaker_label": "spk_1",
+                            "end_time": "247.153"
+                        },
+                        {
+                            "start_time": "247.153",
+                            "speaker_label": "spk_1",
+                            "end_time": "247.403"
+                        },
+                        {
+                            "start_time": "247.403",
+                            "speaker_label": "spk_1",
+                            "end_time": "248.083"
+                        },
+                        {
+                            "start_time": "248.083",
+                            "speaker_label": "spk_1",
+                            "end_time": "248.553"
+                        },
+                        {
+                            "start_time": "248.553",
+                            "speaker_label": "spk_1",
+                            "end_time": "249.263"
+                        },
+                        {
+                            "start_time": "249.753",
+                            "speaker_label": "spk_1",
+                            "end_time": "250.223"
+                        },
+                        {
+                            "start_time": "250.223",
+                            "speaker_label": "spk_1",
+                            "end_time": "250.303"
+                        },
+                        {
+                            "start_time": "250.303",
+                            "speaker_label": "spk_1",
+                            "end_time": "250.683"
+                        },
+                        {
+                            "start_time": "250.693",
+                            "speaker_label": "spk_1",
+                            "end_time": "250.873"
+                        },
+                        {
+                            "start_time": "250.873",
+                            "speaker_label": "spk_1",
+                            "end_time": "251.343"
+                        },
+                        {
+                            "start_time": "251.793",
+                            "speaker_label": "spk_1",
+                            "end_time": "252.053"
+                        },
+                        {
+                            "start_time": "252.053",
+                            "speaker_label": "spk_1",
+                            "end_time": "252.453"
+                        },
+                        {
+                            "start_time": "252.653",
+                            "speaker_label": "spk_1",
+                            "end_time": "252.873"
+                        },
+                        {
+                            "start_time": "252.873",
+                            "speaker_label": "spk_1",
+                            "end_time": "253.113"
+                        },
+                        {
+                            "start_time": "253.113",
+                            "speaker_label": "spk_1",
+                            "end_time": "253.243"
+                        },
+                        {
+                            "start_time": "253.253",
+                            "speaker_label": "spk_1",
+                            "end_time": "253.653"
+                        },
+                        {
+                            "start_time": "253.653",
+                            "speaker_label": "spk_1",
+                            "end_time": "254.013"
+                        },
+                        {
+                            "start_time": "254.013",
+                            "speaker_label": "spk_1",
+                            "end_time": "254.113"
+                        },
+                        {
+                            "start_time": "254.113",
+                            "speaker_label": "spk_1",
+                            "end_time": "254.243"
+                        },
+                        {
+                            "start_time": "254.243",
+                            "speaker_label": "spk_1",
+                            "end_time": "254.603"
+                        },
+                        {
+                            "start_time": "254.603",
+                            "speaker_label": "spk_1",
+                            "end_time": "255.123"
+                        },
+                        {
+                            "start_time": "255.123",
+                            "speaker_label": "spk_1",
+                            "end_time": "255.443"
+                        },
+                        {
+                            "start_time": "255.453",
+                            "speaker_label": "spk_1",
+                            "end_time": "255.703"
+                        },
+                        {
+                            "start_time": "255.703",
+                            "speaker_label": "spk_1",
+                            "end_time": "255.783"
+                        },
+                        {
+                            "start_time": "255.783",
+                            "speaker_label": "spk_1",
+                            "end_time": "256.173"
+                        },
+                        {
+                            "start_time": "256.173",
+                            "speaker_label": "spk_1",
+                            "end_time": "256.463"
+                        },
+                        {
+                            "start_time": "256.463",
+                            "speaker_label": "spk_1",
+                            "end_time": "257.023"
+                        },
+                        {
+                            "start_time": "257.023",
+                            "speaker_label": "spk_1",
+                            "end_time": "257.583"
+                        },
+                        {
+                            "start_time": "257.593",
+                            "speaker_label": "spk_1",
+                            "end_time": "257.823"
+                        },
+                        {
+                            "start_time": "257.823",
+                            "speaker_label": "spk_1",
+                            "end_time": "257.963"
+                        },
+                        {
+                            "start_time": "257.963",
+                            "speaker_label": "spk_1",
+                            "end_time": "258.133"
+                        },
+                        {
+                            "start_time": "258.133",
+                            "speaker_label": "spk_1",
+                            "end_time": "259.103"
+                        },
+                        {
+                            "start_time": "259.103",
+                            "speaker_label": "spk_1",
+                            "end_time": "259.403"
+                        },
+                        {
+                            "start_time": "259.403",
+                            "speaker_label": "spk_1",
+                            "end_time": "259.493"
+                        },
+                        {
+                            "start_time": "259.493",
+                            "speaker_label": "spk_1",
+                            "end_time": "260.063"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "260.653",
+                    "speaker_label": "spk_1",
+                    "end_time": "265.063",
+                    "items": [
+                        {
+                            "start_time": "260.653",
+                            "speaker_label": "spk_1",
+                            "end_time": "260.883"
+                        },
+                        {
+                            "start_time": "260.883",
+                            "speaker_label": "spk_1",
+                            "end_time": "260.973"
+                        },
+                        {
+                            "start_time": "260.973",
+                            "speaker_label": "spk_1",
+                            "end_time": "261.413"
+                        },
+                        {
+                            "start_time": "261.413",
+                            "speaker_label": "spk_1",
+                            "end_time": "261.803"
+                        },
+                        {
+                            "start_time": "261.813",
+                            "speaker_label": "spk_1",
+                            "end_time": "262.783"
+                        },
+                        {
+                            "start_time": "262.783",
+                            "speaker_label": "spk_1",
+                            "end_time": "263.853"
+                        },
+                        {
+                            "start_time": "263.853",
+                            "speaker_label": "spk_1",
+                            "end_time": "264.333"
+                        },
+                        {
+                            "start_time": "264.333",
+                            "speaker_label": "spk_1",
+                            "end_time": "264.453"
+                        },
+                        {
+                            "start_time": "264.453",
+                            "speaker_label": "spk_1",
+                            "end_time": "265.063"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "265.953",
+                    "speaker_label": "spk_1",
+                    "end_time": "271.263",
+                    "items": [
+                        {
+                            "start_time": "265.953",
+                            "speaker_label": "spk_1",
+                            "end_time": "266.243"
+                        },
+                        {
+                            "start_time": "266.243",
+                            "speaker_label": "spk_1",
+                            "end_time": "266.363"
+                        },
+                        {
+                            "start_time": "266.363",
+                            "speaker_label": "spk_1",
+                            "end_time": "266.523"
+                        },
+                        {
+                            "start_time": "266.523",
+                            "speaker_label": "spk_1",
+                            "end_time": "267.003"
+                        },
+                        {
+                            "start_time": "267.003",
+                            "speaker_label": "spk_1",
+                            "end_time": "267.383"
+                        },
+                        {
+                            "start_time": "267.383",
+                            "speaker_label": "spk_1",
+                            "end_time": "267.473"
+                        },
+                        {
+                            "start_time": "267.473",
+                            "speaker_label": "spk_1",
+                            "end_time": "267.893"
+                        },
+                        {
+                            "start_time": "267.893",
+                            "speaker_label": "spk_1",
+                            "end_time": "268.193"
+                        },
+                        {
+                            "start_time": "268.203",
+                            "speaker_label": "spk_1",
+                            "end_time": "268.533"
+                        },
+                        {
+                            "start_time": "268.533",
+                            "speaker_label": "spk_1",
+                            "end_time": "268.953"
+                        },
+                        {
+                            "start_time": "268.953",
+                            "speaker_label": "spk_1",
+                            "end_time": "269.133"
+                        },
+                        {
+                            "start_time": "269.133",
+                            "speaker_label": "spk_1",
+                            "end_time": "269.343"
+                        },
+                        {
+                            "start_time": "269.343",
+                            "speaker_label": "spk_1",
+                            "end_time": "269.903"
+                        },
+                        {
+                            "start_time": "269.913",
+                            "speaker_label": "spk_1",
+                            "end_time": "270.073"
+                        },
+                        {
+                            "start_time": "270.073",
+                            "speaker_label": "spk_1",
+                            "end_time": "270.383"
+                        },
+                        {
+                            "start_time": "270.383",
+                            "speaker_label": "spk_1",
+                            "end_time": "270.753"
+                        },
+                        {
+                            "start_time": "270.763",
+                            "speaker_label": "spk_1",
+                            "end_time": "271.263"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "271.953",
+                    "speaker_label": "spk_1",
+                    "end_time": "273.963",
+                    "items": [
+                        {
+                            "start_time": "271.953",
+                            "speaker_label": "spk_1",
+                            "end_time": "272.253"
+                        },
+                        {
+                            "start_time": "272.253",
+                            "speaker_label": "spk_1",
+                            "end_time": "272.613"
+                        },
+                        {
+                            "start_time": "272.613",
+                            "speaker_label": "spk_1",
+                            "end_time": "272.723"
+                        },
+                        {
+                            "start_time": "272.723",
+                            "speaker_label": "spk_1",
+                            "end_time": "272.843"
+                        },
+                        {
+                            "start_time": "272.843",
+                            "speaker_label": "spk_1",
+                            "end_time": "272.913"
+                        },
+                        {
+                            "start_time": "272.913",
+                            "speaker_label": "spk_1",
+                            "end_time": "273.243"
+                        },
+                        {
+                            "start_time": "273.243",
+                            "speaker_label": "spk_1",
+                            "end_time": "273.663"
+                        },
+                        {
+                            "start_time": "273.663",
+                            "speaker_label": "spk_1",
+                            "end_time": "273.963"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "275.033",
+                    "speaker_label": "spk_1",
+                    "end_time": "296.073",
+                    "items": [
+                        {
+                            "start_time": "275.033",
+                            "speaker_label": "spk_1",
+                            "end_time": "275.683"
+                        },
+                        {
+                            "start_time": "275.683",
+                            "speaker_label": "spk_1",
+                            "end_time": "276.063"
+                        },
+                        {
+                            "start_time": "276.063",
+                            "speaker_label": "spk_1",
+                            "end_time": "276.233"
+                        },
+                        {
+                            "start_time": "276.233",
+                            "speaker_label": "spk_1",
+                            "end_time": "276.383"
+                        },
+                        {
+                            "start_time": "276.383",
+                            "speaker_label": "spk_1",
+                            "end_time": "276.693"
+                        },
+                        {
+                            "start_time": "276.693",
+                            "speaker_label": "spk_1",
+                            "end_time": "276.873"
+                        },
+                        {
+                            "start_time": "276.873",
+                            "speaker_label": "spk_1",
+                            "end_time": "277.383"
+                        },
+                        {
+                            "start_time": "277.383",
+                            "speaker_label": "spk_1",
+                            "end_time": "277.723"
+                        },
+                        {
+                            "start_time": "277.733",
+                            "speaker_label": "spk_1",
+                            "end_time": "278.253"
+                        },
+                        {
+                            "start_time": "278.673",
+                            "speaker_label": "spk_1",
+                            "end_time": "279.563"
+                        },
+                        {
+                            "start_time": "279.573",
+                            "speaker_label": "spk_1",
+                            "end_time": "279.713"
+                        },
+                        {
+                            "start_time": "279.723",
+                            "speaker_label": "spk_1",
+                            "end_time": "279.813"
+                        },
+                        {
+                            "start_time": "279.823",
+                            "speaker_label": "spk_1",
+                            "end_time": "280.393"
+                        },
+                        {
+                            "start_time": "280.393",
+                            "speaker_label": "spk_1",
+                            "end_time": "280.503"
+                        },
+                        {
+                            "start_time": "280.503",
+                            "speaker_label": "spk_1",
+                            "end_time": "280.573"
+                        },
+                        {
+                            "start_time": "280.573",
+                            "speaker_label": "spk_1",
+                            "end_time": "280.873"
+                        },
+                        {
+                            "start_time": "280.873",
+                            "speaker_label": "spk_1",
+                            "end_time": "281.383"
+                        },
+                        {
+                            "start_time": "281.383",
+                            "speaker_label": "spk_1",
+                            "end_time": "281.623"
+                        },
+                        {
+                            "start_time": "281.623",
+                            "speaker_label": "spk_1",
+                            "end_time": "281.793"
+                        },
+                        {
+                            "start_time": "281.803",
+                            "speaker_label": "spk_1",
+                            "end_time": "282.823"
+                        },
+                        {
+                            "start_time": "282.823",
+                            "speaker_label": "spk_1",
+                            "end_time": "283.423"
+                        },
+                        {
+                            "start_time": "283.423",
+                            "speaker_label": "spk_1",
+                            "end_time": "283.863"
+                        },
+                        {
+                            "start_time": "284.253",
+                            "speaker_label": "spk_1",
+                            "end_time": "284.463"
+                        },
+                        {
+                            "start_time": "284.463",
+                            "speaker_label": "spk_1",
+                            "end_time": "284.953"
+                        },
+                        {
+                            "start_time": "284.953",
+                            "speaker_label": "spk_1",
+                            "end_time": "285.563"
+                        },
+                        {
+                            "start_time": "285.563",
+                            "speaker_label": "spk_1",
+                            "end_time": "285.973"
+                        },
+                        {
+                            "start_time": "285.973",
+                            "speaker_label": "spk_1",
+                            "end_time": "286.173"
+                        },
+                        {
+                            "start_time": "286.173",
+                            "speaker_label": "spk_1",
+                            "end_time": "286.273"
+                        },
+                        {
+                            "start_time": "286.273",
+                            "speaker_label": "spk_1",
+                            "end_time": "286.713"
+                        },
+                        {
+                            "start_time": "286.713",
+                            "speaker_label": "spk_1",
+                            "end_time": "286.933"
+                        },
+                        {
+                            "start_time": "286.933",
+                            "speaker_label": "spk_1",
+                            "end_time": "287.013"
+                        },
+                        {
+                            "start_time": "287.013",
+                            "speaker_label": "spk_1",
+                            "end_time": "287.243"
+                        },
+                        {
+                            "start_time": "287.243",
+                            "speaker_label": "spk_1",
+                            "end_time": "287.423"
+                        },
+                        {
+                            "start_time": "287.423",
+                            "speaker_label": "spk_1",
+                            "end_time": "287.603"
+                        },
+                        {
+                            "start_time": "287.603",
+                            "speaker_label": "spk_1",
+                            "end_time": "288.143"
+                        },
+                        {
+                            "start_time": "288.243",
+                            "speaker_label": "spk_1",
+                            "end_time": "288.733"
+                        },
+                        {
+                            "start_time": "288.733",
+                            "speaker_label": "spk_1",
+                            "end_time": "289.113"
+                        },
+                        {
+                            "start_time": "289.123",
+                            "speaker_label": "spk_1",
+                            "end_time": "289.493"
+                        },
+                        {
+                            "start_time": "289.503",
+                            "speaker_label": "spk_1",
+                            "end_time": "290.033"
+                        },
+                        {
+                            "start_time": "290.033",
+                            "speaker_label": "spk_1",
+                            "end_time": "290.373"
+                        },
+                        {
+                            "start_time": "290.373",
+                            "speaker_label": "spk_1",
+                            "end_time": "290.983"
+                        },
+                        {
+                            "start_time": "290.993",
+                            "speaker_label": "spk_1",
+                            "end_time": "291.183"
+                        },
+                        {
+                            "start_time": "291.183",
+                            "speaker_label": "spk_1",
+                            "end_time": "292.223"
+                        },
+                        {
+                            "start_time": "292.523",
+                            "speaker_label": "spk_1",
+                            "end_time": "292.703"
+                        },
+                        {
+                            "start_time": "292.703",
+                            "speaker_label": "spk_1",
+                            "end_time": "293.113"
+                        },
+                        {
+                            "start_time": "293.113",
+                            "speaker_label": "spk_1",
+                            "end_time": "293.463"
+                        },
+                        {
+                            "start_time": "293.463",
+                            "speaker_label": "spk_1",
+                            "end_time": "293.723"
+                        },
+                        {
+                            "start_time": "293.733",
+                            "speaker_label": "spk_1",
+                            "end_time": "294.303"
+                        },
+                        {
+                            "start_time": "294.303",
+                            "speaker_label": "spk_1",
+                            "end_time": "294.853"
+                        },
+                        {
+                            "start_time": "294.853",
+                            "speaker_label": "spk_1",
+                            "end_time": "295.203"
+                        },
+                        {
+                            "start_time": "295.203",
+                            "speaker_label": "spk_1",
+                            "end_time": "295.313"
+                        },
+                        {
+                            "start_time": "295.313",
+                            "speaker_label": "spk_1",
+                            "end_time": "296.073"
+                        }
+                    ]
+                },
+                {
+                    "start_time": "296.623",
+                    "speaker_label": "spk_1",
+                    "end_time": "301.363",
+                    "items": [
+                        {
+                            "start_time": "296.623",
+                            "speaker_label": "spk_1",
+                            "end_time": "296.723"
+                        },
+                        {
+                            "start_time": "296.723",
+                            "speaker_label": "spk_1",
+                            "end_time": "296.943"
+                        },
+                        {
+                            "start_time": "296.953",
+                            "speaker_label": "spk_1",
+                            "end_time": "297.693"
+                        },
+                        {
+                            "start_time": "297.703",
+                            "speaker_label": "spk_1",
+                            "end_time": "298.233"
+                        },
+                        {
+                            "start_time": "298.243",
+                            "speaker_label": "spk_1",
+                            "end_time": "298.633"
+                        },
+                        {
+                            "start_time": "298.633",
+                            "speaker_label": "spk_1",
+                            "end_time": "299.043"
+                        },
+                        {
+                            "start_time": "299.093",
+                            "speaker_label": "spk_1",
+                            "end_time": "299.423"
+                        },
+                        {
+                            "start_time": "299.423",
+                            "speaker_label": "spk_1",
+                            "end_time": "299.783"
+                        },
+                        {
+                            "start_time": "299.793",
+                            "speaker_label": "spk_1",
+                            "end_time": "300.043"
+                        },
+                        {
+                            "start_time": "300.043",
+                            "speaker_label": "spk_1",
+                            "end_time": "300.553"
+                        },
+                        {
+                            "start_time": "300.553",
+                            "speaker_label": "spk_1",
+                            "end_time": "300.933"
+                        },
+                        {
+                            "start_time": "300.933",
+                            "speaker_label": "spk_1",
+                            "end_time": "301.363"
+                        }
+                    ]
+                }
+            ]
+        },
+        "items": [
+            {
+                "start_time": "5.24",
+                "end_time": "5.85",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "Today"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "6.3",
+                "end_time": "6.4",
+                "alternatives": [
+                    {
+                        "confidence": "0.9996",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "6.4",
+                "end_time": "7.24",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "devastation"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "7.25",
+                "end_time": "7.39",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "7.39",
+                "end_time": "7.96",
+                "alternatives": [
+                    {
+                        "confidence": "0.9762",
+                        "content": "Cyclone"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "7.97",
+                "end_time": "8.17",
+                "alternatives": [
+                    {
+                        "confidence": "0.873",
+                        "content": "e"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "8.17",
+                "end_time": "8.57",
+                "alternatives": [
+                    {
+                        "confidence": "0.7853",
+                        "content": "di"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "8.65",
+                "end_time": "8.98",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "one"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "8.98",
+                "end_time": "9.05",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "9.05",
+                "end_time": "9.15",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "9.15",
+                "end_time": "9.76",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "worst"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "9.76",
+                "end_time": "10.09",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "weather"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "10.09",
+                "end_time": "10.51",
+                "alternatives": [
+                    {
+                        "confidence": "0.9994",
+                        "content": "related"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "10.51",
+                "end_time": "11.07",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "disasters"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "11.07",
+                "end_time": "11.25",
+                "alternatives": [
+                    {
+                        "confidence": "0.3052",
+                        "content": "Toe"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "11.26",
+                "end_time": "11.49",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "ever"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "11.49",
+                "end_time": "11.79",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "hit"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "11.8",
+                "end_time": "11.92",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "11.92",
+                "end_time": "12.23",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Southern"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "12.23",
+                "end_time": "12.83",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Hemisphere"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "13.66",
+                "end_time": "13.98",
+                "alternatives": [
+                    {
+                        "confidence": "0.8944",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "13.98",
+                "end_time": "14.15",
+                "alternatives": [
+                    {
+                        "confidence": "0.8362",
+                        "content": "DH"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "14.47",
+                "end_time": "14.9",
+                "alternatives": [
+                    {
+                        "confidence": "0.8978",
+                        "content": "Sonya"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "14.9",
+                "end_time": "15.53",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Soda"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "15.71",
+                "end_time": "15.99",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "15.99",
+                "end_time": "16.2",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "what"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "16.2",
+                "end_time": "16.41",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "16.42",
+                "end_time": "16.88",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "earth"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "16.89",
+                "end_time": "17.11",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "is"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "17.12",
+                "end_time": "17.42",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "going"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "17.42",
+                "end_time": "17.54",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "17.54",
+                "end_time": "17.63",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "17.63",
+                "end_time": "18.25",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Parliament"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "?"
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "27.97",
+                "end_time": "28.19",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "The"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "28.19",
+                "end_time": "28.56",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "people"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "28.56",
+                "end_time": "28.71",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "who"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "28.71",
+                "end_time": "29.19",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "were"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "29.2",
+                "end_time": "29.64",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "perhaps"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "29.64",
+                "end_time": "29.71",
+                "alternatives": [
+                    {
+                        "confidence": "0.9967",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "29.71",
+                "end_time": "29.8",
+                "alternatives": [
+                    {
+                        "confidence": "0.9991",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "29.8",
+                "end_time": "30.08",
+                "alternatives": [
+                    {
+                        "confidence": "0.9975",
+                        "content": "worst"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "30.08",
+                "end_time": "30.6",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "situation"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "30.6",
+                "end_time": "30.69",
+                "alternatives": [
+                    {
+                        "confidence": "0.8797",
+                        "content": "with"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "30.69",
+                "end_time": "30.75",
+                "alternatives": [
+                    {
+                        "confidence": "0.9676",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "30.75",
+                "end_time": "31.06",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "people"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "31.06",
+                "end_time": "31.17",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "who"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "31.17",
+                "end_time": "31.25",
+                "alternatives": [
+                    {
+                        "confidence": "0.9287",
+                        "content": "were"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "31.25",
+                "end_time": "31.6",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "stuck"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "31.6",
+                "end_time": "31.69",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "31.69",
+                "end_time": "31.78",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "31.78",
+                "end_time": "32.27",
+                "alternatives": [
+                    {
+                        "confidence": "0.9905",
+                        "content": "trees"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "32.27",
+                "end_time": "32.72",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "because"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "33.03",
+                "end_time": "33.23",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "it"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "33.23",
+                "end_time": "33.51",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "wasn't"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "33.51",
+                "end_time": "33.77",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "just"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "33.77",
+                "end_time": "34.17",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "people"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "34.17",
+                "end_time": "34.31",
+                "alternatives": [
+                    {
+                        "confidence": "0.9794",
+                        "content": "who"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "34.31",
+                "end_time": "34.51",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "got"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "34.51",
+                "end_time": "34.86",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "driven"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "34.86",
+                "end_time": "35.1",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "up"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "35.1",
+                "end_time": "35.47",
+                "alternatives": [
+                    {
+                        "confidence": "0.9997",
+                        "content": "into"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "35.48",
+                "end_time": "35.81",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "into"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "35.81",
+                "end_time": "35.92",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "35.92",
+                "end_time": "36.3",
+                "alternatives": [
+                    {
+                        "confidence": "0.9996",
+                        "content": "trees"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "36.3",
+                "end_time": "36.48",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "by"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "36.48",
+                "end_time": "36.6",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "36.6",
+                "end_time": "36.9",
+                "alternatives": [
+                    {
+                        "confidence": "0.9994",
+                        "content": "water"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "36.9",
+                "end_time": "37.06",
+                "alternatives": [
+                    {
+                        "confidence": "0.9951",
+                        "content": "but"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "37.06",
+                "end_time": "37.54",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "snakes"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "37.54",
+                "end_time": "37.68",
+                "alternatives": [
+                    {
+                        "confidence": "0.9977",
+                        "content": "as"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "37.68",
+                "end_time": "38.03",
+                "alternatives": [
+                    {
+                        "confidence": "0.9995",
+                        "content": "well"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "38.03",
+                "end_time": "38.21",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "And"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "38.21",
+                "end_time": "38.56",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "people"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "38.56",
+                "end_time": "38.85",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "getting"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "38.85",
+                "end_time": "39.15",
+                "alternatives": [
+                    {
+                        "confidence": "0.9292",
+                        "content": "bitten"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "39.15",
+                "end_time": "39.35",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "while"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "39.35",
+                "end_time": "39.49",
+                "alternatives": [
+                    {
+                        "confidence": "0.9897",
+                        "content": "they're"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "39.49",
+                "end_time": "39.65",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "up"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "39.65",
+                "end_time": "39.74",
+                "alternatives": [
+                    {
+                        "confidence": "0.9989",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "39.74",
+                "end_time": "39.82",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "39.82",
+                "end_time": "40.31",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "trees"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "40.53",
+                "end_time": "40.63",
+                "alternatives": [
+                    {
+                        "confidence": "0.9976",
+                        "content": "Oh"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "40.63",
+                "end_time": "40.76",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "my"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "40.76",
+                "end_time": "41.02",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "God"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "41.02",
+                "end_time": "41.16",
+                "alternatives": [
+                    {
+                        "confidence": "0.9952",
+                        "content": "it's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "41.16",
+                "end_time": "41.99",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "terrifying"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "42.21",
+                "end_time": "42.4",
+                "alternatives": [
+                    {
+                        "confidence": "0.9661",
+                        "content": "Yeah"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "42.4",
+                "end_time": "42.55",
+                "alternatives": [
+                    {
+                        "confidence": "0.9797",
+                        "content": "it's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "42.55",
+                "end_time": "43.28",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "terrifying"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "43.29",
+                "end_time": "43.56",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Kind"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "43.56",
+                "end_time": "43.64",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "43.64",
+                "end_time": "44.17",
+                "alternatives": [
+                    {
+                        "confidence": "0.9973",
+                        "content": "Imagine"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "44.17",
+                "end_time": "44.4",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "that"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "44.4",
+                "end_time": "44.74",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "choice"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "44.74",
+                "end_time": "44.83",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "44.84",
+                "end_time": "45.07",
+                "alternatives": [
+                    {
+                        "confidence": "0.9995",
+                        "content": "being"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "45.07",
+                "end_time": "45.16",
+                "alternatives": [
+                    {
+                        "confidence": "0.9995",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "45.16",
+                "end_time": "45.27",
+                "alternatives": [
+                    {
+                        "confidence": "0.9933",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "45.27",
+                "end_time": "45.63",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "tree"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "45.63",
+                "end_time": "45.85",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "46.24",
+                "end_time": "46.52",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "being"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "46.52",
+                "end_time": "46.61",
+                "alternatives": [
+                    {
+                        "confidence": "0.9995",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "46.61",
+                "end_time": "46.67",
+                "alternatives": [
+                    {
+                        "confidence": "0.9987",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "46.67",
+                "end_time": "47.1",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "tree"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "47.1",
+                "end_time": "47.51",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "above"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "47.51",
+                "end_time": "47.89",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "water"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "47.89",
+                "end_time": "48.0",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "48.0",
+                "end_time": "48.23",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "not"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "48.23",
+                "end_time": "48.55",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "knowing"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "48.55",
+                "end_time": "48.67",
+                "alternatives": [
+                    {
+                        "confidence": "0.9996",
+                        "content": "when"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "48.67",
+                "end_time": "48.75",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "48.75",
+                "end_time": "49.04",
+                "alternatives": [
+                    {
+                        "confidence": "0.8801",
+                        "content": "water"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "49.04",
+                "end_time": "49.13",
+                "alternatives": [
+                    {
+                        "confidence": "0.8801",
+                        "content": "is"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "49.13",
+                "end_time": "49.27",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "going"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "49.27",
+                "end_time": "49.35",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "to"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "49.35",
+                "end_time": "49.55",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "go"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "49.55",
+                "end_time": "49.92",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "away"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "49.92",
+                "end_time": "50.1",
+                "alternatives": [
+                    {
+                        "confidence": "0.9969",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "50.49",
+                "end_time": "50.78",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "not"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "50.78",
+                "end_time": "51.07",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "knowing"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "51.07",
+                "end_time": "51.26",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "how"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "51.26",
+                "end_time": "51.43",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "long"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "51.43",
+                "end_time": "51.53",
+                "alternatives": [
+                    {
+                        "confidence": "0.9612",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "51.53",
+                "end_time": "51.94",
+                "alternatives": [
+                    {
+                        "confidence": "0.895",
+                        "content": "consider"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "51.94",
+                "end_time": "52.02",
+                "alternatives": [
+                    {
+                        "confidence": "0.8266",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "52.02",
+                "end_time": "52.11",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "52.11",
+                "end_time": "52.4",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "tree"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "52.4",
+                "end_time": "52.92",
+                "alternatives": [
+                    {
+                        "confidence": "0.9995",
+                        "content": "for"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "52.93",
+                "end_time": "53.78",
+                "alternatives": [
+                    {
+                        "confidence": "0.6948",
+                        "content": "Onda"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "53.78",
+                "end_time": "53.96",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "having"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "53.96",
+                "end_time": "54.04",
+                "alternatives": [
+                    {
+                        "confidence": "0.9967",
+                        "content": "to"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "54.04",
+                "end_time": "54.28",
+                "alternatives": [
+                    {
+                        "confidence": "0.8584",
+                        "content": "share"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "54.28",
+                "end_time": "54.46",
+                "alternatives": [
+                    {
+                        "confidence": "0.9939",
+                        "content": "that"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "54.46",
+                "end_time": "54.95",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "space"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "54.95",
+                "end_time": "55.34",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "with"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "55.35",
+                "end_time": "55.6",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "with"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "55.6",
+                "end_time": "56.22",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "snakes"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "58.17",
+                "end_time": "58.62",
+                "alternatives": [
+                    {
+                        "confidence": "0.9813",
+                        "content": "Two"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "58.62",
+                "end_time": "58.91",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "weeks"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "58.91",
+                "end_time": "59.38",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "ago"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "59.39",
+                "end_time": "60.04",
+                "alternatives": [
+                    {
+                        "confidence": "0.9939",
+                        "content": "Cyclone"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "60.05",
+                "end_time": "60.23",
+                "alternatives": [
+                    {
+                        "confidence": "0.7312",
+                        "content": "E"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "60.23",
+                "end_time": "60.64",
+                "alternatives": [
+                    {
+                        "confidence": "0.5766",
+                        "content": "Di"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "60.65",
+                "end_time": "61.05",
+                "alternatives": [
+                    {
+                        "confidence": "0.9981",
+                        "content": "hit"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "61.05",
+                "end_time": "61.83",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Mozambique"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "61.84",
+                "end_time": "62.11",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "one"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "62.11",
+                "end_time": "62.17",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "62.17",
+                "end_time": "62.25",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "62.25",
+                "end_time": "62.71",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "poorest"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "62.71",
+                "end_time": "63.09",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "countries"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "63.09",
+                "end_time": "63.18",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "63.18",
+                "end_time": "63.26",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "63.26",
+                "end_time": "63.75",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "world"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "64.44",
+                "end_time": "64.66",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "It"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "64.66",
+                "end_time": "65.08",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "caused"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "65.09",
+                "end_time": "66.03",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "catastrophic"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "66.03",
+                "end_time": "66.58",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "damage"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "66.89",
+                "end_time": "67.66",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "obliterating"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "67.66",
+                "end_time": "67.93",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "most"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "67.93",
+                "end_time": "68.0",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "68.0",
+                "end_time": "68.08",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "68.08",
+                "end_time": "68.4",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "city"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "68.4",
+                "end_time": "68.52",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "68.53",
+                "end_time": "69.06",
+                "alternatives": [
+                    {
+                        "confidence": "0.9739",
+                        "content": "bearer"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "69.3",
+                "end_time": "69.73",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "killing"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "69.74",
+                "end_time": "70.53",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "hundreds"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "70.62",
+                "end_time": "70.76",
+                "alternatives": [
+                    {
+                        "confidence": "0.7257",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "70.76",
+                "end_time": "71.18",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "destroying"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "71.18",
+                "end_time": "71.27",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "71.27",
+                "end_time": "71.6",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "homes"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "71.6",
+                "end_time": "71.72",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "71.73",
+                "end_time": "72.21",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "thousands"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "72.21",
+                "end_time": "72.31",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "72.31",
+                "end_time": "72.75",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "others"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "73.4",
+                "end_time": "73.65",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "And"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "73.66",
+                "end_time": "74.08",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "then"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "74.36",
+                "end_time": "74.49",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "74.49",
+                "end_time": "74.84",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "floods"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "74.84",
+                "end_time": "75.75",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "came"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "77.44",
+                "end_time": "77.69",
+                "alternatives": [
+                    {
+                        "confidence": "0.9931",
+                        "content": "The"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "77.69",
+                "end_time": "78.21",
+                "alternatives": [
+                    {
+                        "confidence": "0.9731",
+                        "content": "fallout"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "78.22",
+                "end_time": "78.36",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "from"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "78.36",
+                "end_time": "78.43",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "78.43",
+                "end_time": "78.84",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "tropical"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "78.84",
+                "end_time": "79.25",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "storm"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "79.25",
+                "end_time": "79.38",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "has"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "79.38",
+                "end_time": "79.85",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "affected"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "79.86",
+                "end_time": "80.27",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "almost"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "80.28",
+                "end_time": "80.58",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "two"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "80.58",
+                "end_time": "80.98",
+                "alternatives": [
+                    {
+                        "confidence": "0.9763",
+                        "content": "million"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "80.98",
+                "end_time": "81.53",
+                "alternatives": [
+                    {
+                        "confidence": "0.9996",
+                        "content": "lives"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "81.75",
+                "end_time": "81.96",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "not"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "81.96",
+                "end_time": "82.19",
+                "alternatives": [
+                    {
+                        "confidence": "0.9994",
+                        "content": "just"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "82.19",
+                "end_time": "82.27",
+                "alternatives": [
+                    {
+                        "confidence": "0.9994",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "82.27",
+                "end_time": "83.03",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Mozambique"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "83.04",
+                "end_time": "83.18",
+                "alternatives": [
+                    {
+                        "confidence": "0.9997",
+                        "content": "but"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "83.18",
+                "end_time": "83.47",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "also"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "83.47",
+                "end_time": "84.01",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Malawi"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "84.01",
+                "end_time": "84.17",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "84.17",
+                "end_time": "84.93",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Zimbabwe"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "85.54",
+                "end_time": "86.02",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Questions"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "86.02",
+                "end_time": "86.08",
+                "alternatives": [
+                    {
+                        "confidence": "0.9387",
+                        "content": "are"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "86.08",
+                "end_time": "86.29",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "being"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "86.29",
+                "end_time": "86.51",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "asked"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "86.51",
+                "end_time": "86.72",
+                "alternatives": [
+                    {
+                        "confidence": "0.9982",
+                        "content": "about"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "86.72",
+                "end_time": "86.9",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "why"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "86.9",
+                "end_time": "87.01",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "87.01",
+                "end_time": "87.43",
+                "alternatives": [
+                    {
+                        "confidence": "0.973",
+                        "content": "government"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "87.44",
+                "end_time": "87.58",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "did"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "87.58",
+                "end_time": "87.78",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "not"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "87.78",
+                "end_time": "88.05",
+                "alternatives": [
+                    {
+                        "confidence": "0.9748",
+                        "content": "doom"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "88.05",
+                "end_time": "88.35",
+                "alternatives": [
+                    {
+                        "confidence": "0.9753",
+                        "content": "or"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "88.35",
+                "end_time": "88.44",
+                "alternatives": [
+                    {
+                        "confidence": "0.9985",
+                        "content": "to"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "88.45",
+                "end_time": "88.81",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "protect"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "88.81",
+                "end_time": "88.91",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "88.91",
+                "end_time": "89.44",
+                "alternatives": [
+                    {
+                        "confidence": "0.998",
+                        "content": "opposition"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "89.44",
+                "end_time": "89.91",
+                "alternatives": [
+                    {
+                        "confidence": "0.9989",
+                        "content": "city"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "89.91",
+                "end_time": "90.08",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "90.09",
+                "end_time": "90.57",
+                "alternatives": [
+                    {
+                        "confidence": "0.991",
+                        "content": "bearer"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "91.23",
+                "end_time": "91.39",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "And"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "91.39",
+                "end_time": "91.56",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "now"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "91.56",
+                "end_time": "91.7",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "91.71",
+                "end_time": "92.06",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "first"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "92.06",
+                "end_time": "92.47",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "cases"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "92.47",
+                "end_time": "92.58",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "92.59",
+                "end_time": "92.7",
+                "alternatives": [
+                    {
+                        "confidence": "0.9988",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "92.7",
+                "end_time": "93.29",
+                "alternatives": [
+                    {
+                        "confidence": "0.9658",
+                        "content": "waterborne"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "93.29",
+                "end_time": "93.83",
+                "alternatives": [
+                    {
+                        "confidence": "0.9989",
+                        "content": "disease"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "93.83",
+                "end_time": "94.39",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "cholera"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "94.72",
+                "end_time": "94.83",
+                "alternatives": [
+                    {
+                        "confidence": "0.9416",
+                        "content": "are"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "94.83",
+                "end_time": "95.6",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "complicating"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "95.61",
+                "end_time": "95.74",
+                "alternatives": [
+                    {
+                        "confidence": "0.9431",
+                        "content": "an"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "95.74",
+                "end_time": "96.2",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "already"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "96.2",
+                "end_time": "96.88",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "massive"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "97.19",
+                "end_time": "97.39",
+                "alternatives": [
+                    {
+                        "confidence": "0.9792",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "97.39",
+                "end_time": "98.06",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "complex"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "98.07",
+                "end_time": "98.85",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "emergency"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "100.44",
+                "end_time": "100.75",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "from"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "100.75",
+                "end_time": "100.83",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "100.83",
+                "end_time": "101.36",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "Guardian"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "101.46",
+                "end_time": "101.69",
+                "alternatives": [
+                    {
+                        "confidence": "0.9704",
+                        "content": "I'm"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "101.69",
+                "end_time": "102.11",
+                "alternatives": [
+                    {
+                        "confidence": "0.8521",
+                        "content": "Anoushka"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "102.11",
+                "end_time": "102.75",
+                "alternatives": [
+                    {
+                        "confidence": "0.8799",
+                        "content": "Astana"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "103.31",
+                "end_time": "103.71",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "today"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "103.71",
+                "end_time": "103.84",
+                "alternatives": [
+                    {
+                        "confidence": "0.9909",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "103.85",
+                "end_time": "104.63",
+                "alternatives": [
+                    {
+                        "confidence": "0.9969",
+                        "content": "focus"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "105.09",
+                "end_time": "105.18",
+                "alternatives": [
+                    {
+                        "confidence": "0.4803",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "105.19",
+                "end_time": "106.18",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "devastation"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "106.19",
+                "end_time": "106.32",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "106.32",
+                "end_time": "106.87",
+                "alternatives": [
+                    {
+                        "confidence": "0.9492",
+                        "content": "Cyclone"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "106.88",
+                "end_time": "107.06",
+                "alternatives": [
+                    {
+                        "confidence": "0.822",
+                        "content": "E"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "107.06",
+                "end_time": "107.41",
+                "alternatives": [
+                    {
+                        "confidence": "0.7239",
+                        "content": "Di"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "107.48",
+                "end_time": "107.89",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "one"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "107.89",
+                "end_time": "107.95",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "107.95",
+                "end_time": "108.04",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "108.04",
+                "end_time": "108.46",
+                "alternatives": [
+                    {
+                        "confidence": "0.9997",
+                        "content": "worst"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "108.46",
+                "end_time": "108.66",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "weather"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "108.66",
+                "end_time": "109.23",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "disasters"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "109.23",
+                "end_time": "109.45",
+                "alternatives": [
+                    {
+                        "confidence": "0.4051",
+                        "content": "toe"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "109.46",
+                "end_time": "109.71",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "ever"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "109.71",
+                "end_time": "110.2",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "hit"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "110.21",
+                "end_time": "110.34",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "110.34",
+                "end_time": "110.69",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "southern"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "110.69",
+                "end_time": "111.28",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "hemisphere"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "122.92",
+                "end_time": "123.27",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Last"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "123.27",
+                "end_time": "123.89",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Wednesday"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "123.95",
+                "end_time": "124.27",
+                "alternatives": [
+                    {
+                        "confidence": "0.9993",
+                        "content": "Peter"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "124.27",
+                "end_time": "124.79",
+                "alternatives": [
+                    {
+                        "confidence": "0.9817",
+                        "content": "Bowman"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "124.82",
+                "end_time": "124.96",
+                "alternatives": [
+                    {
+                        "confidence": "0.9982",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "124.96",
+                "end_time": "125.38",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "senior"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "125.38",
+                "end_time": "125.88",
+                "alternatives": [
+                    {
+                        "confidence": "0.9994",
+                        "content": "reporter"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "125.88",
+                "end_time": "126.02",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "at"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "126.02",
+                "end_time": "126.11",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "126.11",
+                "end_time": "126.7",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Guardian"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "126.71",
+                "end_time": "127.03",
+                "alternatives": [
+                    {
+                        "confidence": "0.9288",
+                        "content": "reached"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "127.03",
+                "end_time": "127.12",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "127.12",
+                "end_time": "127.44",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "city"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "127.44",
+                "end_time": "127.59",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "127.6",
+                "end_time": "128.11",
+                "alternatives": [
+                    {
+                        "confidence": "0.9722",
+                        "content": "bearer"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "128.12",
+                "end_time": "128.42",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "128.42",
+                "end_time": "128.49",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "128.49",
+                "end_time": "128.83",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "coast"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "128.83",
+                "end_time": "128.91",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "128.91",
+                "end_time": "129.68",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Mozambique"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "129.98",
+                "end_time": "130.34",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "just"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "130.35",
+                "end_time": "130.89",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "days"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "131.04",
+                "end_time": "131.33",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "after"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "131.33",
+                "end_time": "131.95",
+                "alternatives": [
+                    {
+                        "confidence": "0.9995",
+                        "content": "Cyclone"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "132.06",
+                "end_time": "132.25",
+                "alternatives": [
+                    {
+                        "confidence": "0.8369",
+                        "content": "E"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "132.25",
+                "end_time": "132.56",
+                "alternatives": [
+                    {
+                        "confidence": "0.7742",
+                        "content": "Di"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "132.57",
+                "end_time": "132.77",
+                "alternatives": [
+                    {
+                        "confidence": "0.9958",
+                        "content": "had"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "132.85",
+                "end_time": "133.52",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "devastated"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "133.52",
+                "end_time": "133.62",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "133.62",
+                "end_time": "134.07",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "region"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "135.27",
+                "end_time": "135.41",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "As"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "135.41",
+                "end_time": "135.86",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "soon"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "135.86",
+                "end_time": "136.01",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "as"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "136.01",
+                "end_time": "136.18",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "136.18",
+                "end_time": "136.71",
+                "alternatives": [
+                    {
+                        "confidence": "0.9861",
+                        "content": "arrive"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "136.71",
+                "end_time": "136.9",
+                "alternatives": [
+                    {
+                        "confidence": "0.9406",
+                        "content": "you're"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "136.9",
+                "end_time": "137.35",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "aware"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "137.35",
+                "end_time": "137.54",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "that"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "137.55",
+                "end_time": "137.95",
+                "alternatives": [
+                    {
+                        "confidence": "0.9",
+                        "content": "you're"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "137.96",
+                "end_time": "138.26",
+                "alternatives": [
+                    {
+                        "confidence": "0.853",
+                        "content": "you're"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "138.27",
+                "end_time": "138.34",
+                "alternatives": [
+                    {
+                        "confidence": "0.7841",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "138.34",
+                "end_time": "138.81",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "centre"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "138.81",
+                "end_time": "138.96",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "138.96",
+                "end_time": "139.21",
+                "alternatives": [
+                    {
+                        "confidence": "0.6863",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "139.32",
+                "end_time": "139.63",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "big"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "139.63",
+                "end_time": "140.39",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "emergency"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "140.39",
+                "end_time": "140.9",
+                "alternatives": [
+                    {
+                        "confidence": "0.9936",
+                        "content": "response"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "140.9",
+                "end_time": "141.36",
+                "alternatives": [
+                    {
+                        "confidence": "0.9912",
+                        "content": "effort"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "141.97",
+                "end_time": "142.3",
+                "alternatives": [
+                    {
+                        "confidence": "0.5076",
+                        "content": "There's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "142.3",
+                "end_time": "142.45",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "142.46",
+                "end_time": "142.9",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "bustle"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "142.9",
+                "end_time": "143.28",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "143.29",
+                "end_time": "143.66",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "kind"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "143.66",
+                "end_time": "143.97",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "143.98",
+                "end_time": "144.34",
+                "alternatives": [
+                    {
+                        "confidence": "0.9831",
+                        "content": "aid"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "144.34",
+                "end_time": "144.76",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "workers"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "144.76",
+                "end_time": "144.85",
+                "alternatives": [
+                    {
+                        "confidence": "0.9937",
+                        "content": "The"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "144.85",
+                "end_time": "145.43",
+                "alternatives": [
+                    {
+                        "confidence": "0.9632",
+                        "content": "Operation"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "145.43",
+                "end_time": "145.85",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Centre"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "145.85",
+                "end_time": "146.01",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "is"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "146.01",
+                "end_time": "146.25",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "right"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "146.25",
+                "end_time": "146.53",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "next"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "146.53",
+                "end_time": "146.59",
+                "alternatives": [
+                    {
+                        "confidence": "0.973",
+                        "content": "to"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "146.59",
+                "end_time": "146.68",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "146.68",
+                "end_time": "147.24",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "arrivals"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "147.24",
+                "end_time": "147.58",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "hall"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "149.12",
+                "end_time": "149.21",
+                "alternatives": [
+                    {
+                        "confidence": "0.9971",
+                        "content": "I"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "149.21",
+                "end_time": "149.39",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "got"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "149.39",
+                "end_time": "149.5",
+                "alternatives": [
+                    {
+                        "confidence": "0.9976",
+                        "content": "there"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "149.5",
+                "end_time": "149.73",
+                "alternatives": [
+                    {
+                        "confidence": "0.9919",
+                        "content": "about"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "149.73",
+                "end_time": "149.98",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "eleven"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "149.98",
+                "end_time": "150.29",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "o'Clock"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "150.29",
+                "end_time": "150.37",
+                "alternatives": [
+                    {
+                        "confidence": "0.9841",
+                        "content": "at"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "150.37",
+                "end_time": "150.74",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "night"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "150.75",
+                "end_time": "150.98",
+                "alternatives": [
+                    {
+                        "confidence": "0.912",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "150.98",
+                "end_time": "151.16",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "sort"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "151.16",
+                "end_time": "151.48",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "151.77",
+                "end_time": "151.93",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "at"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "151.93",
+                "end_time": "152.18",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "that"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "152.18",
+                "end_time": "152.68",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "stage"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "152.68",
+                "end_time": "152.71",
+                "alternatives": [
+                    {
+                        "confidence": "0.9945",
+                        "content": "I"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "152.71",
+                "end_time": "153.0",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "mean"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "153.66",
+                "end_time": "153.84",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "153.84",
+                "end_time": "153.95",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "153.95",
+                "end_time": "154.45",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "dark"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "154.45",
+                "end_time": "154.61",
+                "alternatives": [
+                    {
+                        "confidence": "0.9904",
+                        "content": "You're"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "154.61",
+                "end_time": "154.99",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "aware"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "154.99",
+                "end_time": "155.09",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "155.09",
+                "end_time": "155.28",
+                "alternatives": [
+                    {
+                        "confidence": "0.9995",
+                        "content": "all"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "155.28",
+                "end_time": "155.56",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "these"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "155.56",
+                "end_time": "156.07",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "fallen"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "156.07",
+                "end_time": "156.8",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "trees"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "157.11",
+                "end_time": "157.32",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "157.32",
+                "end_time": "157.39",
+                "alternatives": [
+                    {
+                        "confidence": "0.9996",
+                        "content": "A"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "157.39",
+                "end_time": "157.57",
+                "alternatives": [
+                    {
+                        "confidence": "0.9914",
+                        "content": "ll"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "157.57",
+                "end_time": "157.67",
+                "alternatives": [
+                    {
+                        "confidence": "0.9974",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "157.67",
+                "end_time": "158.28",
+                "alternatives": [
+                    {
+                        "confidence": "0.7028",
+                        "content": "roads"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "158.42",
+                "end_time": "158.84",
+                "alternatives": [
+                    {
+                        "confidence": "0.9993",
+                        "content": "No"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "158.84",
+                "end_time": "159.25",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "lights"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "159.25",
+                "end_time": "159.4",
+                "alternatives": [
+                    {
+                        "confidence": "0.9992",
+                        "content": "at"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "159.4",
+                "end_time": "159.75",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "all"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "160.27",
+                "end_time": "160.7",
+                "alternatives": [
+                    {
+                        "confidence": "0.8525",
+                        "content": "No"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "160.7",
+                "end_time": "161.28",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "people"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "161.42",
+                "end_time": "161.65",
+                "alternatives": [
+                    {
+                        "confidence": "0.9614",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "161.66",
+                "end_time": "162.05",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "bits"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "162.05",
+                "end_time": "162.13",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "162.13",
+                "end_time": "162.65",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "standing"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "162.65",
+                "end_time": "163.19",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "water"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "163.72",
+                "end_time": "164.46",
+                "alternatives": [
+                    {
+                        "confidence": "0.999",
+                        "content": "glass"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "164.65",
+                "end_time": "164.96",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "bits"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "164.96",
+                "end_time": "165.05",
+                "alternatives": [
+                    {
+                        "confidence": "0.9686",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "165.05",
+                "end_time": "165.23",
+                "alternatives": [
+                    {
+                        "confidence": "0.7963",
+                        "content": "us"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "165.23",
+                "end_time": "165.62",
+                "alternatives": [
+                    {
+                        "confidence": "0.8933",
+                        "content": "Best"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "165.62",
+                "end_time": "165.81",
+                "alternatives": [
+                    {
+                        "confidence": "0.8927",
+                        "content": "us"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "165.81",
+                "end_time": "166.05",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "off"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "166.06",
+                "end_time": "166.16",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "166.16",
+                "end_time": "166.54",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "roof"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "166.54",
+                "end_time": "167.33",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "corrugated"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "167.33",
+                "end_time": "167.6",
+                "alternatives": [
+                    {
+                        "confidence": "0.6845",
+                        "content": "iron"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "167.61",
+                "end_time": "167.87",
+                "alternatives": [
+                    {
+                        "confidence": "0.6316",
+                        "content": "instead"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "167.87",
+                "end_time": "167.95",
+                "alternatives": [
+                    {
+                        "confidence": "0.8138",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "167.95",
+                "end_time": "168.31",
+                "alternatives": [
+                    {
+                        "confidence": "0.8112",
+                        "content": "all"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "168.32",
+                "end_time": "168.64",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "coming"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "168.64",
+                "end_time": "168.87",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "out"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "168.87",
+                "end_time": "168.94",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "168.94",
+                "end_time": "169.04",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "169.04",
+                "end_time": "169.4",
+                "alternatives": [
+                    {
+                        "confidence": "0.996",
+                        "content": "dark"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "169.4",
+                "end_time": "169.77",
+                "alternatives": [
+                    {
+                        "confidence": "0.4617",
+                        "content": "atyou"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "172.02",
+                "end_time": "172.3",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Can"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "172.3",
+                "end_time": "172.38",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "172.38",
+                "end_time": "173.01",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "describe"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "173.01",
+                "end_time": "173.32",
+                "alternatives": [
+                    {
+                        "confidence": "0.8375",
+                        "content": "error"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "173.32",
+                "end_time": "173.6",
+                "alternatives": [
+                    {
+                        "confidence": "0.9799",
+                        "content": "for"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "173.6",
+                "end_time": "173.86",
+                "alternatives": [
+                    {
+                        "confidence": "0.7437",
+                        "content": "May"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "?"
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "174.32",
+                "end_time": "175.07",
+                "alternatives": [
+                    {
+                        "confidence": "0.2772",
+                        "content": "There's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "175.35",
+                "end_time": "175.7",
+                "alternatives": [
+                    {
+                        "confidence": "0.8442",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "175.7",
+                "end_time": "176.15",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "small"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "176.15",
+                "end_time": "176.55",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "city"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "176.55",
+                "end_time": "176.7",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "176.7",
+                "end_time": "177.36",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "177.37",
+                "end_time": "177.95",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "coast"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "178.22",
+                "end_time": "178.62",
+                "alternatives": [
+                    {
+                        "confidence": "0.941",
+                        "content": "It's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "178.62",
+                "end_time": "178.9",
+                "alternatives": [
+                    {
+                        "confidence": "0.9896",
+                        "content": "run"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "178.9",
+                "end_time": "179.36",
+                "alternatives": [
+                    {
+                        "confidence": "0.9896",
+                        "content": "down"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "179.36",
+                "end_time": "179.48",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "It"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "179.48",
+                "end_time": "179.66",
+                "alternatives": [
+                    {
+                        "confidence": "0.9983",
+                        "content": "could"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "179.66",
+                "end_time": "179.82",
+                "alternatives": [
+                    {
+                        "confidence": "0.9983",
+                        "content": "have"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "179.82",
+                "end_time": "180.08",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "seen"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "180.08",
+                "end_time": "180.4",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "better"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "180.4",
+                "end_time": "180.97",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "days"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "180.98",
+                "end_time": "181.13",
+                "alternatives": [
+                    {
+                        "confidence": "0.9246",
+                        "content": "It's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "181.13",
+                "end_time": "181.22",
+                "alternatives": [
+                    {
+                        "confidence": "0.8972",
+                        "content": "an"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "181.22",
+                "end_time": "181.85",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "opposition"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "181.85",
+                "end_time": "182.27",
+                "alternatives": [
+                    {
+                        "confidence": "0.9945",
+                        "content": "city"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "182.27",
+                "end_time": "182.76",
+                "alternatives": [
+                    {
+                        "confidence": "0.9934",
+                        "content": "so"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "182.77",
+                "end_time": "183.63",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "hasn't"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "183.63",
+                "end_time": "184.06",
+                "alternatives": [
+                    {
+                        "confidence": "0.8874",
+                        "content": "really"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "184.06",
+                "end_time": "184.68",
+                "alternatives": [
+                    {
+                        "confidence": "0.9917",
+                        "content": "seen"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "184.78",
+                "end_time": "185.26",
+                "alternatives": [
+                    {
+                        "confidence": "0.8062",
+                        "content": "Ah"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "185.26",
+                "end_time": "185.52",
+                "alternatives": [
+                    {
+                        "confidence": "0.9973",
+                        "content": "lot"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "185.52",
+                "end_time": "185.66",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "185.66",
+                "end_time": "185.92",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "love"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "185.92",
+                "end_time": "186.19",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "from"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "186.19",
+                "end_time": "186.27",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "186.27",
+                "end_time": "186.82",
+                "alternatives": [
+                    {
+                        "confidence": "0.989",
+                        "content": "government"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "186.83",
+                "end_time": "187.03",
+                "alternatives": [
+                    {
+                        "confidence": "0.9915",
+                        "content": "There"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "187.03",
+                "end_time": "187.1",
+                "alternatives": [
+                    {
+                        "confidence": "0.7944",
+                        "content": "are"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "187.1",
+                "end_time": "187.35",
+                "alternatives": [
+                    {
+                        "confidence": "0.9958",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "187.47",
+                "end_time": "187.94",
+                "alternatives": [
+                    {
+                        "confidence": "0.9994",
+                        "content": "few"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "187.94",
+                "end_time": "188.32",
+                "alternatives": [
+                    {
+                        "confidence": "0.9868",
+                        "content": "old"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "188.8",
+                "end_time": "189.05",
+                "alternatives": [
+                    {
+                        "confidence": "0.9983",
+                        "content": "sort"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "189.05",
+                "end_time": "189.14",
+                "alternatives": [
+                    {
+                        "confidence": "0.9992",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "189.14",
+                "end_time": "189.91",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Portuguese"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "189.91",
+                "end_time": "190.48",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "colonial"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "190.48",
+                "end_time": "191.19",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "buildings"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "191.56",
+                "end_time": "191.7",
+                "alternatives": [
+                    {
+                        "confidence": "0.9255",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "191.7",
+                "end_time": "191.73",
+                "alternatives": [
+                    {
+                        "confidence": "0.5418",
+                        "content": "I"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "191.73",
+                "end_time": "191.88",
+                "alternatives": [
+                    {
+                        "confidence": "0.9959",
+                        "content": "had"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "191.88",
+                "end_time": "191.92",
+                "alternatives": [
+                    {
+                        "confidence": "0.9989",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "191.92",
+                "end_time": "192.1",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "lot"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "192.1",
+                "end_time": "192.21",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "192.21",
+                "end_time": "192.85",
+                "alternatives": [
+                    {
+                        "confidence": "0.4239",
+                        "content": "truce"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "192.86",
+                "end_time": "193.63",
+                "alternatives": [
+                    {
+                        "confidence": "0.9861",
+                        "content": "So"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "193.92",
+                "end_time": "194.38",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "194.38",
+                "end_time": "194.56",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "know"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "194.56",
+                "end_time": "194.7",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "at"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "194.7",
+                "end_time": "194.88",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "one"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "194.88",
+                "end_time": "195.29",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "stage"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "195.29",
+                "end_time": "195.39",
+                "alternatives": [
+                    {
+                        "confidence": "0.9996",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "195.39",
+                "end_time": "195.61",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "kind"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "195.61",
+                "end_time": "195.68",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "195.68",
+                "end_time": "196.23",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "think"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "196.42",
+                "end_time": "196.54",
+                "alternatives": [
+                    {
+                        "confidence": "0.9867",
+                        "content": "if"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "196.54",
+                "end_time": "196.68",
+                "alternatives": [
+                    {
+                        "confidence": "0.9438",
+                        "content": "you've"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "196.68",
+                "end_time": "196.88",
+                "alternatives": [
+                    {
+                        "confidence": "0.9989",
+                        "content": "been"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "196.88",
+                "end_time": "197.04",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "there"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "197.04",
+                "end_time": "197.39",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "before"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "197.39",
+                "end_time": "197.47",
+                "alternatives": [
+                    {
+                        "confidence": "0.9926",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "197.47",
+                "end_time": "197.88",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "storm"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "197.88",
+                "end_time": "198.01",
+                "alternatives": [
+                    {
+                        "confidence": "0.9996",
+                        "content": "it"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "198.01",
+                "end_time": "198.14",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "would"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "198.14",
+                "end_time": "198.33",
+                "alternatives": [
+                    {
+                        "confidence": "0.9984",
+                        "content": "have"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "198.33",
+                "end_time": "198.39",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "198.39",
+                "end_time": "198.77",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "certain"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "198.77",
+                "end_time": "199.19",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "charm"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "199.19",
+                "end_time": "199.36",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "from"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "199.36",
+                "end_time": "199.6",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "all"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "199.6",
+                "end_time": "199.7",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "199.7",
+                "end_time": "200.26",
+                "alternatives": [
+                    {
+                        "confidence": "0.9855",
+                        "content": "trees"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "200.7",
+                "end_time": "201.23",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Now"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "201.23",
+                "end_time": "201.35",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "201.35",
+                "end_time": "201.71",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "course"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "201.71",
+                "end_time": "201.79",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "201.79",
+                "end_time": "202.02",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "lot"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "202.02",
+                "end_time": "202.18",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "202.19",
+                "end_time": "202.5",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "202.51",
+                "end_time": "202.83",
+                "alternatives": [
+                    {
+                        "confidence": "0.5296",
+                        "content": "poorer"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "202.83",
+                "end_time": "203.33",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "neighbourhoods"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "203.33",
+                "end_time": "203.44",
+                "alternatives": [
+                    {
+                        "confidence": "0.9711",
+                        "content": "have"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "203.44",
+                "end_time": "203.64",
+                "alternatives": [
+                    {
+                        "confidence": "0.7092",
+                        "content": "been"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "203.64",
+                "end_time": "203.94",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "very"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "203.94",
+                "end_time": "204.19",
+                "alternatives": [
+                    {
+                        "confidence": "0.9997",
+                        "content": "very"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "204.19",
+                "end_time": "204.6",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "heavily"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "204.6",
+                "end_time": "204.88",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "hit"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "204.88",
+                "end_time": "204.93",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "I"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "204.93",
+                "end_time": "205.12",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "mean"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "205.12",
+                "end_time": "205.32",
+                "alternatives": [
+                    {
+                        "confidence": "0.9712",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "205.68",
+                "end_time": "205.86",
+                "alternatives": [
+                    {
+                        "confidence": "0.9117",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "205.86",
+                "end_time": "206.18",
+                "alternatives": [
+                    {
+                        "confidence": "0.9934",
+                        "content": "drive"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "206.18",
+                "end_time": "206.45",
+                "alternatives": [
+                    {
+                        "confidence": "0.9956",
+                        "content": "through"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "206.45",
+                "end_time": "206.67",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "them"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "206.67",
+                "end_time": "206.93",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "206.97",
+                "end_time": "207.4",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "207.4",
+                "end_time": "207.62",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "see"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "207.62",
+                "end_time": "208.0",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "people"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "208.0",
+                "end_time": "208.08",
+                "alternatives": [
+                    {
+                        "confidence": "0.9983",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "208.08",
+                "end_time": "208.14",
+                "alternatives": [
+                    {
+                        "confidence": "0.7642",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "208.14",
+                "end_time": "208.42",
+                "alternatives": [
+                    {
+                        "confidence": "0.8024",
+                        "content": "house"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "208.42",
+                "end_time": "208.63",
+                "alternatives": [
+                    {
+                        "confidence": "0.8025",
+                        "content": "is"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "208.64",
+                "end_time": "209.08",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "still"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "209.08",
+                "end_time": "209.74",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "standing"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "209.74",
+                "end_time": "210.11",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "But"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "210.12",
+                "end_time": "210.29",
+                "alternatives": [
+                    {
+                        "confidence": "0.999",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "210.29",
+                "end_time": "210.42",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "know"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "210.42",
+                "end_time": "210.86",
+                "alternatives": [
+                    {
+                        "confidence": "0.9997",
+                        "content": "maybe"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "210.86",
+                "end_time": "210.94",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "210.94",
+                "end_time": "211.03",
+                "alternatives": [
+                    {
+                        "confidence": "0.9362",
+                        "content": "one"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "211.03",
+                "end_time": "211.32",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "hundred"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "211.32",
+                "end_time": "211.69",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "metres"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "211.69",
+                "end_time": "211.97",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "212.36",
+                "end_time": "212.64",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "212.64",
+                "end_time": "213.05",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "muddy"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "213.05",
+                "end_time": "213.52",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "water"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "213.52",
+                "end_time": "214.29",
+                "alternatives": [
+                    {
+                        "confidence": "0.6278",
+                        "content": "tryingto"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "214.54",
+                "end_time": "214.96",
+                "alternatives": [
+                    {
+                        "confidence": "0.9941",
+                        "content": "live"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "214.96",
+                "end_time": "215.33",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "above"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "215.34",
+                "end_time": "215.42",
+                "alternatives": [
+                    {
+                        "confidence": "0.9208",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "215.42",
+                "end_time": "215.9",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "standing"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "215.9",
+                "end_time": "216.39",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "water"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "216.53",
+                "end_time": "216.75",
+                "alternatives": [
+                    {
+                        "confidence": "0.9528",
+                        "content": "It"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "216.75",
+                "end_time": "216.88",
+                "alternatives": [
+                    {
+                        "confidence": "0.9348",
+                        "content": "was"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "216.88",
+                "end_time": "217.18",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "probably"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "217.18",
+                "end_time": "217.59",
+                "alternatives": [
+                    {
+                        "confidence": "0.9996",
+                        "content": "ninety"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "217.59",
+                "end_time": "218.01",
+                "alternatives": [
+                    {
+                        "confidence": "0.9872",
+                        "content": "percent"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "218.01",
+                "end_time": "218.45",
+                "alternatives": [
+                    {
+                        "confidence": "0.6754",
+                        "content": "damaged"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "218.45",
+                "end_time": "218.6",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "but"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "218.6",
+                "end_time": "218.82",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "not"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "218.82",
+                "end_time": "219.47",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "destroyed"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "219.86",
+                "end_time": "220.04",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "The"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "220.04",
+                "end_time": "220.37",
+                "alternatives": [
+                    {
+                        "confidence": "0.7496",
+                        "content": "rial"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "220.37",
+                "end_time": "221.38",
+                "alternatives": [
+                    {
+                        "confidence": "0.9894",
+                        "content": "catastrophe"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "221.39",
+                "end_time": "221.77",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "had"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "221.77",
+                "end_time": "222.17",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "taken"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "222.17",
+                "end_time": "222.52",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "place"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "222.52",
+                "end_time": "223.01",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "outside"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "223.01",
+                "end_time": "223.1",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "223.1",
+                "end_time": "223.63",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "city"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "227.12",
+                "end_time": "227.26",
+                "alternatives": [
+                    {
+                        "confidence": "0.5225",
+                        "content": "Thank"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "227.27",
+                "end_time": "227.33",
+                "alternatives": [
+                    {
+                        "confidence": "0.5219",
+                        "content": "you"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "227.72",
+                "end_time": "227.94",
+                "alternatives": [
+                    {
+                        "confidence": "0.8753",
+                        "content": "Do"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "227.94",
+                "end_time": "228.24",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "people"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "228.24",
+                "end_time": "228.42",
+                "alternatives": [
+                    {
+                        "confidence": "0.9975",
+                        "content": "know"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "228.42",
+                "end_time": "228.51",
+                "alternatives": [
+                    {
+                        "confidence": "0.9855",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "228.51",
+                "end_time": "228.94",
+                "alternatives": [
+                    {
+                        "confidence": "0.9659",
+                        "content": "cyclone"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "228.94",
+                "end_time": "229.08",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "was"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "229.08",
+                "end_time": "229.52",
+                "alternatives": [
+                    {
+                        "confidence": "0.999",
+                        "content": "coming"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "?"
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "232.22",
+                "end_time": "232.74",
+                "alternatives": [
+                    {
+                        "confidence": "0.914",
+                        "content": "Cyclones"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "232.74",
+                "end_time": "232.8",
+                "alternatives": [
+                    {
+                        "confidence": "0.8832",
+                        "content": "are"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "232.8",
+                "end_time": "233.11",
+                "alternatives": [
+                    {
+                        "confidence": "0.9963",
+                        "content": "common"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "233.11",
+                "end_time": "233.22",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "233.22",
+                "end_time": "233.39",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "this"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "233.39",
+                "end_time": "233.71",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "part"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "233.71",
+                "end_time": "233.79",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "233.79",
+                "end_time": "233.89",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "233.89",
+                "end_time": "234.24",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "world"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "234.24",
+                "end_time": "234.28",
+                "alternatives": [
+                    {
+                        "confidence": "0.9988",
+                        "content": "I"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "234.28",
+                "end_time": "234.42",
+                "alternatives": [
+                    {
+                        "confidence": "0.9988",
+                        "content": "mean"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "234.42",
+                "end_time": "234.59",
+                "alternatives": [
+                    {
+                        "confidence": "0.9994",
+                        "content": "it's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "234.59",
+                "end_time": "234.68",
+                "alternatives": [
+                    {
+                        "confidence": "0.9993",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "234.68",
+                "end_time": "235.02",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Indian"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "235.02",
+                "end_time": "235.36",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Ocean"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "235.36",
+                "end_time": "235.55",
+                "alternatives": [
+                    {
+                        "confidence": "0.9288",
+                        "content": "It's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "235.55",
+                "end_time": "235.61",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "235.61",
+                "end_time": "236.49",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "big"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "236.65",
+                "end_time": "237.69",
+                "alternatives": [
+                    {
+                        "confidence": "0.9953",
+                        "content": "swirling"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "237.69",
+                "end_time": "238.4",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "depression"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "238.4",
+                "end_time": "238.79",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "238.88",
+                "end_time": "239.38",
+                "alternatives": [
+                    {
+                        "confidence": "0.772",
+                        "content": "off"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "239.38",
+                "end_time": "239.92",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "winds"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "239.92",
+                "end_time": "240.11",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "240.11",
+                "end_time": "240.5",
+                "alternatives": [
+                    {
+                        "confidence": "0.9983",
+                        "content": "rain"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "240.863",
+                "end_time": "241.163",
+                "alternatives": [
+                    {
+                        "confidence": "0.9965",
+                        "content": "They"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "241.163",
+                "end_time": "241.493",
+                "alternatives": [
+                    {
+                        "confidence": "0.9267",
+                        "content": "plan"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "241.493",
+                "end_time": "241.653",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "for"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "241.653",
+                "end_time": "241.713",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "a"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "241.713",
+                "end_time": "241.993",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "fairly"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "241.993",
+                "end_time": "242.383",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "major"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "242.383",
+                "end_time": "242.863",
+                "alternatives": [
+                    {
+                        "confidence": "0.9888",
+                        "content": "event"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "244.533",
+                "end_time": "244.613",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "I"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "244.613",
+                "end_time": "244.773",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "mean"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "244.773",
+                "end_time": "245.063",
+                "alternatives": [
+                    {
+                        "confidence": "0.9888",
+                        "content": "what"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "245.063",
+                "end_time": "245.263",
+                "alternatives": [
+                    {
+                        "confidence": "0.9888",
+                        "content": "what"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "?"
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "245.263",
+                "end_time": "245.383",
+                "alternatives": [
+                    {
+                        "confidence": "0.9589",
+                        "content": "I"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "245.383",
+                "end_time": "245.553",
+                "alternatives": [
+                    {
+                        "confidence": "0.9838",
+                        "content": "She"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "245.553",
+                "end_time": "245.943",
+                "alternatives": [
+                    {
+                        "confidence": "0.9994",
+                        "content": "happened"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "245.943",
+                "end_time": "246.053",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "246.053",
+                "end_time": "246.233",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "this"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "246.233",
+                "end_time": "246.773",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "case"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "246.923",
+                "end_time": "247.153",
+                "alternatives": [
+                    {
+                        "confidence": "0.6821",
+                        "content": "this"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "247.153",
+                "end_time": "247.403",
+                "alternatives": [
+                    {
+                        "confidence": "0.9827",
+                        "content": "very"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "247.403",
+                "end_time": "248.083",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "slow"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "248.083",
+                "end_time": "248.553",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "moving"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "248.553",
+                "end_time": "249.263",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "storm"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "249.753",
+                "end_time": "250.223",
+                "alternatives": [
+                    {
+                        "confidence": "0.9153",
+                        "content": "Hence"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "250.223",
+                "end_time": "250.303",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "250.303",
+                "end_time": "250.683",
+                "alternatives": [
+                    {
+                        "confidence": "0.9984",
+                        "content": "coast"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "250.693",
+                "end_time": "250.873",
+                "alternatives": [
+                    {
+                        "confidence": "0.9771",
+                        "content": "by"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "250.873",
+                "end_time": "251.343",
+                "alternatives": [
+                    {
+                        "confidence": "0.841",
+                        "content": "bearer"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "251.793",
+                "end_time": "252.053",
+                "alternatives": [
+                    {
+                        "confidence": "0.9953",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "252.053",
+                "end_time": "252.453",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Then"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "252.653",
+                "end_time": "252.873",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "it"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "252.873",
+                "end_time": "253.113",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "kind"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "253.113",
+                "end_time": "253.243",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "253.253",
+                "end_time": "253.653",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "doubles"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "253.653",
+                "end_time": "254.013",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "back"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "254.013",
+                "end_time": "254.113",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "254.113",
+                "end_time": "254.243",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "it"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "254.243",
+                "end_time": "254.603",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "hits"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "254.603",
+                "end_time": "255.123",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "again"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "255.123",
+                "end_time": "255.443",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "So"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "255.453",
+                "end_time": "255.703",
+                "alternatives": [
+                    {
+                        "confidence": "0.9996",
+                        "content": "said"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "255.703",
+                "end_time": "255.783",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "255.783",
+                "end_time": "256.173",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "storm"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "256.173",
+                "end_time": "256.463",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "makes"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "256.463",
+                "end_time": "257.023",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "landfall"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "257.023",
+                "end_time": "257.583",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "twice"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "257.593",
+                "end_time": "257.823",
+                "alternatives": [
+                    {
+                        "confidence": "0.379",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "257.823",
+                "end_time": "257.963",
+                "alternatives": [
+                    {
+                        "confidence": "0.9093",
+                        "content": "as"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "257.963",
+                "end_time": "258.133",
+                "alternatives": [
+                    {
+                        "confidence": "0.6234",
+                        "content": "its"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "258.133",
+                "end_time": "259.103",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "grinding"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "259.103",
+                "end_time": "259.403",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "over"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "259.403",
+                "end_time": "259.493",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "259.493",
+                "end_time": "260.063",
+                "alternatives": [
+                    {
+                        "confidence": "0.9926",
+                        "content": "coast"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "260.653",
+                "end_time": "260.883",
+                "alternatives": [
+                    {
+                        "confidence": "0.8607",
+                        "content": "It"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "260.883",
+                "end_time": "260.973",
+                "alternatives": [
+                    {
+                        "confidence": "0.8607",
+                        "content": "is"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "260.973",
+                "end_time": "261.413",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "putting"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "261.413",
+                "end_time": "261.803",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "down"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "261.813",
+                "end_time": "262.783",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "absolutely"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "262.783",
+                "end_time": "263.853",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "phenomenal"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "263.853",
+                "end_time": "264.333",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "amounts"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "264.333",
+                "end_time": "264.453",
+                "alternatives": [
+                    {
+                        "confidence": "0.9811",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "264.453",
+                "end_time": "265.063",
+                "alternatives": [
+                    {
+                        "confidence": "0.9811",
+                        "content": "water"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "265.953",
+                "end_time": "266.243",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "So"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "266.243",
+                "end_time": "266.363",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "when"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "266.363",
+                "end_time": "266.523",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "this"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "266.523",
+                "end_time": "267.003",
+                "alternatives": [
+                    {
+                        "confidence": "0.9974",
+                        "content": "happened"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "267.003",
+                "end_time": "267.383",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "267.383",
+                "end_time": "267.473",
+                "alternatives": [
+                    {
+                        "confidence": "0.9726",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "267.473",
+                "end_time": "267.893",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Thursday"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "267.893",
+                "end_time": "268.193",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "night"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "268.203",
+                "end_time": "268.533",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "people"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "268.533",
+                "end_time": "268.953",
+                "alternatives": [
+                    {
+                        "confidence": "0.8128",
+                        "content": "emerged"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "268.953",
+                "end_time": "269.133",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "from"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "269.133",
+                "end_time": "269.343",
+                "alternatives": [
+                    {
+                        "confidence": "0.9975",
+                        "content": "this"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "269.343",
+                "end_time": "269.903",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "thinking"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "269.913",
+                "end_time": "270.073",
+                "alternatives": [
+                    {
+                        "confidence": "0.9977",
+                        "content": "I'm"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "270.073",
+                "end_time": "270.383",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "still"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "270.383",
+                "end_time": "270.753",
+                "alternatives": [
+                    {
+                        "confidence": "0.9944",
+                        "content": "here"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "270.763",
+                "end_time": "271.263",
+                "alternatives": [
+                    {
+                        "confidence": "0.6692",
+                        "content": "Okay"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "271.953",
+                "end_time": "272.253",
+                "alternatives": [
+                    {
+                        "confidence": "0.985",
+                        "content": "it's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "272.253",
+                "end_time": "272.613",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "done"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "272.613",
+                "end_time": "272.723",
+                "alternatives": [
+                    {
+                        "confidence": "0.9987",
+                        "content": "We're"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "272.723",
+                "end_time": "272.843",
+                "alternatives": [
+                    {
+                        "confidence": "0.9974",
+                        "content": "going"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "272.843",
+                "end_time": "272.913",
+                "alternatives": [
+                    {
+                        "confidence": "0.9974",
+                        "content": "to"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "272.913",
+                "end_time": "273.243",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "start"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "273.243",
+                "end_time": "273.663",
+                "alternatives": [
+                    {
+                        "confidence": "0.9721",
+                        "content": "tidying"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "273.663",
+                "end_time": "273.963",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "up"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "275.033",
+                "end_time": "275.683",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Double"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "275.683",
+                "end_time": "276.063",
+                "alternatives": [
+                    {
+                        "confidence": "0.9946",
+                        "content": "tap"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "276.063",
+                "end_time": "276.233",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "as"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "276.233",
+                "end_time": "276.383",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "it"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "276.383",
+                "end_time": "276.693",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "were"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "276.693",
+                "end_time": "276.873",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "that"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "276.873",
+                "end_time": "277.383",
+                "alternatives": [
+                    {
+                        "confidence": "0.9993",
+                        "content": "happened"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "277.383",
+                "end_time": "277.723",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "was"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "277.733",
+                "end_time": "278.253",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "278.673",
+                "end_time": "279.563",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "water"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "279.573",
+                "end_time": "279.713",
+                "alternatives": [
+                    {
+                        "confidence": "0.5689",
+                        "content": "that"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "279.723",
+                "end_time": "279.813",
+                "alternatives": [
+                    {
+                        "confidence": "0.3308",
+                        "content": "had"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "279.823",
+                "end_time": "280.393",
+                "alternatives": [
+                    {
+                        "confidence": "0.9083",
+                        "content": "fallen"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "280.393",
+                "end_time": "280.503",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "on"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "280.503",
+                "end_time": "280.573",
+                "alternatives": [
+                    {
+                        "confidence": "0.9747",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "280.573",
+                "end_time": "280.873",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "higher"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "280.873",
+                "end_time": "281.383",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "ground"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "281.383",
+                "end_time": "281.623",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "over"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "281.623",
+                "end_time": "281.793",
+                "alternatives": [
+                    {
+                        "confidence": "0.8099",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "281.803",
+                "end_time": "282.823",
+                "alternatives": [
+                    {
+                        "confidence": "0.877",
+                        "content": "Zimbabwean"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "282.823",
+                "end_time": "283.423",
+                "alternatives": [
+                    {
+                        "confidence": "0.9963",
+                        "content": "Zimbabwean"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "283.423",
+                "end_time": "283.863",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "border"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "284.253",
+                "end_time": "284.463",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "The"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "284.463",
+                "end_time": "284.953",
+                "alternatives": [
+                    {
+                        "confidence": "0.9982",
+                        "content": "ground"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "284.953",
+                "end_time": "285.563",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "slopes"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "285.563",
+                "end_time": "285.973",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "down"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "285.973",
+                "end_time": "286.173",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "from"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "286.173",
+                "end_time": "286.273",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "286.273",
+                "end_time": "286.713",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "border"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "286.713",
+                "end_time": "286.933",
+                "alternatives": [
+                    {
+                        "confidence": "0.9997",
+                        "content": "all"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "286.933",
+                "end_time": "287.013",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "287.013",
+                "end_time": "287.243",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "way"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "287.243",
+                "end_time": "287.423",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "to"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "287.423",
+                "end_time": "287.603",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "this"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "287.603",
+                "end_time": "288.143",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "area"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": ","
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "288.243",
+                "end_time": "288.733",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "which"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "288.733",
+                "end_time": "289.113",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "is"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "289.123",
+                "end_time": "289.493",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "the"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "289.503",
+                "end_time": "290.033",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "lowest"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "290.033",
+                "end_time": "290.373",
+                "alternatives": [
+                    {
+                        "confidence": "0.9918",
+                        "content": "lying"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "290.373",
+                "end_time": "290.983",
+                "alternatives": [
+                    {
+                        "confidence": "0.9665",
+                        "content": "ground"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "290.993",
+                "end_time": "291.183",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "in"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "291.183",
+                "end_time": "292.223",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "Mozambique"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "alternatives": [
+                    {
+                        "confidence": null,
+                        "content": "."
+                    }
+                ],
+                "type": "punctuation"
+            },
+            {
+                "start_time": "292.523",
+                "end_time": "292.703",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "The"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "292.703",
+                "end_time": "293.113",
+                "alternatives": [
+                    {
+                        "confidence": "0.5428",
+                        "content": "dam's"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "293.113",
+                "end_time": "293.463",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "topped"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "293.463",
+                "end_time": "293.723",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "out"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "293.733",
+                "end_time": "294.303",
+                "alternatives": [
+                    {
+                        "confidence": "0.9543",
+                        "content": "from"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "294.303",
+                "end_time": "294.853",
+                "alternatives": [
+                    {
+                        "confidence": "0.9971",
+                        "content": "sheer"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "294.853",
+                "end_time": "295.203",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "amount"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "295.203",
+                "end_time": "295.313",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "of"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "295.313",
+                "end_time": "296.073",
+                "alternatives": [
+                    {
+                        "confidence": "0.9975",
+                        "content": "rainfall"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "296.623",
+                "end_time": "296.723",
+                "alternatives": [
+                    {
+                        "confidence": "0.8185",
+                        "content": "and"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "296.723",
+                "end_time": "296.943",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "then"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "296.953",
+                "end_time": "297.693",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "poured"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "297.703",
+                "end_time": "298.233",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "down"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "298.243",
+                "end_time": "298.633",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "into"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "298.633",
+                "end_time": "299.043",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "this"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "299.093",
+                "end_time": "299.423",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "into"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "299.423",
+                "end_time": "299.783",
+                "alternatives": [
+                    {
+                        "confidence": "1.0",
+                        "content": "this"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "299.793",
+                "end_time": "300.043",
+                "alternatives": [
+                    {
+                        "confidence": "0.7916",
+                        "content": "this"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "300.043",
+                "end_time": "300.553",
+                "alternatives": [
+                    {
+                        "confidence": "0.7667",
+                        "content": "low"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "300.553",
+                "end_time": "300.933",
+                "alternatives": [
+                    {
+                        "confidence": "0.9998",
+                        "content": "flat"
+                    }
+                ],
+                "type": "pronunciation"
+            },
+            {
+                "start_time": "300.933",
+                "end_time": "301.363",
+                "alternatives": [
+                    {
+                        "confidence": "0.9999",
+                        "content": "area"
+                    }
+                ],
+                "type": "pronunciation"
+            }
+        ]
+    },
+    "status": "COMPLETED"
+}

--- a/src/lib/Util/adapters/amazon-transcribe/sample/todayinfocuswords.sample.json
+++ b/src/lib/Util/adapters/amazon-transcribe/sample/todayinfocuswords.sample.json
@@ -1,0 +1,48 @@
+[{
+    "start_time": "8.65",
+    "end_time": "8.98",
+    "alternatives": [
+        {
+            "confidence": "0.9999",
+            "content": "one"
+        }
+    ],
+    "type": "pronunciation",
+    "speaker_label": "spk_0"
+},
+{
+    "start_time": "8.98",
+    "end_time": "9.05",
+    "alternatives": [
+        {
+            "confidence": "0.9999",
+            "content": "of"
+        }
+    ],
+    "type": "pronunciation",
+    "speaker_label": "spk_1"
+},
+{
+    "start_time": "9.05",
+    "end_time": "9.15",
+    "alternatives": [
+        {
+            "confidence": "1.0",
+            "content": "the"
+        }
+    ],
+    "type": "pronunciation",
+    "speaker_label": "spk_1"
+},
+{
+    "start_time": "9.15",
+    "end_time": "9.76",
+    "alternatives": [
+        {
+            "confidence": "1.0",
+            "content": "worst"
+        }
+    ],
+    "type": "pronunciation",
+    "speaker_label": "spk_0"
+}]


### PR DESCRIPTION
Resolves https://github.com/bbc/react-transcript-editor/issues/127 

**Describe what the PR does**    
This adds support for speaker detection for the `amazontranscribe` adaptor. It's fairly similar to how this works for the BBCKaldi adaptor. One thing I wasn't sure of was how to enable/disable the speaker grouping, so I've currently set it based off whether there's a speaker_labels block in the amazon JSON. 

**State whether the PR is ready for review or whether it needs extra work**    
Ready for review, very happy to make changes though!

**Additional context**    
Currently this doesn't look fantastic in the UI as the speaker label gets cropped, but that's perhaps for a future PR.
![Screenshot from 2019-04-07 20-57-20](https://user-images.githubusercontent.com/3606555/55689036-cf92de80-5977-11e9-8410-edebe7323528.png)


