### PR TITLE
Don't add 'speaker' prefix twice.

### DIFF
--- a/packages/stt-adapters/amazon-transcribe/group-words-by-speakers.js
+++ b/packages/stt-adapters/amazon-transcribe/group-words-by-speakers.js
@@ -23,9 +23,9 @@ export const findSpeakerForWord = (word, segments) => {
     return startTime >= parseFloat(seg.start_time) && endTime <= parseFloat(seg.end_time);
   });
   if (firstMatchingSegment === undefined) {
-    return 'Speaker UKN';
+    return 'UKN';
   } else {
-    return `Speaker ${ firstMatchingSegment.speaker_label.replace('spk_', '') }`;
+    return firstMatchingSegment.speaker_label.replace('spk_', '');
   }
 };
 

--- a/packages/stt-adapters/amazon-transcribe/group-words-by-speakers.test.js
+++ b/packages/stt-adapters/amazon-transcribe/group-words-by-speakers.test.js
@@ -34,7 +34,7 @@ describe('findSpeakerForWord', () => {
       'type': 'pronunciation'
     }, speakerLabels.segments);
 
-    expect(speaker).toBe('Speaker 0');
+    expect(speaker).toBe('0');
   });
 });
 


### PR DESCRIPTION
**Describe what the PR does**    
Fixes bug where the speaker labels end up being something like 'Speaker Speaker 0' as opposed to just 'Speaker 0', as a result of the 'Speaker ' prefix being added both in `index.js` and in `group-words-by-speakers.js`

**State whether the PR is ready for review or whether it needs extra work**    
Ready for review

**Additional context**    
Oops :(
