### PR TITLE
turn on sourcemaps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 module.exports = {
   mode: 'production',
+  devtool: 'source-map',
   entry: {
     index: './packages/index.js',
     TranscriptEditor: './packages/components/transcript-editor/index.js',


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
No, but it is related to https://github.com/mac-s-g/react-json-view/pull/226. 

**Describe what the PR does**    
This PR tells webpack to generate sourcemaps when running `component:build`, which has two benefits
1. allows for easier debugging when using the built version of the component.
2. silences a webpack error. Read more about this in the linked ticket above.

**State whether the PR is ready for review or whether it needs extra work**    
Ready.

**Additional context**
For more information about the webpack warning, see https://github.com/webpack-contrib/source-map-loader/pull/82