### PR TITLE
optional transcript title spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bbc/react-transcript-editor",
   "description": "A React component to make transcribing audio and video easier and faster.",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "keywords": [
     "transcript",
     "transcriptions",

--- a/packages/components/media-player/index.js
+++ b/packages/components/media-player/index.js
@@ -411,7 +411,7 @@ class MediaPlayer extends React.Component {
 
     const playerControlsSection = (
       <div className={ styles.controlsSection }>
-        <h2 className={ styles.title }>{this.props.title}</h2>
+        {this.props.title ? <h2 className={ styles.title }>{this.props.title}</h2> : null}
         <PlayerControls
           playMedia={ this.togglePlayMedia.bind(this) }
           isPlaying={ this.state.isPlaying }


### PR DESCRIPTION
Removes space in MediaPlayer if title is not provided to optimise real estate

**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
NA

**Describe what the PR does**    
Removes space in MediaPlayer if title is not provided to optimise real estate

**State whether the PR is ready for review or whether it needs extra work**    
Ready for review 

**Additional context**    
With title
![Screen Shot 2019-05-15 at 16 22 16](https://user-images.githubusercontent.com/4661975/57787985-3b622700-772e-11e9-9966-e4aa2ce2e5c9.png)

without title - before
![Screen Shot 2019-05-15 at 16 27 45](https://user-images.githubusercontent.com/4661975/57788116-6e0c1f80-772e-11e9-8280-9250cd08ead7.png)


without title - after
![Screen Shot 2019-05-15 at 16 28 37](https://user-images.githubusercontent.com/4661975/57788170-8845fd80-772e-11e9-95ad-ae6b7e9f948e.png)

