### PR TITLE
Added parameter for hiding save button, straight property pass-through

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -262,6 +262,7 @@ class App extends React.Component {
           handleAnalyticsEvents={ this.handleAnalyticsEvents }
           title={ this.state.title }
           ref={ this.transcriptEditorRef }
+          showSaveButton= { true }
         />
 
         <label>Components Analytics</label>

--- a/packages/components/media-player/index.js
+++ b/packages/components/media-player/index.js
@@ -431,6 +431,7 @@ class MediaPlayer extends React.Component {
           setPlayBackRate={ this.handlePlayBackRateChange.bind(this) }
           playbackRateOptions={ this.state.playbackRateOptions }
           pictureInPicture={ this.handlePictureInPicture }
+          renderSave={ this.props.showSaveButton }
           handleSaveTranscript={ () => {
             this.props.handleSaveTranscript();
           } }
@@ -461,7 +462,8 @@ MediaPlayer.propTypes = {
   timecodeOffset: PropTypes.number,
   handleAnalyticsEvents: PropTypes.func,
   mediaDuration: PropTypes.string,
-  handleSaveTranscript: PropTypes.func
+  handleSaveTranscript: PropTypes.func,
+  showSaveButton: PropTypes.bool,
 };
 
 export default hotkeys(MediaPlayer);

--- a/packages/components/media-player/src/PlayerControls.js
+++ b/packages/components/media-player/src/PlayerControls.js
@@ -43,6 +43,19 @@ class PlayerControls extends React.Component {
   }
 
   render() {
+
+    let saveButton = null;
+
+    if (this.props.renderSave) {
+      saveButton = <button
+        value="Save"
+        title="Save"
+        className={ style.playerButton }
+        onClick={ this.props.handleSaveTranscript }>
+        <FontAwesomeIcon icon={ faSave } />
+      </button>;
+    }
+
     return (
       <div className={ style.playerControls }>
         <div className={ style.timeBox }>
@@ -106,13 +119,7 @@ class PlayerControls extends React.Component {
               handleChange={ this.props.setPlayBackRate } />
           </span>
 
-          <button
-            value="Save"
-            title="Save"
-            className={ style.playerButton }
-            onClick={ this.props.handleSaveTranscript }>
-            <FontAwesomeIcon icon={ faSave } />
-          </button>
+          { saveButton }
 
           <button
             value="Picture-in-picture"
@@ -152,7 +159,8 @@ PlayerControls.propTypes = {
   playbackRateOptions: PropTypes.array,
   setPlayBackRate: PropTypes.func,
   pictureInPicture: PropTypes.func,
-  handleSaveTranscript: PropTypes.func
+  handleSaveTranscript: PropTypes.func,
+  renderSave: PropTypes.bool,
 };
 
 export default PlayerControls;

--- a/packages/components/transcript-editor/index.js
+++ b/packages/components/transcript-editor/index.js
@@ -302,6 +302,7 @@ class TranscriptEditor extends React.Component {
         handleAnalyticsEvents={ this.props.handleAnalyticsEvents }
         videoRef={ this.videoRef }
         handleSaveTranscript={ this.handleSaveTranscript }
+        showSaveButton={ this.props.showSaveButton }
       />
     );
 
@@ -459,7 +460,8 @@ TranscriptEditor.propTypes = {
   sttJsonType: PropTypes.string,
   handleAnalyticsEvents: PropTypes.func,
   fileName: PropTypes.string,
-  transcriptData: PropTypes.object
+  transcriptData: PropTypes.object,
+  showSaveButton: PropTypes.showSaveButton
 };
 
 export default TranscriptEditor;


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
This PR references #176. 

**Describe what the PR does**    
The `TranscriptEditor` tag has a new parameter `showSaveButton`. This is a boolean which is passed down to `PlayerControls`, where it hides or shows the save button.

**State whether the PR is ready for review or whether it needs extra work**    
This is a example PR for this Problem which is very simple. If there is interest of developing such a feature to a greater extend, it would be better to use a more structured approach like a configuration file instead of passing down multiple parameters for each individual component.
