### PR TITLE
Bugfix: Editor grabs focus on realignment even if editor not in focus

### DIFF
--- a/packages/components/timed-text-editor/index.js
+++ b/packages/components/timed-text-editor/index.js
@@ -129,26 +129,32 @@ class TimedTextEditor extends React.Component {
     // Re-convert updated content to raw to gain access to block keys
     const updatedContentBlocks = convertToRaw(updatedContent);
 
-    // Build block map, which maps the block keys of the previous content to the block keys of the
-    // updated content.
-    var blockMap = {};
-    for (var blockIdx = 0; blockIdx < currentContent.blocks.length; blockIdx++) {
-      blockMap[currentContent.blocks[blockIdx].key] = updatedContentBlocks.blocks[blockIdx].key;
-    }
-
     // Get current selection state and update block keys
     const selectionState = this.state.editorState.getSelection();
 
-    const selection = selectionState.merge({
-      anchorOffset: selectionState.getAnchorOffset(),
-      anchorKey: blockMap[selectionState.getAnchorKey()],
-      focusOffset: selectionState.getFocusOffset(),
-      focusKey: blockMap[selectionState.getFocusKey()],
-    });
+    // Check if editor has currently the focus. If yes, keep current selection.
+    if (selectionState.getHasFocus()) {
 
-    // Set the updated selection state on the new editor state
-    const newEditorStateSelected = EditorState.forceSelection(newEditorState, selection);
-    this.setState({ editorState: newEditorStateSelected });
+      // Build block map, which maps the block keys of the previous content to the block keys of the
+      // updated content.
+      var blockMap = {};
+      for (var blockIdx = 0; blockIdx < currentContent.blocks.length; blockIdx++) {
+        blockMap[currentContent.blocks[blockIdx].key] = updatedContentBlocks.blocks[blockIdx].key;
+      }
+
+      const selection = selectionState.merge({
+        anchorOffset: selectionState.getAnchorOffset(),
+        anchorKey: blockMap[selectionState.getAnchorKey()],
+        focusOffset: selectionState.getFocusOffset(),
+        focusKey: blockMap[selectionState.getFocusKey()],
+      });
+
+      // Set the updated selection state on the new editor state
+      const newEditorStateSelected = EditorState.forceSelection(newEditorState, selection);
+      this.setState({ editorState: newEditorStateSelected });
+    } else {
+      this.setState({ editorState: newEditorState });
+    }
   }
 
   loadData() {


### PR DESCRIPTION
**Describe what the PR does**    
After word realignment, the editor needs to set the focus again on the previous focus position. At the moment, this is also the case if the user has the focus not in the editor. In that case, the editor grabs the current focus away from whatever the user is doing, which is quite annoying.


**State whether the PR is ready for review or whether it needs extra work**    
This PR fixes this problem by checking if the editor has focus at the time. If not, the focus will not be set back to the previous focus position

**Additional context**    
The bug can be observed in the demo application: start the player and open the drop-down for importing or exporting transcripts. The focus will switch back to the player, making it hard to select a new setting.