### PR TITLE
Fix Performance issue for long videos.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13700,6 +13700,14 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "react-visibility-sensor": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
+      "integrity": "sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "reactcss": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
@@ -15443,6 +15451,16 @@
                 "pac-resolver": "^3.0.0",
                 "raw-body": "^2.2.0",
                 "socks-proxy-agent": "^4.0.1"
+              },
+              "dependencies": {
+                "https-proxy-agent-snyk-fork": {
+                  "version": "git://github.com/snyk/node-https-proxy-agent.git#5e86ccb682d0c833c8daa25ee6f91c670161cd66",
+                  "from": "git://github.com/snyk/node-https-proxy-agent.git#fix/https-agent-vuln",
+                  "requires": {
+                    "agent-base": "^4.3.0",
+                    "debug": "^3.1.0"
+                  }
+                }
               }
             },
             "pac-resolver": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-fast-compare": "^2.0.4",
     "react-keyboard-shortcuts": "^1.1.3",
     "react-simple-tooltip": "^2.6.1",
+    "react-visibility-sensor": "^5.1.1",
     "sbd": "^1.0.15",
     "smpte-timecode": "^1.2.3"
   },

--- a/packages/components/timed-text-editor/WrapperBlock.js
+++ b/packages/components/timed-text-editor/WrapperBlock.js
@@ -7,7 +7,7 @@ import {
   convertFromRaw,
   convertToRaw
  } from 'draft-js';
-
+ import VisibilitySensor from 'react-visibility-sensor';
 import SpeakerLabel from './SpeakerLabel';
 // import { shortTimecode, secondsToTimecode } from '../../Util/timecode-converter/';
 
@@ -50,7 +50,8 @@ class WrapperBlock extends React.Component {
 
     this.setState({
       speaker: speaker,
-      start: start
+      start: start,
+      getElement: document.querySelector(".notranslate")
     });
   }
   // reducing unnecessary re-renders
@@ -165,7 +166,16 @@ class WrapperBlock extends React.Component {
     }
   };
 
+  visibilityChanged = (isVisible) => {
+    console.log("ISVISIBLE", isVisible);
+  }
+
   render() {
+
+    let containmentDOMRect = this.state.getElement
+      ? this.state.getElement
+      : null;
+
     let startTimecode = this.state.start;
     if (this.props.blockProps.timecodeOffset) {
       startTimecode += this.props.blockProps.timecodeOffset;
@@ -186,19 +196,23 @@ class WrapperBlock extends React.Component {
     );
 
     return (
-      <div className={ style.WrapperBlock }>
-        <div
-          className={ [ style.markers, style.unselectable ].join(' ') }
-          contentEditable={ false }
-        >
-          {this.props.blockProps.showSpeakers ? speakerElement : ''}
+      <VisibilitySensor partialVisibility={true} onChange={this.visibilityChanged} containment={containmentDOMRect} scrollCheck>
+         {({isVisible}) =>  isVisible ?
+          <div className={ style.WrapperBlock }>
+              <div
+                className={ [ style.markers, style.unselectable ].join(' ') }
+                contentEditable={ false }
+              >
+                {this.props.blockProps.showSpeakers ? speakerElement : ''}
 
-          {this.props.blockProps.showTimecodes ? timecodeElement : ''}
-        </div>
-        <div className={ style.text }>
-          <EditorBlock { ...this.props } />
-        </div>
-      </div>
+                {this.props.blockProps.showTimecodes ? timecodeElement : ''}
+              </div>
+              <div className={ style.text }>
+                <EditorBlock { ...this.props } />
+              </div>
+            </div> : <span className={ style.loadingBlockPlaceholder }>loading...</span>
+          }
+        </VisibilitySensor>
     );
   }
 }

--- a/packages/components/timed-text-editor/WrapperBlock.module.css
+++ b/packages/components/timed-text-editor/WrapperBlock.module.css
@@ -79,6 +79,16 @@ to get text out of component with timecodes and speaker names in the interim */
   margin-right: 0.5em;
 }
 
+.loadingBlockPlaceholder{
+  display: flex;
+  width: 100%;
+  min-height: 50px;
+  font-weight: bold;
+  justify-content: center;
+  align-items: center;
+  justify-items: center;
+  background-color: #f7f7f7;
+}
 
 /* Mobile devices */
 @media (max-width: 768px) {


### PR DESCRIPTION


**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
ISSUE: [https://github.com/bbc/react-transcript-editor/issues/150](Performance hit for media over 1 hour #150)

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
Added react-visibility-sensor and modified wrapperBlock.js file to load only the visible area which can be helpful for the long videos with long transcript.


**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
This is my 1st PR so please let me know if I did anything wrong and I will amend my mistake.
Thanks.