### PR TITLE
Punctuation bug in speechmatics adapter

### DIFF
--- a/packages/stt-adapters/speechmatics/index.js
+++ b/packages/stt-adapters/speechmatics/index.js
@@ -65,7 +65,7 @@ const groupWordsInParagraphs = (words, speakers, maxParagraphWords) => {
 const curatePunctuation = (words) => {
   const curatedWords = [];
   words.forEach((word) => {
-    if (/[.?!]/.test(word.name)) {
+    if (/[.?!]/.test(word.name) && word.name.length == 1 && curatedWords.length > 0) {
       curatedWords[curatedWords.length - 1].name = curatedWords[curatedWords.length - 1].name + word.name;
       curatedWords[curatedWords.length - 1].duration = (parseFloat(curatedWords[curatedWords.length - 1].duration) + parseFloat(word.duration)).toString();
     } else {


### PR DESCRIPTION
**Describe what the PR does**    

Fixed bug which manifested the following way

- If there was a punctuation mark in a word, the word got merged with its predecessor
- If there was a punctuation mark in the first word of a transcript, the adapter crashed

This fix addresses both these problems.

The Problem was a insufficent test whether a word is a puncutation mark or not in the `curatePunctuation` function. The function is necessary to merge punctuation marks with its previous word, as this is the norm for the react-player, while speechmatics transcripts put punctuation marks in their own "word".

**Details**

The `word.name.length == 1` condition ensures that the "word" is indeed a single punctuation mark and not a word with a punctuation mark at the end, e.g. "Mr.".

The `curatedWords.length > 0` condition prevents the function to crash if the first word in a transcript is a punctuation mark, as otherwise the `curatedWords.length - 1` index will be `-1`, which leads to a index-out-of bounds error.

**State whether the PR is ready for review or whether it needs extra work**    
Ready for review.