### PR TITLE
Fix: speaker segmentation doesn't lose words

### DIFF
--- a/packages/stt-adapters/bbc-kaldi/index.js
+++ b/packages/stt-adapters/bbc-kaldi/index.js
@@ -31,6 +31,13 @@ const groupWordsInParagraphs = words => {
     }
   });
 
+  // Anything after the last punctuation mark, we currently throw away
+  // Add a final paragraph
+  if (paragraph.words.length > 0) {
+    paragraph.text = paragraph.text.join(' ');
+    results.push(paragraph);
+  }
+
   return results;
 };
 

--- a/packages/stt-adapters/bbc-kaldi/index.test.js
+++ b/packages/stt-adapters/bbc-kaldi/index.test.js
@@ -6,12 +6,89 @@ import kaldiTedTalkTranscript from './sample/kaldiTedTalkTranscript.sample.json'
 // TODO: figure out why the second of these two tests hang
 // might need to review the draftJS data structure output
 describe('bbcKaldiToDraft', () => {
-  const result = bbcKaldiToDraft(kaldiTedTalkTranscript);
-  it('Should be defined', ( ) => {
+  it('Should be defined', () => {
+    const result = bbcKaldiToDraft(kaldiTedTalkTranscript);
+
     expect(result).toBeDefined();
   });
 
-  it('Should be equal to expected value', ( ) => {
+  it('Should be equal to expected value', () => {
+    const result = bbcKaldiToDraft(kaldiTedTalkTranscript);
+
     expect(result).toEqual(draftTranscriptExample);
+  });
+
+  it('Should sort words with no segmentation and no ending punctuation into paragraphs', () => {
+    const data = {
+      retval: {
+        words: [
+          {
+            start: 1.00,
+            confidence: 0.68,
+            end: 1.17,
+            word: 'test',
+            punct: 'Test',
+            index: 0,
+          },
+          {
+            start: 1.17,
+            confidence: 0.61,
+            end: 1.38,
+            word: 'words',
+            punct: 'words',
+            index: 1,
+          },
+        ]
+      }
+    };
+
+    const result = bbcKaldiToDraft(data);
+
+    expect(result.length).toEqual(1);
+  });
+
+  it('Should sort words with no segmentation and no ending punctuation into paragraphs', () => {
+    const data = {
+      retval: {
+        words: [
+          {
+            start: 1.00,
+            confidence: 0.68,
+            end: 1.17,
+            word: 'test',
+            punct: 'Test',
+            index: 0,
+          },
+          {
+            start: 1.17,
+            confidence: 0.61,
+            end: 1.38,
+            word: 'words',
+            punct: 'words.',
+            index: 1,
+          },
+          {
+            start: 1.38,
+            confidence: 0.99,
+            end: 1.44,
+            word: 'second',
+            punct: 'Second',
+            index: 2,
+          },
+          {
+            start: 11.00,
+            confidence: 0.68,
+            end: 11.17,
+            word: 'paragraph',
+            punct: 'paragraph',
+            index: 3,
+          },
+        ]
+      }
+    };
+
+    const result = bbcKaldiToDraft(data);
+
+    expect(result.length).toEqual(2);
   });
 });


### PR DESCRIPTION
**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

This addresses the `groupWordsInParagraphs` function inside the Kaldi-to-draft editor.

Usually, we have speaker segmentation attached from Kaldi, so we haven't been calling this.

But it's throwing away any words that go beyond the last full stop (or exclamation etc.)

Eg. if you input: `Live Kaldi Test. Here is some transcript data` sorts to just `Live Kaldi Test.'

and if you input `Here is some transcript data, it results in an empty list of paragraphs (which bricks the whole app 🙄😄)  

Super quick PR. Added some tests too - let me know if you need more context.