### PR TITLE
Timestamp Sync Bug

### DIFF
--- a/packages/components/timed-text-editor/UpdateTimestamps/stt-align-node.js
+++ b/packages/components/timed-text-editor/UpdateTimestamps/stt-align-node.js
@@ -100,14 +100,13 @@ function adjustTimecodesBoundaries(words) {
 }
 
 function interpolate(wordsList) {
-  const words = interpolationOptimization(wordsList);
-  const indicies = [ ...Array(words.length).keys() ];
+  const indicies = [ ...Array(wordsList.length).keys() ];
   const indiciesWithStart = [];
   const indiciesWithEnd = [];
   const startTimes = [];
   const endTimes = [];
 
-  words.forEach((word, index) => {
+  wordsList.forEach((word, index) => {
     if ('start' in word) {
       indiciesWithStart.push(index);
       startTimes.push(word.start);
@@ -121,7 +120,7 @@ function interpolate(wordsList) {
   // http://borischumichev.github.io/everpolate/#linear
   const outStartTimes = everpolate.linear(indicies, indiciesWithStart, startTimes);
   const outEndTimes = everpolate.linear(indicies, indiciesWithEnd, endTimes);
-  const wordsResults = words.map((word, index) => {
+  const wordsResults = wordsList.map((word, index) => {
     if (!('start' in word)) {
       word.start = outStartTimes[index];
     }


### PR DESCRIPTION
**Is your Pull Request request related to another [issue](https://github.com/bbc/react-transcript-editor/issues) in this repository ?**      
No

**Describe what the PR does**    
This PR removes the call to the interpolationOptimization method in stt-align-node. The reason for removing this call is that interpolationOptimization causes an issue with the transcript timestamps aligning correctly with the audio/video. We currently use react-transcript-editor in a STT correction workflow. In the course of correcting a transcript we discovered that the transcript and audio/video slowly get out of sync with each other. The culprit seems to be interpolation optimization - as editing takes place, it erroneously shifts each word's start time. This issue is most noticeable in transcripts where STT failed to pick up some chunks of speech.

**State whether the PR is ready for review or whether it needs extra work**    
Ready

**Additional context**    
It is possible that this fix is specific to our use case and not applicable to the wider audience of the transcript editor. If this is the case, I could add to this PR a user-facing option in the settings panel to allow interpolation optimization to be toggled on/off.
