### PR TITLE
Bugfix: the editor crashes if you delete all words from a block

### DIFF
--- a/packages/components/timed-text-editor/UpdateTimestamps/index.js
+++ b/packages/components/timed-text-editor/UpdateTimestamps/index.js
@@ -42,19 +42,23 @@ const createContentFromEntityList = (currentContent, newEntities) => {
       console.log('speaker', speaker, block);
       speaker = 'U_UKN';
     }
-    const updatedBlock = {
-      text: blockEntites.map((entry) => entry.punct).join(' '),
-      type: 'paragraph',
-      data: {
-        speaker: speaker,
-        words: blockEntites,
-        start: blockEntites[0].start
-      },
-      entityRanges: generateEntitiesRanges(blockEntites, 'punct'),
-    };
 
-    updatedBlockArray.push(updatedBlock);
-    totalWords += wordsInBlock;
+    // only add the block, if it is non-empty:
+    if (blockEntites.length > 0) {
+      const updatedBlock = {
+        text: blockEntites.map((entry) => entry.punct).join(' '),
+        type: 'paragraph',
+        data: {
+          speaker: speaker,
+          words: blockEntites,
+          start: blockEntites[0].start
+        },
+        entityRanges: generateEntitiesRanges(blockEntites, 'punct'),
+      };
+
+      updatedBlockArray.push(updatedBlock);
+      totalWords += wordsInBlock;
+    }
   }
 
   return { blocks: updatedBlockArray, entityMap: createEntityMap(updatedBlockArray) };

--- a/packages/components/timed-text-editor/index.js
+++ b/packages/components/timed-text-editor/index.js
@@ -138,8 +138,9 @@ class TimedTextEditor extends React.Component {
         blockIdx < currentContent.blocks.length;
         blockIdx++
       ) {
-        blockMap[currentContent.blocks[blockIdx].key] =
-          updatedContentBlocks.blocks[blockIdx].key;
+        var updated = updatedContentBlocks.blocks[blockIdx];
+        if (updated != undefined)
+          blockMap[currentContent.blocks[blockIdx].key] = updated.key;
       }
 
       const selection = selectionState.merge({


### PR DESCRIPTION
Should solve this [issue](https://github.com/bbc/react-transcript-editor/issues/215)

## Steps to reproduce

- Use 'Load Demo' here https://bbc.github.io/react-transcript-editor/?path=/story/demo--default
- Delete all words in one block / paragraph

Deleting the complete transcript text still leads to a different error.
